### PR TITLE
Make source classes import explicit ( close #67 )

### DIFF
--- a/magpylib/source/__init__.py
+++ b/magpylib/source/__init__.py
@@ -25,6 +25,7 @@ Quicklist for :mod:`~magpylib.source.current` sources:
    Line
    Circular
 
+
 .. currentmodule:: magpylib.source.moment
 
 Quicklist for :mod:`~magpylib.source.moment` sources:
@@ -36,7 +37,6 @@ Quicklist for :mod:`~magpylib.source.moment` sources:
 """
 __all__ = ["magnet","current","moment"] # This is for Sphinx
 
-
-import magpylib.source.magnet as magnet
-import magpylib.source.current as current
-import magpylib.source.moment as moment
+import magpylib._lib.classes.magnets as magnet
+import magpylib._lib.classes.currents as current
+import magpylib._lib.classes.moments as moment


### PR DESCRIPTION
    - Implicit export from top level did not work on
      some machines.
    - This makes the exports more obvious and
       should fix it this occurrence.