### PR TITLE
Fix direc=True not working with Circular

### DIFF
--- a/magpylib/_lib/utility.py
+++ b/magpylib/_lib/utility.py
@@ -10,6 +10,13 @@ def checkDimensions(expectedD: int, dim: Tuple[float,float,float], exitMsg: str=
     return dimension
 
 ##### Collection Helpers
+def addListToCollection(sourceList, inputList,dupWarning):
+    assert all(isSource(a) for a in inputList), "Non-source object in Collection initialization"
+    if dupWarning is True: ## Skip iterating both lists if warnings are off
+        for source in inputList:
+            addUniqueSource(source,sourceList) ## Checks if source is in list, throw warning
+    else:
+        sourceList.extend(inputList)  
 
 def isSource(theObject : any) -> bool:
     """

--- a/tests/test_Collection.py
+++ b/tests/test_Collection.py
@@ -66,12 +66,24 @@ def test_collectionGetBList():
             for j in range(3):
                 assert round(result[i][j],rounding) == round(mockResult[i][j],rounding)
 
+def test_CollectionAddList():
+    errMsg = "Failed to place items in collection, got: "
+    from magpylib._lib.classes.magnets import Box
+    def boxFactory():
+        mag=(2,3,5)
+        dim=(2,2,2)
+        return Box(mag,dim)
+    listSize = 5
+    boxList = list(boxFactory() for a in range(0,listSize))
+
+    c = Collection(boxList)
+    lenOfCol = len(c.sources)
+    assert lenOfCol == listSize, errMsg + str(lenOfCol) + "; expected: " + str(listSize)
+
 def test_collectionGetBMulticoreList():
     from magpylib._lib.classes.magnets import Box
 
     #Input
-
-
     mag=(2,3,5)
     dim=(2,2,2)
     pos=array([     [2,2,2],
@@ -100,7 +112,6 @@ def test_collectionGetBMulticoreArray():
     from numpy import allclose
     #Input
 
-
     mag=(2,3,5)
     dim=(2,2,2)
     pos=array([     [[2,2,2],
@@ -109,7 +120,6 @@ def test_collectionGetBMulticoreArray():
                     [[2,2,2],
                     [2,2,2],
                     [2,2,3]]])
-
 
     mockResult = [  [[0.24976596, 0.21854521, 0.15610372],
                     [0.24976596, 0.21854521, 0.15610372],


### PR DESCRIPTION
Fixes some issues with the display System.

## Fix Notes

Collection.displaySystem(direc=True) would throw an error for Circular Current since the previous refactor didn't save the calculated vertices for the Circular Current to be drawn. This is now fixed.

Collection.displaySystem(direc=True) would not display Line Current direction correctly if the Line was rotated. This is because normally the rotations of the Vertices in the object are not rotated before being drawn, so now it creates a copy of the object which is altered. This may be optimized later.

Collection() and Collection.AddSources() would not accept a list of sources as an argument. This proved handy and was added.
