### PR TITLE
Add label feature to markers

### DIFF
--- a/magpylib/_lib/classes/collection.py
+++ b/magpylib/_lib/classes/collection.py
@@ -15,7 +15,7 @@ from numpy import array,amax, linspace, pi, sin, cos, finfo
 from magpylib._lib.classes.magnets import Box,Cylinder,Sphere
 from magpylib._lib.classes.currents import Line, Circular
 from magpylib._lib.classes.moments import Dipole
-from magpylib._lib.utility import drawCurrentArrows, drawMagAxis, drawDipole
+from magpylib._lib.utility import drawCurrentArrows, drawMagAxis, drawDipole, isDisplayMarker
 from magpylib._lib.utility import addListToCollection, isSource,  addUniqueSource
 from magpylib._lib.mathLibPrivate import angleAxisRotation, fastNorm3D
 from magpylib._lib.mathLibPublic import rotatePosition
@@ -350,14 +350,17 @@ class Collection():
 
         Parameters
         ----------
-        markers : list[vec3]
-            List of position vectors to add visual markers to the display
+        markers : list[scalar,scalar,scalar,[label]]
+            List of position vectors to add visual markers to the display, optional label.
             Default: [[0,0,0]]
 
         >>> from magpylib import Collection, source
         >>> c=source.current.Circular(3,7)
         >>> x = Collection(c)
-        >>> x.displaySystem([[2,3,5],[10,20,10],[5,5,5],[8,8,8]])
+        >>> marker0 = [0,0,0,"Neutral Position"]
+        >>> marker1 = [10,10,10]
+        >>> x.displaySystem(markers=[ marker0,
+        ...                           marker1])
 
         suppress : bool
             If True, only return Figure information, do not show. Interactive mode must be off.
@@ -416,8 +419,7 @@ class Collection():
 
         ## Check input and Add markers to the Markers list before plotting
         for m in markers:
-            assert len(m) == 3, "A Position vector for markers is not 3D"
-            assert all(isinstance(p,int) or isinstance(p,float) for p in m), "Position vector for marker has non-int or non-float types." #pylint: disable=not-an-iterable
+            assert isDisplayMarker(m), "Invalid marker definition in displaySystem:" + str(m) + ". Needs to be [vec3] or [vec3,string]"
             markersList+=[m]
 
         for s in self.sources:
@@ -558,7 +560,10 @@ class Collection():
 
         for m in markersList: ## Draw Markers
             ax.scatter(m[0],m[1],m[2],s=20,marker='x')
-            maxSize = amax(abs(max(m)))
+            if(len(m)>3):
+                zdir = None
+                ax.text(m[0], m[1], m[2], m[3], zdir)
+            maxSize = amax(abs(max(m[:2])))
             if maxSize > SYSSIZE:
                 SYSSIZE = maxSize
         

--- a/magpylib/_lib/utility.py
+++ b/magpylib/_lib/utility.py
@@ -248,6 +248,12 @@ def initializeMulticorePool(processes):
     assert processes > 0, "Could not identify multiple cores for getB. This machine may not support multiprocessing."
     return Pool(processes=processes) 
 
+def isDisplayMarker(object_ref):
+    m = object_ref
+    if len(m) == 3:# Check if it's [numeric,numeric,numeric]
+        return all(isinstance(p,int) or isinstance(p,float) for p in m)
+    if len(m) == 4: # Check if it's [numeric,numeric,numeric,"label"]
+        return all(isinstance(p,int) or isinstance(p,float) for p in m[:2]) and isinstance(m[3],str)
 def posVectorFinder(dArray,positionsList):
     # Explore an array and append all the indexed values 
     # that are position vectors to the given list.

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,7 +1,30 @@
 from typing import Tuple
-from magpylib._lib.utility import checkDimensions,rotateToCS,getBField, isPosVector
+from magpylib._lib.utility import checkDimensions,rotateToCS,getBField, isPosVector,isDisplayMarker
 from numpy import float64, isnan, array
 import pytest
+
+
+def test_IsDisplayMarker_error():
+    marker1=[0,0,0]
+    marker2=[0,0,1]
+    marker3=[0,0,1,"hello world!"] 
+    marker4=[0,0,1,-1] # Should fail!
+
+    markerList = [marker1,marker2,marker3,marker4]
+    with pytest.raises(AssertionError):
+        for marker in markerList:
+            assert isDisplayMarker(marker)
+
+def test_IsDisplayMarker():
+    errMsg = "marker identifier has failed: "
+    marker1=[0,0,0]
+    marker2=[0,0,1]
+    marker3=[0,0,1,"hello world!"]
+
+    markerList = [marker1,marker2,marker3]
+    for marker in markerList:
+        assert isDisplayMarker(marker), errMsg + str(marker)
+
 
 def test_checkDimensionZero():
     # errMsg = "Did not raise all zeros Error"


### PR DESCRIPTION
# Notes

Add a label option to the display markers.
 - This allows users to name their markers for whatever reason, possibly organizing or making points more apparent.
- Add isDisplayMarker() function for identifying valid marker formats.
- Add test

```python 
from magpylib import source,Collection

item = source.magnet.Box([1,2,3],[1,2,3],pos=[5,5,5])
col = Collection(item)

marker0 = [0,0,0,"(0,0,0)"] #Labels can lie
marker1 = [-1,0,0]
marker2 = [1,2,3,"A cooler marker very far away from the boring labels"]

col.displaySystem(markers=[marker0,marker1,marker2])
```

![image](https://user-images.githubusercontent.com/7332704/55737702-fb6c9d80-5a25-11e9-987c-8e332f17dc4d.png)
