### PR TITLE
Add numpy array as valid input for Line vertices

### DIFF
--- a/magpylib/_lib/classes/currents.py
+++ b/magpylib/_lib/classes/currents.py
@@ -11,7 +11,7 @@ d=0.0 ## Default Diameter
 ######################################
 
 #%% IMPORTS
-from numpy import array,float64
+from numpy import array,float64, ndarray
 import sys
 from magpylib._lib.mathLibPrivate import angleAxisRotation
 from magpylib._lib.classes.base import LineCurrent
@@ -170,9 +170,10 @@ class Line(LineCurrent):
         LineCurrent.__init__(self,pos,angle,axis,curr)
         
         #secure input type and check input format of dim
-        assert type(vertices) != type(listOfPos), 'Line Current: enter a list of position vertices - Ex: Line(vertices=[(1,2,3),(3,2,1)])'
-        assert all(type(pos)==tuple or type(pos)==list for pos in vertices), 'Line-current: Input position (3D) tuples or lists within the list - Ex: Line(vertices=[(1,2,3),(3,2,1)])'
-        assert all(len(d)==3 for d in vertices), 'Line-current: Bad input dimension, tuple vectors in list must be 3D' 
+        assert isinstance(vertices,list) or isinstance(vertices,ndarray), 'Line Current: enter a list of position vertices - Ex: Line(vertices=[(1,2,3),(3,2,1)])'
+        assert all(isinstance(pos,tuple) or isinstance(pos,list) 
+                or isinstance(pos,ndarray) for pos in vertices), 'Line-current: Input position (3D) tuples or lists within the list - Ex: Line(vertices=[(1,2,3),(3,2,1)])'
+        assert all(len(d)==3 for d in vertices), 'Line-current: Bad input dimension, vectors in list must be 3D' 
         self.vertices = array(vertices, dtype=float64,copy=False)
         
     def getB(self,pos): ## Particular Line current B field calculation. Check RCS for getB() interface

--- a/tests/test_sources/test_currents/test_Line.py
+++ b/tests/test_sources/test_currents/test_Line.py
@@ -3,7 +3,18 @@ from numpy import isnan, array
 import pytest 
 
 
+
+def test_LineNumpyArray():
+    # Test some valid variations of numpy arrays for Line vertices.
+    cur=6
+    pos=(9,2,4)
+    vertices = [array([0,0,0]),array([4,6,2]),array([20,3,6])]
+    current.Line(cur,vertices,pos)
+    vertices = array([[0,0,0],[4,6,2],[20,3,6]])
+    current.Line(cur,vertices,pos)
+
 def test_LineGetB():
+    # Test a single getB calculation.
     erMsg = "Results from getB are unexpected"
     mockResults = array([ 0.00653909, -0.01204138,  0.00857173]) ## Expected 3 results for this input
     
@@ -20,6 +31,7 @@ def test_LineGetB():
         assert round(result[i],rounding)==round(mockResults[i],rounding), erMsg
 
 def test_LineGetBAngle():
+    # Create the line with a rotated position then verify with getB. 
     erMsg = "Results from getB are unexpected"
     mockResults = (-0.00493354,  0.00980648,  0.0119963 ) ## Expected 3 results for this input
     
@@ -38,7 +50,8 @@ def test_LineGetBAngle():
     for i in range(3):
         assert round(result[i],rounding)==round(mockResults[i],rounding), erMsg
 
-def test_CircularMulticoreGetB():
+def test_LineGetBSweep():
+    # Perform multipoint getB calculations with Line (sequential).
     erMsg = "Results from getB are unexpected"
     mockResults = (     (-0.00493354,  0.00980648,  0.0119963 ),
                         (-0.00493354,  0.00980648,  0.0119963 ),
@@ -57,7 +70,7 @@ def test_CircularMulticoreGetB():
     pm = current.Line(curr,vertices,pos,angle)
 
     ## Positions list
-    result = pm.getBsweep(arrayOfPos) 
+    result = pm.getBsweep(arrayOfPos,multiprocessing=False) 
 
     ## Rounding for floating point error 
     rounding = 4 


### PR DESCRIPTION
    - Add two numpy array cases for
      valid input
    - Add test
    - Add test comments

The following two types of input are now valid for declaring Lines:

```python
from magpylib import source
current = 5
# Arrays in a list
vertices = [array([0,0,0]),array([4,6,2]),array([20,3,6])]
source.current.Line(current,vertices)

# List in an array
vertices = array([[0,0,0],[4,6,2],[20,3,6]])
source.current.Line(current,vertices)
```