### PR TITLE
fixed the rounding problem .5-.55 for remaining field calculations

### DIFF
--- a/magpylib/_lib/fields/Current_CircularLoop.py
+++ b/magpylib/_lib/fields/Current_CircularLoop.py
@@ -27,14 +27,13 @@ def Bfield_CircularCurrentLoop(i0,d0,pos):
     r0 = d0/2  #radius of current loop
 
     #avoid singularity at CL
-    #if abs(r-r0)<1e-10 and abs(z)<1e-10:
     #    print('WARNING: close to singularity - setting field to zero')
     #    return array([0,0,0])
-
-    if (r==r0 and z==0):
+    rr0=r-r0
+    if (-1e-15<rr0 and rr0<1e-15): #rounding to eliminate the .5-.55 problem when sweeping
+        if (-1e-15<z and z<1e-15):
             print('Warning: getB Position directly on current line')
             return array([NaN,NaN,NaN])
-        
 
     deltaP = sqrt((r+r0)**2+z**2)
     deltaM = sqrt((r-r0)**2+z**2)
@@ -42,11 +41,11 @@ def Bfield_CircularCurrentLoop(i0,d0,pos):
     kappaBar=1-kappa
 
     #avoid discontinuity at r=0
-    if r==0: 
+    if (-1e-15<r and r<1e-15): 
         Br = 0.
     else:
-        Br = -2*1e-7*i0*(z/r/deltaM)*(ellipticK(kappaBar)-(2-kappaBar)/(2-2*kappaBar)*ellipticE(kappaBar))    *1e3           #account for mm input
-    Bz = -2*1e-7*i0*(1/deltaM)*(-ellipticK(kappaBar)+(2-kappaBar-4*(r0/deltaM)**2)/(2-2*kappaBar)*ellipticE(kappaBar))  *1e3 #account for mm input
+        Br = -2*1e-4*i0*(z/r/deltaM)*(ellipticK(kappaBar)-(2-kappaBar)/(2-2*kappaBar)*ellipticE(kappaBar))
+    Bz = -2*1e-4*i0*(1/deltaM)*(-ellipticK(kappaBar)+(2-kappaBar-4*(r0/deltaM)**2)/(2-2*kappaBar)*ellipticE(kappaBar))
 
     #transfer to cartesian coordinates
     Bcy = array([Br,0.,Bz])*1000. #mT output
@@ -54,4 +53,3 @@ def Bfield_CircularCurrentLoop(i0,d0,pos):
     Bkart = T_Cy_to_Kart.dot(Bcy)
 
     return Bkart
-

--- a/magpylib/_lib/fields/Current_Line.py
+++ b/magpylib/_lib/fields/Current_Line.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import sys
 from numpy import array,NaN
 from magpylib._lib.mathLibPrivate import fastSum3D, fastNorm3D, fastCross3D
 
@@ -17,7 +16,6 @@ from magpylib._lib.mathLibPrivate import fastSum3D, fastNorm3D, fastCross3D
     
 #source: http://www.phys.uri.edu/gerhard/PHY204/tsl216.pdf
 # FieldOfLineCurrent
-
 
 # observer at p0
 # current I0 flows in straight line from p1 to p2

--- a/magpylib/_lib/fields/PM_Cylinder.py
+++ b/magpylib/_lib/fields/PM_Cylinder.py
@@ -3,11 +3,9 @@
 # MAGNETIC FIELD CALCULATION OF CYLINDER IN CANONICAL BASIS
 
 
-
 #%% IMPORTS
 from numpy import pi,sqrt,array,arctan,cos,sin,arange,NaN
 from magpylib._lib.mathLibPrivate import getPhi, elliptic
-
 
 
 #%% Cylinder Field Calculation
@@ -47,7 +45,13 @@ def Bfield_Cylinder(MAG, pos, dim, Nphi0): #returns arr3
     #   0. volume cases      no quantities are zero
     #   1. on surfaces:      one quantity is zero
     #   2. on edge lines:    two quantities are zero
-    CASE = [Rmr,zP,zM].count(0)
+    CASE = 0
+    for case in array([Rmr,zP,zM]):
+        if (case<1e-15 and -1e-15<case):
+            CASE+=1
+    # rounding is required to catch numerical problem cases like .5-.55=.05000000000000001
+    #   which then result in 'normal' cases but the square eliminates the small digits
+    
     
     #edge cases ----------------------------------------------
     if CASE == 2:


### PR DESCRIPTION
fixes the 0.5-0.55 problem for remaining Bfield-calcualtions (Cylinder, circular). idea: the field evaluates as NaN with rounding to 1e-15 ... except for the current line....but users can figure this one out...