### PR TITLE
Fix error with aspect for 3D plot kwarg ( #127 )

### DIFF
--- a/magpylib/_lib/classes/collection.py
+++ b/magpylib/_lib/classes/collection.py
@@ -587,7 +587,6 @@ class Collection(FieldSampler):
             xlim=(-SYSSIZE, SYSSIZE),
             ylim=(-SYSSIZE, SYSSIZE),
             zlim=(-SYSSIZE, SYSSIZE),
-            aspect=1
         )
         plt.tight_layout()
 


### PR DESCRIPTION
A minor version update has been released for matplotlib.

Some changes went in effect, including the [force aspect in 3D plot error](https://github.com/matplotlib/matplotlib/issues/1077).

The following is no longer valid:
https://github.com/OrtnerMichael/magPyLib/blob/542846043af78b4afa6a7c035e0965563dd0463f/magpylib/_lib/classes/collection.py#L586-L591


Simply removing the aspect kwarg fixes this. There is no effect from what I've seen.