### PR TITLE
Bundle LICENSE with PyPi package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE README.md

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 #   $ (packCondaTest) pip install .
 # The library is now in the packCondaTest environment.
 ##
-_magPyVersion = "1.0.1-beta"
+_magPyVersion = "1.0.2-beta"
 
 _SphinxVersion = "1.8.2"
 _name = "magpylib"


### PR DESCRIPTION
# Notes
PyPi was not bundling the LICENSE in the latest release, this MANIFEST.in should fix it.
