### PR TITLE
Fix zero length

### DIFF
--- a/magpylib/_lib/fields/Current_Line.py
+++ b/magpylib/_lib/fields/Current_Line.py
@@ -24,7 +24,7 @@
 
 from numpy import array, NaN
 from magpylib._lib.mathLibPrivate import fastSum3D, fastNorm3D, fastCross3D
-
+from warnings import warn
 
 # %% CURRENT LINE
 # Describes the magnetic field of a line current. The line is given by a set of
@@ -42,6 +42,11 @@ from magpylib._lib.mathLibPrivate import fastSum3D, fastNorm3D, fastCross3D
 # current I0 flows in straight line from p1 to p2
 def Bfield_LineSegment(p0, p1, p2, I0):
     # must receive FLOAT only !!!!
+    # Check for zero-length segment
+    if all(p1==p2):
+        warn("Zero-length segment line detected in vertices list,"
+             "returning [0,0,0]", RuntimeWarning)
+        return array([0, 0, 0])
 
     # projection of p0 onto line p1-p2
     p4 = p1+(p1-p2)*fastSum3D((p0-p1)*(p1-p2))/fastSum3D((p1-p2)*(p1-p2))
@@ -57,7 +62,7 @@ def Bfield_LineSegment(p0, p1, p2, I0):
         norm_41 = fastNorm3D(p4-p1)
 
         if (norm_41 <= norm_12 and norm_42 <= norm_12):  # in-between the two points
-            print('Warning: getB Position directly on current line')
+            warn('Warning: getB Position directly on current line', RuntimeWarning)
             return array([NaN, NaN, NaN])
         else:
             return array([0, 0, 0])

--- a/tests/test_fields/test_CurrentLine.py
+++ b/tests/test_fields/test_CurrentLine.py
@@ -2,9 +2,26 @@ from magpylib._lib.fields.Current_Line import Bfield_CurrentLine
 from numpy import array
 import pytest
 
+def test_Bfield_Zero_Length_segment():
+    # Check if Zero-length segments in vertices return valid 
+    errMsg = "Field sample outside of Line is unexpected"
+    mockResult = [0,0.72951356,0]
+
+    current = 5
+    pos = [0,0,0]
+
+    vertices = array([[-1,0,0],[1,0,5],[1,0,5]])
+    with pytest.warns(Warning):
+        results=Bfield_CurrentLine(pos,vertices,current)
+        rounding = 4
+
+        for i in range(0,3):
+            assert round(mockResult[i],rounding)==round(results[i],rounding), errMsg
+
+
 def test_Bfield_CurrentLine_outside():
     # Fundamental Positions in every 8 Octants
-    errMsg = "Field sample outside of Box is unexpected"
+    errMsg = "Field sample outside of Line is unexpected"
     mockResults = [ [-15.426123, -42.10796, -12.922307],
                     [67.176642, -3.154985, -10.209148],
                     [-52.57675, 14.702422, 16.730058],


### PR DESCRIPTION
# Related Issues

#162 

# Notes

This has the field calculation return `[0,0,0]` for repeated segments, it will also throw a warning.

