### PR TITLE
Add block kwarg to displaySystem's plt.show()

### DIFF
--- a/magpylib/_lib/classes/collection.py
+++ b/magpylib/_lib/classes/collection.py
@@ -639,6 +639,6 @@ class Collection(FieldSampler):
         plt.tight_layout()
 
         if suppress is False:
-            plt.show()
+            plt.show(block=False)
 
         return plt.gcf()


### PR DESCRIPTION
# Related Issues

#174 

# Notes

This adds the `block=False` kwarg to `plt.show()` in Collection.displaySystem(), allowing displaySystem to work as intended in environments where interactive mode is off.

If for some reason users want to have displaySystem() block execution, users may use `suppress=True` and call upon `plt.show()`externally without the keyword.