### PR TITLE
Enhance collection getBsweep

### DIFF
--- a/magpylib/_lib/classes/collection.py
+++ b/magpylib/_lib/classes/collection.py
@@ -32,6 +32,8 @@ listOfPos=[[x,y,z]] # List of Positions
 #######################################
 # %% IMPORTS
 from copy import deepcopy
+from itertools import repeat
+from multiprocessing import cpu_count
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
@@ -42,8 +44,10 @@ from magpylib._lib.classes.moments import Dipole
 from magpylib._lib.classes.fieldsampler import FieldSampler
 from magpylib._lib.utility import drawCurrentArrows, drawMagAxis, drawDipole, isDisplayMarker
 from magpylib._lib.utility import addListToCollection, isSource,  addUniqueSource, isPosVector
+from magpylib._lib.utility import initializeMulticorePool
 from magpylib._lib.mathLibPrivate import angleAxisRotation
 from magpylib._lib.mathLibPublic import rotatePosition
+
 
 
 class Collection(FieldSampler):
@@ -209,14 +213,33 @@ class Collection(FieldSampler):
                 else:
                     self.sources += [s]
 
+    def _getBsweepObj_pickle(self,positions,item):
+        return item.getBsweep(positions,multiprocessing=False)
+
+    def _getBsweepObj(self, pos, processes):
+        # In the case there are many objects and few positions in the collection
+        # treat parallelization this way:
+        # Take every object in parallel and sequentially calculate getB for each.
+        pool = initializeMulticorePool(processes)
+        results = pool.starmap(self._getBsweepObj_pickle,
+                                zip(repeat(pos,
+                                    times=len(self.sources)),
+                                    self.sources))
+        pool.close()
+        pool.join()
+        return array(results)
+
     def getBsweep(self, pos=numpyArray, multiprocessing=False, processes=0):
 
         Btotal = []
 
         assert all(isPosVector(item)
                    for item in pos), "Non-position vector in Collection getBsweep"
-        calcFields = [s.getBsweep(pos, multiprocessing=multiprocessing,
-                                  processes=processes) for s in self.sources]
+        if cpu_count() < len(numpyArray) or multiprocessing is False: # If there are too few positions to parallelize in 
+            calcFields = [s.getBsweep(pos, multiprocessing=multiprocessing,
+                                    processes=processes) for s in self.sources]
+        else:
+            calcFields = self._getBsweepObj(pos,processes)
 
         for p in range(len(pos)):  # For each position, calculate and sum all fields
             px = py = pz = 0
@@ -639,6 +662,6 @@ class Collection(FieldSampler):
         plt.tight_layout()
 
         if suppress is False:
-            plt.show()
+            plt.show(block=False)
 
         return plt.gcf()

--- a/tests/test_Collection.py
+++ b/tests/test_Collection.py
@@ -358,7 +358,42 @@ def test_GetBSweepList():
         for j in range(3):
             assert round(result[i][j],rounding) == round(mockResult[i][j],rounding)
 
-def test_GetBSweepList_multiprocessing():
+def test_GetBSweepList_multiprocessing_many_positions_few_objects():
+    # Check if getB sweep is performing multipoint
+    # calculations utilizing multiple processes
+
+    from magpylib._lib.classes.magnets import Box
+    type_erMsg =  "getBsweep did not return a numpy array."
+    #Input
+    mag=(2,3,5)
+    dim=(2,2,2)
+    pos=array([     [2,2,2],
+                    [2,2,2],
+                    [2,2,3],
+                    [2,2,2],
+                    [2,2,2],
+                    [2,2,3]])
+
+
+    mockResult = [  [0.24976596, 0.21854521, 0.15610372],
+                    [0.24976596, 0.21854521, 0.15610372],
+                    [0.12442073, 0.10615358, 0.151319  ],
+                    [0.24976596, 0.21854521, 0.15610372],
+                    [0.24976596, 0.21854521, 0.15610372],
+                    [0.12442073, 0.10615358, 0.151319  ],]
+    #Run   
+    b = Box(mag,dim)
+    b2 = Box(mag,dim)
+    c = Collection(b,b2)
+    result = c.getBsweep(pos,multiprocessing=True)
+    assert isinstance(result,ndarray), type_erMsg
+    rounding = 4
+    for i in range(len(mockResult)):
+        for j in range(3):
+            assert round(result[i][j],rounding) == round(mockResult[i][j],rounding)
+
+
+def test_GetBSweepList_multiprocessing_many_objects_few_positions():
     # Check if getB sweep is performing multipoint
     # calculations utilizing multiple processes
 
@@ -371,17 +406,16 @@ def test_GetBSweepList_multiprocessing():
                     [2,2,2],
                     [2,2,3]])
 
-
-    mockResult = [  [0.24976596, 0.21854521, 0.15610372],
-                    [0.24976596, 0.21854521, 0.15610372],
-                    [0.12442073, 0.10615358, 0.151319  ],]
+    numberOfBoxes = 30 
+    mockResult = [  array([0.12488298, 0.10927261, 0.07805186]) * numberOfBoxes,
+                    array([0.12488298, 0.10927261, 0.07805186]) * numberOfBoxes,
+                    array([0.06221036, 0.05307679, 0.0756595 ]) * numberOfBoxes,]
     #Run   
-    b = Box(mag,dim)
-    b2 = Box(mag,dim)
-    c = Collection(b,b2)
+    
+    c = Collection([Box(mag,dim) for i in range(numberOfBoxes)])
     result = c.getBsweep(pos,multiprocessing=True)
     assert isinstance(result,ndarray), type_erMsg
-    rounding = 4
+    rounding = 3
     for i in range(len(mockResult)):
         for j in range(3):
             assert round(result[i][j],rounding) == round(mockResult[i][j],rounding)


### PR DESCRIPTION
## Related Issues

#164 

## Notes

This adds handling for when `Collection.getBsweep(multiprocessing=True)` happens to have several objects but too few positions to parallelize efficiently, which ends up costing performance.

Benchmark Code:
https://gist.github.com/lucasgcb/40f5979d9436a671ed2600e429f52fa2

Benchmark was run with getBsweep of 1 Object for 10000 positions and getBsweep of compounding 10000 objects in 1 position.

<details>
<summary> Click Here for Benchmark Results </summary>

As we expected, running getBsweep when there are too few positions resulted in ridiculous processing times. I had to cancel out at 500 Objects since time was getting worse by each step.

![image](https://user-images.githubusercontent.com/7332704/60007110-f78a0800-9671-11e9-97ad-ccf4bfc00014.png)

After the tweak, getBsweep achieved a more acceptable processing time for 10000 objects.
Note how doing this is a more complex operation than performing getB, so there's some room for improvement. 

![image](https://user-images.githubusercontent.com/7332704/60007315-5b143580-9672-11e9-90d1-17ae3b1b673f.png)








</details>