### PR TITLE
display system fix (ax reference instead of plt)

### DIFF
--- a/magpylib/_lib/classes/collection.py
+++ b/magpylib/_lib/classes/collection.py
@@ -620,17 +620,17 @@ class Collection(FieldSampler):
         for d in dipolesList:
             drawDipole(d.position, d.moment,
                        d.angle, d.axis,
-                       SYSSIZE, plt)
+                       SYSSIZE, ax)
 
         if direc is True:  # Draw the Magnetization axes and current directions
-            drawCurrentArrows(currentsList, SYSSIZE, plt)
-            drawMagAxis(magnetsList, SYSSIZE, plt)
+            drawCurrentArrows(currentsList, SYSSIZE, ax)
+            drawMagAxis(magnetsList, SYSSIZE, ax)
 
-        for tick in ax.xaxis.get_ticklabels()+ax.yaxis.get_ticklabels()+ax.zaxis.get_ticklabels():
-            tick.set_fontsize(12)
-        ax.set_xlabel('x[mm]', fontsize=12)
-        ax.set_ylabel('y[mm]', fontsize=12)
-        ax.set_zlabel('z[mm]', fontsize=12)
+        #for tick in ax.xaxis.get_ticklabels()+ax.yaxis.get_ticklabels()+ax.zaxis.get_ticklabels():
+        #    tick.set_fontsize(12)
+        ax.set_xlabel('x[mm]')#, fontsize=12)
+        ax.set_ylabel('y[mm]')#, fontsize=12)   #change font size through rc parameters
+        ax.set_zlabel('z[mm]')#, fontsize=12)
         ax.set(
             xlim=(-SYSSIZE, SYSSIZE),
             ylim=(-SYSSIZE, SYSSIZE),

--- a/magpylib/_lib/utility.py
+++ b/magpylib/_lib/utility.py
@@ -22,7 +22,7 @@
 # page at https://www.github.com/magpylib/magpylib/issues.
 # -------------------------------------------------------------------------------
 from typing import Tuple
-from numpy import float64, isnan, array
+from numpy import float64, isnan, array, sqrt
 # Helper function for validating input dimensions
 
 
@@ -82,7 +82,7 @@ def addUniqueSource(source, sourceList):
 ####
 
 
-def drawMagnetizationVector(position, magnetization, angle, axis, color, SYSSIZE, pyplot):
+def drawMagnetizationVector(position, magnetization, angle, axis, color, SYSSIZE, ax):
     """Draw the magnetization vector of a magnet.
 
     Parameters
@@ -108,14 +108,14 @@ def drawMagnetizationVector(position, magnetization, angle, axis, color, SYSSIZE
     P = position
     # Get a lil different but unique tone
     c = [color[0]/2, color[1]/2, color[2]/2, color[3]]
-    pyplot.quiver(P[0], P[1], P[2],  # X,Y,Z position
+    ax.quiver(P[0], P[1], P[2],  # X,Y,Z position
                   M[0], M[1], M[2],  # Components of the Vector
                   normalize=True,
                   length=SYSSIZE,
                   color=c)
 
 
-def drawMagAxis(magnetList, SYSSIZE, pyplot):
+def drawMagAxis(magnetList, SYSSIZE, ax):
     """
     Draws the magnetization vectors of magnet objects in a list.
 
@@ -136,12 +136,12 @@ def drawMagAxis(magnetList, SYSSIZE, pyplot):
     for s in magnetList:
         drawMagnetizationVector(s.position, s.magnetization,
                                 s.angle, s.axis, s.color,
-                                SYSSIZE, pyplot)
+                                SYSSIZE, ax)
 
 ####
 
 
-def drawLineArrows(vertices, current, SYSSIZE, pyplot):
+def drawLineArrows(vertices, current, SYSSIZE, ax):
     """
     Helper function for Collection.displaySystem()
     Draw Arrows inside the line to show current orientation
@@ -165,14 +165,14 @@ def drawLineArrows(vertices, current, SYSSIZE, pyplot):
         x = vertices[(-(v+1), v)[current <= 0]]
         y = vertices[(-((v+2) % lenli), (v+1) % lenli)
                      [current <= 0]]  # Get second to last
-        pyplot.quiver((x[0]+y[0])/2, (x[1]+y[1])/2, (x[2]+y[2])/2,  # Mid point in line
+        ax.quiver((x[0]+y[0])/2, (x[1]+y[1])/2, (x[2]+y[2])/2,  # Mid point in line
                       # Components of the Vector
                       x[0]-y[0], x[1]-y[1], x[2]-y[2],
                       normalize=True,
                       length=SYSSIZE/12,
                       color='k')
 
-        pyplot.quiver(y[0], y[1], y[2],  # Arrow at start
+        ax.quiver(y[0], y[1], y[2],  # Arrow at start
                       # Components of the Vector
                       x[0]-y[0], x[1]-y[1], x[2]-y[2],
                       normalize=True,
@@ -180,14 +180,14 @@ def drawLineArrows(vertices, current, SYSSIZE, pyplot):
                       color='k')
 
 
-def drawCurrentArrows(currentList, SYSSIZE, pyplot):
+def drawCurrentArrows(currentList, SYSSIZE, ax):
     for s in currentList:
-        drawLineArrows(s.vertices, s.current, SYSSIZE, pyplot)
+        drawLineArrows(s.vertices, s.current, SYSSIZE, ax)
 
 ###
 
 
-def drawDipole(position, moment, angle, axis, SYSSIZE, pyplot):
+def drawDipole(position, moment, angle, axis, SYSSIZE, ax):
     """
     Draw a dipole moment arrow.
 
@@ -206,8 +206,8 @@ def drawDipole(position, moment, angle, axis, SYSSIZE, pyplot):
     from magpylib._lib.mathLibPublic import rotatePosition
     P = rotatePosition(position, angle, axis)
     M = rotatePosition(moment, angle, axis)
-
-    pyplot.quiver(P[0], P[1], P[2],  # X,Y,Z position
+    
+    ax.quiver(P[0], P[1], P[2],  # X,Y,Z position
                   M[0], M[1], M[2],  # Components of the Vector
                   normalize=True,
                   length=SYSSIZE/12,

--- a/magpylib/_lib/utility.py
+++ b/magpylib/_lib/utility.py
@@ -22,7 +22,7 @@
 # page at https://www.github.com/magpylib/magpylib/issues.
 # -------------------------------------------------------------------------------
 from typing import Tuple
-from numpy import float64, isnan, array, sqrt
+from numpy import float64, isnan, array
 # Helper function for validating input dimensions
 
 


### PR DESCRIPTION
@lucasgcb 

please check out these changes.

I notices that there were some functions in utility that are used in displaySystem to draw quivers. However, they were given 'pyplot' as argument rather than the respective axis. In this case matplotlib always gives plt.gca() (which is the current active axis).

With the new option subplotAx in displaySystem it is now possible to activate other axes BEFORE the plotting takes place. so the quiver objects will jump to the last used axis.

This problem should be fixed with this commit, but please double check it!!!