### PR TITLE
Proofread dokuv2

### DIFF
--- a/docs/_pages/1_how2install.md
+++ b/docs/_pages/1_how2install.md
@@ -1,14 +1,15 @@
 # Installation Instructions
 
-- [Installation Instructions](#installation-instructions)
-  - [Install with pip](#install-with-pip)
-  - [Windows Install](#windows-install)
-      - [Anaconda 3 Install](#anaconda-3-install-for-spyder-or-jupyter-notebook)
-      - [Clean Python 3 install](#clean-python-3-install)
-  - [Linux Install](#linux-install)
-      - [Anaconda 3 Install](#anaconda-3-install)
-      - [Terminal Python 3 Install](#terminal-python-3-install)
-  - [Download Sites](#download-pages)
+- Content 
+  - [Installation Instructions](#installation-instructions)
+    - [Install with pip](#install-with-pip)
+    - [Windows Install](#windows-install)
+        - [Anaconda 3 Install](#anaconda-3-install)
+        - [Clean Python 3 Install](#clean-python-3-install)
+    - [Linux Install](#linux-install)
+        - [Anaconda 3 Linux Install](#anaconda-3-linux-install)
+        - [Terminal Python 3 Install](#terminal-python-3-install)
+    - [Download Sites](#download-sites)
 
 ```eval_rst
 
@@ -18,13 +19,13 @@
 
 ## Install with pip
 
-The quickest installation on any platform ist through pip.
+The quickest installation on any platform is through pip.
 
 ```
 pip install magpylib
 ```
 
-If you are unfamiliar with pip please follow the detailed guides below
+If you are unfamiliar with pip, please follow the detailed guides below:
 
 ---
 
@@ -81,11 +82,11 @@ If you want to have a custom environment without using conda, you may simply ins
 
 ## Linux Install
 
-#### Anaconda 3 Install
+#### Anaconda 3 Linux Install
 
 <details>
 
-<a href="#anaconda-3-install"><summary> Click here for Steps </summary></a>
+<a href="#anaconda-3-linux-install"><summary> Click here for Steps </summary></a>
 
 1. [Download Anaconda][anaconda]
 2. Open a terminal window and type `anaconda-navigator`

--- a/docs/_pages/2_guideExamples.md
+++ b/docs/_pages/2_guideExamples.md
@@ -14,7 +14,7 @@ It is the aim of this section to give a few code examples that show how the libr
 ```eval_rst
 
 .. warning::
-    With Spyder inline plotting the graphics output can be false. Use graphic backend *Qt5* instead of *Inline* in settings/IPython console/Graphics.
+    With Spyder's IPython *Inline* graphics plotting, plots made after calling :meth:`~magpylib.Collection.displaySystem()` can come out blank. Set the IPython Graphics backend to *Automatic* or *Qt5* instead of *Inline* in settings/IPython console/Graphics method to address this.
 ```
 
 ### A Simple Collection and its Field

--- a/docs/_pages/3_MATLAB.md
+++ b/docs/_pages/3_MATLAB.md
@@ -4,15 +4,15 @@
 
 .. note::
 
-   Matlab does not support Tkinter, which disables matplotlib. This means that :meth:`~magpylib.Collection.displaySystem()` will not generate a display and might interrupt the program.
+   MATLAB does not support Tkinter, which disables matplotlib. This means that :meth:`~magpylib.Collection.displaySystem()` will not generate a display and might interrupt the program.
 
 ```
 
 ## Setting Python Interpreter
 
-As of version R2015b, Matlab allows you to call libraries from other 
+As of version R2015b, MATLAB allows you to call libraries from other 
 programming languages, including Python, which enables users to run 
-magpylib from the Matlab interface. The following guide intends to 
+magpylib from the MATLAB interface. The following guide intends to 
 provide a digest of the [Official MATLAB documentation](https://www.mathworks.com/help/matlab/call-python-libraries.html) 
 with a focus on utilizing this interface with magpylib.
 
@@ -22,29 +22,29 @@ with a focus on utilizing this interface with magpylib.
 
 &nbsp;
 
-Running the following line in the Matlab console tells you which 
-Python environment (user space interpreter) is connected to your Matlab.
+Running the following line in the MATLAB console tells you which 
+Python environment (user space interpreter) is connected to your MATLAB interface.
 
 ```matlab
 >>> pyversion
 ```
 
 If magpylib is already installed in this environment you can directly 
-call it, as shown in the [example](#example:-Calling-magpylib-from-Matlab) below.
+call it, as shown in the [example](#example:-Calling-magpylib-from-MATLAB) below.
 If not please follow the [installation guide](1_how2install.md) and install magpylib.
 
 If you choose to install magpylib in a different environment than the one that is
-currently connected to your Matlab interpreter, use the following command 
-in the Matlab console to connect the new environment instead (choose correct 
+currently connected to your MATLAB interpreter, use the following command 
+in the MATLAB console to connect the new environment instead (choose correct 
 path pointing at your Python interpreter).
 
 ```matlab
 >>> pyversion C:\Users\...\AppData\Local\Continuum\anaconda3\envs\magpy\python.exe
 ```
 
-## Example: Calling magpylib from Matlab
+## Example: Calling magpylib from MATLAB
 
-The following Matlab script showcases most functionalities.
+The following MATLAB script showcases most functionalities.
 
 ```matlab
 %%%%%%%%%%%%%%%%%% magpytest.m %%%%%%%%%%%%%%

--- a/docs/_pages/3_MATLAB.md
+++ b/docs/_pages/3_MATLAB.md
@@ -33,7 +33,7 @@ If magpylib is already installed in this environment you can directly
 call it, as shown in the [example](#example:-Calling-magpylib-from-Matlab) below.
 If not please follow the [installation guide](1_how2install.md) and install magpylib.
 
-If you choose to install magplyib in a different environment than the one that is
+If you choose to install magpylib in a different environment than the one that is
 currently connected to your Matlab interpreter, use the following command 
 in the Matlab console to connect the new environment instead (choose correct 
 path pointing at your Python interpreter).

--- a/docs/pyplots/examples/01b_AllSources.py
+++ b/docs/pyplots/examples/01b_AllSources.py
@@ -28,13 +28,16 @@ s5 = source.current.Circular(curr=10, dim=5)                        #Circular
 s6 = source.moment.Dipole(moment=[0,0,100])                         #Dipole
 
 for i,s in enumerate([s1,s2,s3,s4,s5,s6]):
-    
-    #plot geometry
+
+    #plot geometry in memory
     c = Collection(s)
-    c.displaySystem(subplotAx=axsA[i],markers=[(6,0,6)])
+    c.displaySystem(subplotAx=axsA[i],markers=[(6,0,6)],suppress=True)
     axsA[i].plot([-6,6,6,-6,-6],[0,0,0,0,0],[-6,-6,6,6,-6])
 
-    #plot field
+    #plot field in memory
     B = array([s.getB(p) for p in posis]).reshape(50,50,3)
     axsB[i].pcolor(X,Y,norm(B,axis=2),cmap=plt.cm.get_cmap('coolwarm'))
     axsB[i].streamplot(X, Y, B[:,:,0], B[:,:,2], color='k',linewidth=1)
+
+#display plots
+plt.show()

--- a/docs/pyplots/examples/03a_Bsweep1.py
+++ b/docs/pyplots/examples/03a_Bsweep1.py
@@ -28,7 +28,7 @@ ax1 = fig.add_subplot(121,projection='3d')
 ax2 = fig.add_subplot(122)
 
 #add displaySystem on ax1
-c.displaySystem(subplotAx=ax1)
+c.displaySystem(subplotAx=ax1,suppress=True)
 
 ##amplitude plot on ax2
 X,Z = np.meshgrid(xs,zs)

--- a/docs/pyplots/examples/04_ComplexShape.py
+++ b/docs/pyplots/examples/04_ComplexShape.py
@@ -26,7 +26,7 @@ ax1 = fig.add_subplot(121,projection='3d')
 ax2 = fig.add_subplot(122)
 
 #add displaySystem on ax1
-c.displaySystem(subplotAx=ax1)
+c.displaySystem(subplotAx=ax1,suppress=True)
 ax1.view_init(elev=75)
 
 ##amplitude plot on ax2

--- a/docs/pyplots/examples/05_Multiprocessing.py
+++ b/docs/pyplots/examples/05_Multiprocessing.py
@@ -10,36 +10,38 @@ def main():
     spi1 = [(-t*cos(t),-t*sin(t),t) for t in linspace(-50,-10,200)]
     spi2 = [(10*cos(t),10*sin(t),t) for t in linspace(-9.8, 9.8,50)]
     spi3 = [( t*cos(t), t*sin(t),t) for t in linspace( 10, 50,200)]
-    
+
     #create source + collection
     s = source.current.Line(curr=1,vertices=spi1+spi2+spi3)
     c = Collection(s)
-    
+
     #create positions
     zs = linspace(-15,15,150)
     posis = [[x,0,z] for x in [7,8] for z in zs ]
-    
+
     ##define figure with 2d and 3d axes
     fig = plt.figure(figsize=(9,4))
     ax1 = fig.add_subplot(121,projection='3d')
     ax2 = fig.add_subplot(122)
-    
+
     #add displaySystem on ax1
-    c.displaySystem(subplotAx=ax1)
-    
+    c.displaySystem(subplotAx=ax1,suppress=True)
+
     #calculate fields and check timings
     T0 = time.perf_counter()
     Bs = c.getBsweep(posis,multiprocessing=False).reshape(2,150,3)
     T1 = time.perf_counter()
     Bs = c.getBsweep(posis,multiprocessing=True).reshape(2,150,3)
     T2 = time.perf_counter()
-    
+
     print('timing without multiprocessing: ' + str(T1-T0))
     print('timing with multiprocessing: ' + str(T2-T1))
 
     #plot fields
     for i in range(2):
         ax2.plot(zs,Bs[i])
+        
+    plt.show()
 
 #run main within multiprocessing guard
 if __name__ == "__main__":


### PR DESCRIPTION
# Notes

## Fixed:
- Some typos 
- Anchor links from the TOC in Installation page being weird.
- Example code being "Inline mode unfriendly". Examples should now work in whatever graphics backend the user has currently

## Changed:
- References of "Matlab" instead of "MATLAB" in the MATLAB page.
- Spyder's Warning -  this is actually a problem with IPython (which is run inside Spyder) and it will show up on other IDEs that utilize it. I've attempted to clarify this so users can take appropriate measures.