### PR TITLE
Add axis input typechecking to all RCS objects

### DIFF
--- a/magpylib/_lib/classes/base.py
+++ b/magpylib/_lib/classes/base.py
@@ -69,6 +69,10 @@ class RCS:
 
     def __init__(self, position, angle, axis):
         # fundamental (unit)-orientation/rotation is [0,0,0,1]
+        assert any(
+            ax != 0 for ax in axis), "Invalid Axis input for Sensor (0,0,0)"
+        assert all(
+            isinstance(ax, int) or isinstance(ax, float) for ax in axis), "Invalid Axis input for Sensor" + str(axis)
 
         self.position = array(position, dtype=float64, copy=False)
         try:

--- a/tests/test_base/test_base.py
+++ b/tests/test_base/test_base.py
@@ -5,6 +5,29 @@ from magpylib._lib.classes.base import MagMoment
 import pytest
 
 
+def test_initialization_bad_axis_error():
+    pos = [1, 23, 2]
+    angle = 90
+    badAxis = (1, 1, "str")
+    with pytest.raises(AssertionError):
+        base.RCS(pos, angle, badAxis)
+
+
+def test_initialization_bad_axis_error2():
+    pos = [1, 23, 2]
+    angle = 90
+    badAxis = (0, 0, 0)
+    with pytest.raises(AssertionError):
+        base.RCS(pos, angle, badAxis)
+
+
+def test_initialization_bad_axis_error3():
+    pos = [23, 2, 20]
+    angle = 90
+    badAxis = (1, 1)
+    with pytest.raises(SystemExit):
+        base.RCS(pos, angle, badAxis)
+
 def test_initialization_bad_pos_error():
     badPos = [23, 2]
     angle = 90
@@ -21,12 +44,6 @@ def test_initialization_bad_angle_error():
         base.RCS(pos, badAngle, axis)
 
 
-def test_initialization_bad_axis_error():
-    pos = [23, 2, 20]
-    angle = 90
-    badAxis = (1, 1)
-    with pytest.raises(SystemExit):
-        base.RCS(pos, angle, badAxis)
 
 
 def test_setOrientation_bad_axis_error():


### PR DESCRIPTION
# Related Issues



# Notes

This adds axis input protection to all RCS enabled objects.

An assertion will check if the axis input follows the following format:

`(numeric,numeric,numeric)`

where `numeric` is any rational number different from 0.