### PR TITLE
Add sensor entry in docs

### DIFF
--- a/docs/_pages/0_documentation.md
+++ b/docs/_pages/0_documentation.md
@@ -8,6 +8,7 @@ The idea behind magpylib is to provide simple and easy to use classes for calcul
 In this part of the documentation the fundamental structure of the magpylib library is detailed.
 
 - Content
+- [Library Documentation](#library-documentation)
   - [Package Structure](#package-structure)
   - [Units and IO Types](#units-and-io-types)
   - [The Source Class](#the-source-class)
@@ -22,6 +23,7 @@ In this part of the documentation the fundamental structure of the magpylib libr
       - [Complex Magnet Geometries](#complex-magnet-geometries)
       - [Display Collection Graphically](#display-collection-graphically)
   - [Math Package](#math-package)
+  - [The Sensor Class](#the-sensor-class)
 
 
 ## Package Structure
@@ -396,3 +398,26 @@ The math package provides some functions for easier use of the angle-axis (Quate
   positionNew = magpy.math.rotatePosition(pos0,angle,axis,anchor)
   print(positionNew)                  #Output = [2. 0. 0.]
   ```
+
+
+## The Sensor Class
+
+```eval_rst
+The field sampling method, getB, in the :class:`magpylib.source` classes will always extract the field components from an absolute orientation in the coordinate space, given a position. 3D sensors do not behave in this manner as their readings are affected the most by their positioning and tilt relative to the system they are sensing. 
+
+Since version 1.2-beta, magpylib now offers the :class:`magpylib.Sensor` class, which provides an object that may be placed and oriented in a coordinate space. This allows for quick analysis of relative measurements of system arrangements. Here is an example:
+
+.. plot:: pyplots/doku/sensorSource.py
+   :include-source:
+
+```
+
+
+```eval_rst
+
+The sensors may also read multiple sources in a :class:`magpylib.Collection`, and be displayed using the :meth:`magpylib.Collection.displaySystem()` method by using the sensors keyword argument. Multiple sensors may be displayed.
+
+.. plot:: pyplots/doku/thorsHammerSensor.py
+   :include-source:
+
+```

--- a/docs/pyplots/doku/sensorSource.py
+++ b/docs/pyplots/doku/sensorSource.py
@@ -1,0 +1,21 @@
+from magpylib import source, Sensor, Collection
+
+
+##### Single source example
+sensorPosition = [5,0,0]
+sensor = Sensor(pos=sensorPosition,
+                angle=90,
+                axis=(0,0,1))
+
+cyl = source.magnet.Cylinder([1,2,300],[0.2,1.5])
+
+# Read field from absolute position in system
+absoluteReading = cyl.getB(sensorPosition)
+print(absoluteReading)
+# [ 0.50438605   1.0087721  297.3683702 ]
+
+# Now, read from sensor and print the relative output
+relativeReading = sensor.getB(cyl)
+print(relativeReading)
+# [ 1.0087721   -0.50438605 297.3683702 ]
+

--- a/docs/pyplots/doku/thorsHammerSensor.py
+++ b/docs/pyplots/doku/thorsHammerSensor.py
@@ -1,0 +1,33 @@
+from magpylib import source, Sensor, Collection
+from numpy import around
+##### Define Sensors
+sensor0Position = [2,1,-2]
+sensor1Position = [-2,-1,-2]
+sensor0 = Sensor(pos=sensor0Position,
+                angle=90,
+                axis=(0,0,1))
+sensor1 = Sensor(sensor1Position,0,(0,0,1))
+
+##### Define magnets, Collection system
+cyl = source.magnet.Cylinder([1,2,300],[0.2,1.5])
+box = source.magnet.Box([1,2,300],[1,1,0.5],[0,0,1])
+col = Collection(cyl,box)
+
+# Read from absolute position in Collection system
+absoluteReading = [col.getB(sensor0Position), col.getB(sensor1Position)]
+print(absoluteReading)
+# [-0.34285586 -0.17269852  0.22153783]
+
+# Rotated sensor reading
+relativeReading = [sensor0.getB(col),sensor1.getB(col)]
+print(relativeReading)
+# [-0.17269852  0.34285586  0.22153783]
+
+sensorList = [sensor0, sensor1]
+markerText0 = "sensor0:{}".format(around(relativeReading[0],2))
+markerText1 = "sensor1:{}".format(around(relativeReading[1],2))
+markerList = [ sensor0Position + [markerText0],
+               sensor1Position + [markerText1],
+               [3,3,3]]
+
+col.displaySystem(sensors=sensorList , markers=markerList, direc=True)

--- a/docs/pyplots/doku/thorsHammerSensor.py
+++ b/docs/pyplots/doku/thorsHammerSensor.py
@@ -16,12 +16,14 @@ col = Collection(cyl,box)
 # Read from absolute position in Collection system
 absoluteReading = [col.getB(sensor0Position), col.getB(sensor1Position)]
 print(absoluteReading)
-# [-0.34285586 -0.17269852  0.22153783]
+# [ array([-0.34285586, -0.17269852,  0.22153783]), 
+#   array([0.34439442, 0.1707909 , 0.22611859])]
 
 # Rotated sensor reading
 relativeReading = [sensor0.getB(col),sensor1.getB(col)]
 print(relativeReading)
-# [-0.17269852  0.34285586  0.22153783]
+# [ array([-0.17269852,  0.34285586,  0.22153783]), 
+#   array([0.34439442, 0.1707909 , 0.22611859])]
 
 sensorList = [sensor0, sensor1]
 markerText0 = "sensor0:{}".format(around(relativeReading[0],2))


### PR DESCRIPTION
# Related Issues

#3 

# Notes

This adds an entry for the Source class in the Library documentation section.

Take a look here:

https://magpylib.readthedocs.io/en/guide-sensor/_pages/0_documentation/#the-sensor-class