### PR TITLE
Inline utility functions for getB

### DIFF
--- a/magpylib/_lib/utility.py
+++ b/magpylib/_lib/utility.py
@@ -258,32 +258,6 @@ def drawDipole(position, moment, angle, axis, SYSSIZE, ax):
 
 # Source package helpers
 
-def rotateToCS(pos, source_ref):
-        # Used in all getB()
-    from magpylib._lib.mathLibPrivate import angleAxisRotation
-    # secure input type and check input format
-    p1 = array(pos, dtype=float64, copy=False)
-
-    # relative position between mag and obs
-    posRel = p1 - source_ref.position
-
-    # rotate this vector into the CS of the magnet (inverse rotation)
-    # Leave this alone for now pylint: disable=invalid-unary-operand-type
-    p21newCm = angleAxisRotation(source_ref.angle, -source_ref.axis, posRel)
-
-    return p21newCm
-
-
-def getBField(BCm, source_ref):
-    # Used in all getB()
-    # BCm is the obtained magnetic field in Cm
-    # the field is well known in the magnet coordinates
-    from magpylib._lib.mathLibPrivate import angleAxisRotation
-    # rotate field vector back
-    B = angleAxisRotation(source_ref.angle, source_ref.axis, BCm)
-
-    return B
-
 
 def recoordinateAndGetB(source_ref, args):
     ## Used in base.RCS.getBDisplacement(),

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,5 +1,5 @@
 from typing import Tuple
-from magpylib._lib.utility import checkDimensions,rotateToCS,getBField, isPosVector,isDisplayMarker
+from magpylib._lib.utility import checkDimensions, isPosVector,isDisplayMarker
 from magpylib._lib.utility import isSensor
 from numpy import float64, isnan, array
 import pytest
@@ -57,23 +57,6 @@ def test_checkDimensionReturn():
     result = checkDimensions(1,dim=(3))
     assert len(result) == 1, errMsg
     
-def test_rotateToCS():
-    errMsg =  "Wrong rotation for Box in CS"
-    mockResults = array([-19. ,   1.2,   8. ]) # Expected result for Input
-
-    # Input
-    mag=[5,5,5]
-    dim=[1,1,1]
-    pos=[63,.8,2]
-    
-    # Run
-    from magpylib import source
-    b = source.magnet.Box(mag,dim,pos)
-    result = rotateToCS([44,2,10],b)
-    
-    rounding=4
-    for i in range(3):
-        assert round(result[i],rounding)==round(mockResults[i],rounding), errMsg
 
 def test_isPosVector():
     errMsg = "isPosVector returned unexpected False value"
@@ -114,25 +97,3 @@ def test_isPosVectorArgs():
                      [1,0,0],
                      (255,(0,1,0)),],]
     assert any(isPosVector(a)==False for a in listOfArgs)                 
-
-def test_getBField():
-    errMsg =  "Wrong field for Box in CS"
-    mockResults = array([-4.72365793e-05,  1.35515955e-05, -7.13360174e-05])
-
-    # Input
-    mockField = array([ 1.40028858e-05, -4.89208175e-05, -7.01030695e-05])
-    axis = [1,1,1]
-    angle = 90
-    
-    class MockSource: ## Mock a Source object with two attributes.
-        def __init__(self, axis, angle):
-            self.axis = axis
-            self.angle = angle
-    mockSource = MockSource(axis,angle)
-    
-    # Run
-    result =  getBField(mockField, mockSource)
-
-    rounding = 4
-    for i in range(3):
-        assert round(result[i],rounding)==round(mockResults[i],rounding), errMsg


### PR DESCRIPTION
# Related Issues

None

# Notes

This places the utility functions for getB of all source objects inline, saving on function calls.
The downside is that it looks not as nice.

Also, deprecate utility functions for getB and their tests.