### PR TITLE
Magpy3 Azure Testing Suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           name: Install Testing Env
           command: mkdir test-results && pip install tox
       - run:
-          name: Run Test Suite
+          name: Run Coverage Test Suite
           command: tox
   deploy:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,182 @@
+# magpylib Changelog
+
+All notable changes to magpylib are documented here.
+
+---
+
+# Releases
+
+## [Unreleased] - 2021-??-??
+
+## [2.3.0b] - 2020-01-17
+
+### Changed
+- Improved performance of getB for diametral magnetized Cylinders by 20%.
+- GetB of Line current now uses vectorized code which leads to massive performance enhancement.
+- **IMPORTANT:** position arguments of `getBv` functions have been flipped! First comes the source position POSm THEN the observer position POSo!
+- - getB(pos) now takes single AND vector position arguments. If a vector is handed to getB it will automatically execute vectorized code from the vector module.
+
+### Added
+- completed the library vector functionality adding magnet Cylinder, moment Dipole, current Circular and Line. This includes adding several private vectorized functions (e.g. ellipticV) to mathLib_vector, adding respective tests and docu examples.
+
+---
+
+## [2.2.0b] - 2019-12-27
+- unreleased version
+
+---
+
+## [2.1.0b] - 2019-12-06
+
+### Added
+- Docstrings for vector functions.
+- displaySystem kwarg `figsize`
+- bringing documentation up to speed
+
+### Fixes
+- init file bug
+
+---
+
+## [2.0.0b] - 2019-11-29
+### Changed
+- Restructuring
+  - displaySystem is now a top-level function, not a Collection method anymore.
+  - getBsweep and multiprocessing options have been completely removed, this functionality
+    should be overtaken by the new vector functionality which uses the numpy native vectorized 
+    code paradigm. If mkl library is set (test by numpy.show_config()) numpy will also 
+    automatically use multiporcessing. Code parallelization at magpylib level should be done
+    by hand.
+- Docstrings are adjusted to work better with intellisense. (Problems with *.rst code)
+- public rotatePosition() is now called angleAxisRotation(), former private angleAxisRotation
+    is now called angleAxisRotation_priv().
+- Major rework of the documentation and examples.
+
+### Added
+- Performance computation trough vector functionality included in new top-level subpackge "vector"
+- Vectorized versions of math functions added to "math" subpackage
+
+---
+
+## [1.2.1b0] - 2019-07-31
+### Changed
+- Optimized getB call (utility integrated)
+- Improved Documentation (added Sensor class v1)
+
+---
+
+## [1.2.0b0] - 2019-07-16
+### Added
+- Sensor Class
+  - This allows users to create a coordinate system-enabled Sensor object, which can be placed, rotated, moved and oriented. 
+  - This object can take the B-Field of a system (be it single source or a Collection) with the added functionality of having its own reference in the coordinate space, allowing users to easily acquire relative B-Field measurements of a system from an arbitrarily placed sensor object. 
+  - Sensors in a list may be displayed in the `Collection.displaySystem()` by using the `sensors` keyword argument.
+- Added content to the `__repr__` builtin to all source classes for quick console evaluations, simply call a defined object in your Python shell to print out its attributes.
+### Changed
+- Edge cases in field calculations now return a proper [RuntimeWarning](https://docs.python.org/3/library/exceptions.html#RuntimeWarning) instead of console prints
+### Fixed
+- Unused imports and variables
+
+---
+
+## [1.1.1b0] - 2019-06-25
+### Added 
+- Changelog
+### Changed
+- Change `Collection.displaySystem()` not having the `block=False` setting for matplotlib's `pyplot.show()` by default, this meant that outside interactive mode calling this function would hang the script until the plot was closed.
+  - If for some reason you want to block the application, you may still use `Collection.displaySystem()`'s `suppress=True` kwarg then call pyplot.show() normally. 
+  - This should cause no API changes, if you have problems please notify us.
+
+### Fixed
+- Fix multiprocessing enabled `Collection.getBsweep()` for lots of objects with few positions causing great performance loss. This functionality now behaves as expected for the use case.
+- Fix `Collection.displaySystem()`'s drawing of Dipole objects in external axes (plots) using the `subplotAx` kwarg crashing the application. This functionality now behaves as expected for the use case.
+
+---
+
+## [1.1.0b0] - 2019-06-14
+### Added
+- Implemented one new kwarg for `Collection.displaySystem()`:
+
+    > `subplotAx=None`
+        Draw into a subplot axe that already exists. The subplot needs to be 3D projected
+        
+  This allows for creating side-by-side plots using displaySystem.
+  Figure information must be set manually in pyplot.figure() in order to not squash the plots upon subplotting.
+    
+
+    <details>
+    <summary> Click here for Example </summary>
+
+    Code: https://gist.github.com/lucasgcb/77d55f2fda688e2fb8e1e4a68bb830b8
+
+    **Output:**
+    ![image](https://user-images.githubusercontent.com/7332704/58973138-86b4a600-87bf-11e9-9e63-35892b7a6713.png)
+
+    </details>
+    
+### Changed
+
+- `getBsweep()` for Collections and Sources now always returns a numpy array
+- Zero-length segments in Line sources now return `[0,0,0]` and a warning, making it easier to draw spirals without letting users do this unaware.
+
+### Fixed
+- Added a workaround fix for a rotation bug we are still working on.
+
+---
+
+## [1.0.2b0] - 2019-05-29
+
+### Added
+
+- `MANIFEST.in` file containing the LICENSE for bundling in PyPi
+
+---
+
+## [1.0.1b0] - 2019-05-28
+
+### Added
+
+- Issue and Pull Request Templates to Repository
+- Continuous Integration settings (Azure and Appveyor)
+- Code Coverage Reports with codecov
+
+
+
+### Removed
+
+- Support for Python 3.5 and under.
+
+---
+
+## [1.0.0b0] - 2019-05-21
+
+The first official release of the magpylib library. 
+
+### Added
+
+- Source classes:
+   - Box
+   - Cylinder
+   - Sphere
+   - Circular Current
+   - Current Line
+   - Dipole
+- Collection class
+
+---
+[Unreleased]:https://github.com/magpylib/magpylib/compare/2.3.0-beta...HEAD
+[2.3.0b]:https://github.com/magpylib/magpylib/compare/2.1.0-beta...2.3.0-beta
+[2.1.0b]:https://github.com/magpylib/magpylib/compare/2.0.0-beta...2.1.0-beta
+[2.0.0b]:https://github.com/magpylib/magpylib/compare/1.2.1-beta...2.0.0-beta
+[1.2.1b0]: https://github.com/magpylib/magpylib/compare/1.2.0-beta...1.2.1-beta
+[1.2.0b0]: https://github.com/magpylib/magpylib/compare/1.1.1-beta...1.2.0-beta
+[1.1.1b0]: https://github.com/magpylib/magpylib/compare/1.1.0-beta...1.1.1-beta
+[1.1.0b0]: https://github.com/magpylib/magpylib/compare/1.0.1-beta...1.1.0-beta
+[1.0.2b0]: https://github.com/magpylib/magpylib/compare/1.0.1-beta...1.0.2-beta
+[1.0.1b0]: https://github.com/magpylib/magpylib/compare/1.0.0-beta...1.0.1-beta
+[1.0.0b0]: https://github.com/magpylib/magpylib/releases/tag/1.0.0-beta
+
+---
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,9 +19,9 @@ strategy:
       python.version: '3.8'
     Python39:
       python.version: '3.9'
-    Python310:
-      python.version: '3.10'
-
+    #Python310:
+    #  python.version: '3.10'
+# Add Python 3.10 when it's stable (Currently 3.10.0a6, alpha, as of 08/03/2021)
 steps:
 - task: UsePythonVersion@0
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,37 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+trigger:
+- master
+- development 
+- magpylib3_development
+- feature/*
+
+pool:
+  vmImage: 'vs2017-win2016'
+strategy:
+  matrix:
+    Python37:
+      python.version: '3.7'
+    Python38:
+      python.version: '3.8'
+    Python39:
+      python.version: '3.9'
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '$(python.version)'
+  displayName: 'Use Python $(python.version)'
+
+- script: |
+    python -m pip install --upgrade pip
+    pip install .
+  displayName: 'Install dependencies'
+
+- script: |
+    pip install pytest pytest-azurepipelines
+    pytest
+  displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
 - master
 - development 
 - magpylib3_development
-- feature/*
+- feature-*
 
 pool:
   vmImage: 'vs2017-win2016'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,8 @@ strategy:
       python.version: '3.8'
     Python39:
       python.version: '3.9'
+    Python310:
+      python.version: '3.10'
 
 steps:
 - task: UsePythonVersion@0


### PR DESCRIPTION
# Related Issues

#266 
#258

# Notes
- Renamed test step in Circle CI to specify it delivers coverage data to our [codecov](https://app.codecov.io/gh/magpylib/magpylib) page
- Added Azure Pipelines trigger to magpylib3_development and to branches starting with `feature-`
- Dropped Python 3.6 from Azure Pipelines testing configuration
- Added Python 3.8 and 3.9 to Azure Pipelines testing configuration
- Readded CHANGELOG.md with previous changelog data
- Added missing version comparisons links to CHANGELOG.md
