### PR TITLE
fix wrong Cylinder faces

### DIFF
--- a/magpylib/_lib/display/disp_utility.py
+++ b/magpylib/_lib/display/disp_utility.py
@@ -58,14 +58,14 @@ def faces_cylinder(src, show_path):
     hs = np.array([-h2,h2])
     phis = np.linspace(0,2*np.pi,res)
     phis2 = np.roll(np.linspace(0,2*np.pi,res),1)
-    faces = [r*np.array([
-        (np.cos(p1), np.sin(p1),  h),
-        (np.cos(p1), np.sin(p1), -h),
-        (np.cos(p2), np.sin(p2), -h),
-        (np.cos(p2), np.sin(p2),  h)])
-        for p1,p2 in zip(phis,phis2) for h in hs]
-    faces += [r*np.array([
-        (np.cos(phi), np.sin(phi), h)
+    faces = [np.array([
+        (r*np.cos(p1), r*np.sin(p1),  h2),
+        (r*np.cos(p1), r*np.sin(p1), -h2),
+        (r*np.cos(p2), r*np.sin(p2), -h2),
+        (r*np.cos(p2), r*np.sin(p2),  h2)])
+        for p1,p2 in zip(phis,phis2)]
+    faces += [np.array([
+        (r*np.cos(phi), r*np.sin(phi), h)
          for phi in phis]) for h in hs]
 
     # add src attributes position and orientation depending on show_path


### PR DESCRIPTION
# Related Issues

When using the `display()` function, a Cylinder source is displayed in 3D plot with dimensions that differ from the ones defined. Given the sample below, a cylinder with a diameter of 10 mm and a height of 4mm is displayed as  a cylinder of diameter equals to 10 mm and a height of 20 mm.
```python
import magpylib as magpy
from magpylib.magnet import Cylinder
from magpylib._lib.display.disp_utility import faces_cylinder

src1 = Cylinder(mag=[0, 0, 1000], dim=[10, 4])
magpy.display(src1, show_path=False)
faces = faces_cylinder(src1, False)
```

![magpylib_issue_display](https://user-images.githubusercontent.com/11948994/114880658-885f4400-9e02-11eb-8fa0-70b91adf3342.png)

# Notes
This comes from the `faces_cylinder()` function, where the z component of each vertex of a face is multiplied by the radius `r`, instead of just x and y components.

Furthermore, the double iteration over the `hs` iterable (`-h2, +h2`) causes the duplication of faces, i.e. the 2 first faces returned by `face_cylinder()` function are identical.
