### PR TITLE
Readd GitHub community cfg file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Create a report to help improve magpylib!
+title: "[BUG] - "
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+```python
+### Please provide either (or both):
+## - a step-by-step description of how to reproduce the issue
+## - a code excerpt, that can be run by itself, which reproduces the issue
+```
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Linux 32bit]
+ - IDE [e.g. Spyder, PyCharm]
+
+**pip freeze output**
+Please run the `pip freeze` command in your python interpreter's environment and paste the output below.
+
+```
+pip freeze output:
+[ PASTE IT HERE ] 
+```
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest something for magpylib!
+title: "[REQUEST]"
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to some problem? If yes, please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the feature you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives or solutions you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question_magnetics.md
+++ b/.github/ISSUE_TEMPLATE/question_magnetics.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: We try to answer your questions about magnetic Systems and Magpylib.
+title: "[QUESTION] - "
+labels: ''
+assignees: ''
+
+---
+
+**Problem description**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+# Related Issues
+
+# Notes
+


### PR DESCRIPTION
# Related Issues

#304 

# Notes

Simply adds the [github configuration](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) files we had in the default before back into the new version, for when it reaches master.