### PR TITLE
Fix Docstring Menu

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,7 @@ This **Example code** calculates the magnetic field of a cylindrical magnet.
 A cylinder shaped permanent magnet with diameter and height of 4 and 5 millimeter, respectively, is created in a global coordinate system with cylinder axis parallel to the z-axis and geometric magnet center in the origin. The magnetization is homogeneous and points in z-direction with an amplitude of 350 millitesla. The magnetic field is calculated in units of millitesla at the observer position (4,4,4) in units of millimeter.
 
 
-**Ressources**
+**Resources**
 
 Examples can be found in the `Examples Section <_pages/2_guideExamples/>`_.
 
@@ -68,12 +68,11 @@ Technical details can be found in the `Documentation <_pages/0_documentation/>`_
    :maxdepth: 1
    :caption: Library Docstrings:
 
-    _autogen/magpylib
+   _autogen/magpylib
 
 
 **Index**
 
-* :ref:`modindex`
 * :ref:`genindex`
+* :ref:`modindex`
 .. * :ref:`search`
-

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 recommonmark>=0.5
 sphinx_rtd_theme>=0.4
-sphinx>=1.8.2
+sphinx==1.8.2

--- a/magpylib/__init__.py
+++ b/magpylib/__init__.py
@@ -2,9 +2,9 @@
 Magpylib provides static 3D magnetic field computation based on analytical
 formulas.
 
-Ressources
+Resources
 ----------
-www.https://magpylib.readthedocs.io/en/latest/
+https://magpylib.readthedocs.io/en/latest/
 https://github.com/magpylib/magpylib
 https://www.sciencedirect.com/science/article/pii/S2352711020300170
 
@@ -56,8 +56,8 @@ observers are positions (array_like) or Sensor objects
 
 1. src.getB(observers) ----------------> field of one source at all observers
 2. sens.getB(sources) -----------------> field of all sources at one sensor
-2. magpylib.getB(sources, observers) --> fields of all sources at all observers
-3. magpylib.getBv(**kwargs) -----------> direct access to core formulas (fastest)
+3. magpylib.getB(sources, observers) --> fields of all sources at all observers
+4. magpylib.getBv(**kwargs) -----------> direct access to core formulas (fastest)
 
 In addition to getB there is getH.
 


### PR DESCRIPTION
# Related Issues
#292 
# Notes
- The index.rst file had been modified by an earlier commit which caused Sphinx to not import the library docstrings into the side bar; This patch fixes this.

- Fixed some grammar on the page and the ``__init__.py`` bullet list.

- Lock Sphinx to 1.8.2 in the requirements because our configuration is exclusive for that version (currently Sphinx is on 4.0). 

###  Check the preview here: https://magpylib.readthedocs.io/en/fix-docstrings/

