### PR TITLE
Name in repr

### DIFF
--- a/magpylib/_src/obj_classes/class_BaseDisplayRepr.py
+++ b/magpylib/_src/obj_classes/class_BaseDisplayRepr.py
@@ -4,7 +4,7 @@ from magpylib._src.display import display
 
 # ALL METHODS ON INTERFACE
 class BaseDisplayRepr:
-    """ Provides the display(self) and self.repr methods for all objects
+    """Provides the display(self) and self.repr methods for all objects
 
     Properties
     ----------
@@ -18,10 +18,14 @@ class BaseDisplayRepr:
     display = display
 
     def __init__(self):
-        if not hasattr(self, '_object_type'):
+        if not hasattr(self, "_object_type"):
             self._object_type = None
 
     # ------------------------------------------------------------------
     # INTERFACE
     def __repr__(self) -> str:
-        return f'{self._object_type}(id={str(id(self))})'
+        name = getattr(self, "name", None)
+        if name is None and hasattr(self, "style"):
+            name = getattr(getattr(self, "style"), "name", None)
+        name_str = "" if name is None else f", name={name!r}"
+        return f"{self._object_type}(id={id(self)!r}{name_str})"

--- a/magpylib/_src/obj_classes/class_Collection.py
+++ b/magpylib/_src/obj_classes/class_Collection.py
@@ -200,7 +200,8 @@ class Collection(BaseDisplayRepr):
             pref = "Source"
         else:
             pref = "Mixed"
-        return f"{pref}{self._object_type}(id={str(id(self))})"
+        s = super().__repr__()
+        return f"{pref}{s}"
 
     # methods -------------------------------------------------------
     def add(self, *objects):

--- a/tests/test_obj_Cuboid.py
+++ b/tests/test_obj_Cuboid.py
@@ -84,4 +84,6 @@ def test_repr_cuboid():
     """ test __repr__
     """
     pm1 = Cuboid((1,2,3),(1,2,3))
+    pm1.style.name = 'cuboid_01'
     assert pm1.__repr__()[:6] == 'Cuboid', 'Cuboid repr failed'
+    assert "name='cuboid_01'" in pm1.__repr__(), 'Cuboid repr failed'


### PR DESCRIPTION
Adds a name entry, if available, in object representations. This feature is meant to ease the tracking of objects  when runing a script or when debugging

```python
import magpylib as magpy
pm1 = magpy.magnet.Cuboid((1,2,3),(1,2,3))
pm2 = magpy.magnet.Cuboid((1,2,3),(1,2,3))
pm2.style.name = 'cuboid_01'
print(pm1)
print(pm2)
```

output:
```
Cuboid(id=140470723768480)
Cuboid(id=140470723768960, name='cuboid_01')
```
