### PR TITLE
Style magic in object init

### DIFF
--- a/magpylib/_src/obj_classes/class_BaseDisplayRepr.py
+++ b/magpylib/_src/obj_classes/class_BaseDisplayRepr.py
@@ -4,7 +4,7 @@ from magpylib._src.display import display
 
 # ALL METHODS ON INTERFACE
 class BaseDisplayRepr:
-    """ Provides the display(self) and self.repr methods for all objects
+    """Provides the display(self) and self.repr methods for all objects
 
     Properties
     ----------
@@ -18,10 +18,10 @@ class BaseDisplayRepr:
     display = display
 
     def __init__(self):
-        if not hasattr(self, '_object_type'):
+        if not hasattr(self, "_object_type"):
             self._object_type = None
 
     # ------------------------------------------------------------------
     # INTERFACE
     def __repr__(self) -> str:
-        return f'{self._object_type}(id={str(id(self))})'
+        return f"{self._object_type}(id={str(id(self))})"

--- a/magpylib/_src/obj_classes/class_BaseExcitations.py
+++ b/magpylib/_src/obj_classes/class_BaseExcitations.py
@@ -2,7 +2,11 @@
 
 import numpy as np
 from magpylib._src.default_classes import default_settings as Config
-from magpylib._src.input_checks import (check_vector_type, check_vector_format, check_scalar_type)
+from magpylib._src.input_checks import (
+    check_vector_type,
+    check_vector_format,
+    check_scalar_type,
+)
 
 
 # MAG PROPERTY ON INTERFACE
@@ -17,30 +21,29 @@ class BaseHomMag:
     Methods
     -------
     """
+
     def __init__(self, magnetization):
         self.magnetization = magnetization
 
     @property
     def magnetization(self):
-        """ Object magnetization attribute getter and setter.
-        """
+        """Object magnetization attribute getter and setter."""
         return self._magnetization
 
     @magnetization.setter
     def magnetization(self, mag):
-        """ Set magnetization vector, shape (3,), unit [mT].
-        """
+        """Set magnetization vector, shape (3,), unit [mT]."""
         # input type and init check
         if Config.checkinputs:
-            check_vector_type(mag, 'magnetization')
-            #check_vector_init(mag, 'magnetization')
+            check_vector_type(mag, "magnetization")
+            # check_vector_init(mag, 'magnetization')
 
         # input type -> ndarray
         mag = np.array(mag, dtype=float)
 
         # input format check
         if Config.checkinputs:
-            check_vector_format(mag, (3,),'magnetization')
+            check_vector_format(mag, (3,), "magnetization")
 
         self._magnetization = mag
 
@@ -57,23 +60,22 @@ class BaseCurrent:
     Methods
     -------
     """
+
     def __init__(self, current):
         self.current = current
 
     @property
     def current(self):
-        """ Object current attribute getter and setter.
-        """
+        """Object current attribute getter and setter."""
         return self._current
 
     @current.setter
     def current(self, current):
-        """ Set Current value, unit [A].
-        """
+        """Set Current value, unit [A]."""
         # input type and init check
         if Config.checkinputs:
-            #check_scalar_init(current, 'current')
-            check_scalar_type(current, 'current')
+            # check_scalar_init(current, 'current')
+            check_scalar_type(current, "current")
 
         # secure type
         if current is None:

--- a/magpylib/_src/obj_classes/class_BaseGeo.py
+++ b/magpylib/_src/obj_classes/class_BaseGeo.py
@@ -55,12 +55,23 @@ class BaseGeo:
 
     """
 
-    def __init__(self, position, orientation, style=None):
+    def __init__(self, position, orientation, style=None, **kwargs):
         # set pos and orient attributes
         self.position = position
         self.orientation = orientation
         self.style_class = self._get_style_class()
-        if style is not None:
+        if style is not None or kwargs:
+            if style is None:
+                style = {}
+            style_kwargs = {}
+            for k, v in kwargs.items():
+                if k.startswith("style_"):
+                    style_kwargs[k[6:]] = v
+                else:
+                    raise TypeError(
+                        f"__init__() got an unexpected keyword argument {k!r}"
+                    )
+            style.update(**style_kwargs)
             self.style = style
 
     def _get_style_class(self):

--- a/magpylib/_src/obj_classes/class_BaseGeo.py
+++ b/magpylib/_src/obj_classes/class_BaseGeo.py
@@ -68,6 +68,7 @@ class BaseGeo:
         not found in `MAGPYLIB_FAMILIES` returns `BaseStyle` class."""
         # pylint: disable=import-outside-toplevel
         from magpylib._src.style import get_style_class
+
         return get_style_class(self)
 
     # properties ----------------------------------------------------

--- a/magpylib/_src/obj_classes/class_BaseGetBH.py
+++ b/magpylib/_src/obj_classes/class_BaseGetBH.py
@@ -6,7 +6,7 @@ from magpylib._src.utility import format_star_input
 
 # ALL METHODS ON INTERFACE
 class BaseGetBH:
-    """ provides simple getB and getH methods
+    """provides simple getB and getH methods
 
     Properties
     ----------

--- a/magpylib/_src/obj_classes/class_Sensor.py
+++ b/magpylib/_src/obj_classes/class_Sensor.py
@@ -100,7 +100,12 @@ class Sensor(BaseGeo, BaseDisplayRepr):
     """
 
     def __init__(
-        self, position=(0, 0, 0), pixel=(0, 0, 0), orientation=None, style=None
+        self,
+        position=(0, 0, 0),
+        pixel=(0, 0, 0),
+        orientation=None,
+        style=None,
+        **kwargs,
     ):
 
         # instance attributes
@@ -108,7 +113,7 @@ class Sensor(BaseGeo, BaseDisplayRepr):
         self._object_type = "Sensor"
 
         # init inheritance
-        BaseGeo.__init__(self, position, orientation, style=style)
+        BaseGeo.__init__(self, position, orientation, style=style, **kwargs)
         BaseDisplayRepr.__init__(self)
 
     # property getters and setters

--- a/magpylib/_src/obj_classes/class_Sensor.py
+++ b/magpylib/_src/obj_classes/class_Sensor.py
@@ -100,27 +100,21 @@ class Sensor(BaseGeo, BaseDisplayRepr):
     """
 
     def __init__(
-            self,
-            position = (0,0,0),
-            pixel=(0,0,0),
-            orientation = None,
-            style = None):
+        self, position=(0, 0, 0), pixel=(0, 0, 0), orientation=None, style=None
+    ):
 
         # instance attributes
         self.pixel = pixel
-        self._object_type = 'Sensor'
+        self._object_type = "Sensor"
 
         # init inheritance
         BaseGeo.__init__(self, position, orientation, style=style)
         BaseDisplayRepr.__init__(self)
 
-
-
     # property getters and setters
     @property
     def pixel(self):
-        """ Sensor pixel attribute getter and setter.
-        """
+        """Sensor pixel attribute getter and setter."""
         return self._pixel
 
     @pixel.setter
@@ -130,17 +124,16 @@ class Sensor(BaseGeo, BaseDisplayRepr):
         """
         # check input type
         if Config.checkinputs:
-            check_vector_type(pix, 'pixel_position')
+            check_vector_type(pix, "pixel_position")
 
         # input type -> ndarray
         pix = np.array(pix, dtype=float)
 
         # check input format
         if Config.checkinputs:
-            check_position_format(pix, 'pixel_position')
+            check_position_format(pix, "pixel_position")
 
         self._pixel = pix
-
 
     # methods -------------------------------------------------------
     def getB(self, *sources, sumup=False, squeeze=True):
@@ -216,7 +209,6 @@ class Sensor(BaseGeo, BaseDisplayRepr):
         """
         sources = format_star_input(sources)
         return getBH_level2(True, sources, self, sumup, squeeze)
-
 
     def getH(self, *sources, sumup=False, squeeze=True):
         """

--- a/magpylib/_src/obj_classes/class_current_Line.py
+++ b/magpylib/_src/obj_classes/class_current_Line.py
@@ -90,6 +90,7 @@ class Line(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseCurrent):
         position=(0, 0, 0),
         orientation=None,
         style=None,
+        **kwargs,
     ):
 
         # instance attributes
@@ -97,7 +98,7 @@ class Line(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseCurrent):
         self._object_type = "Line"
 
         # init inheritance
-        BaseGeo.__init__(self, position, orientation, style=style)
+        BaseGeo.__init__(self, position, orientation, style=style, **kwargs)
         BaseDisplayRepr.__init__(self)
         BaseCurrent.__init__(self, current)
 

--- a/magpylib/_src/obj_classes/class_current_Line.py
+++ b/magpylib/_src/obj_classes/class_current_Line.py
@@ -9,8 +9,8 @@ from magpylib._src.default_classes import default_settings as Config
 from magpylib._src.input_checks import check_vertex_format, check_vector_type
 
 # init for tool tips
-i0=None
-pos1=pos2=(None,None,None)
+i0 = None
+pos1 = pos2 = (None, None, None)
 
 # ON INTERFACE
 class Line(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseCurrent):
@@ -80,19 +80,21 @@ class Line(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseCurrent):
      [ 0.         -0.78438229  0.78438229]
      [ 0.         -0.34429579  0.34429579]]
     """
+
     # pylint: disable=dangerous-default-value
 
     def __init__(
-            self,
-            current = i0,
-            vertices = [pos1, pos2],
-            position = (0,0,0),
-            orientation = None,
-            style = None):
+        self,
+        current=i0,
+        vertices=[pos1, pos2],
+        position=(0, 0, 0),
+        orientation=None,
+        style=None,
+    ):
 
         # instance attributes
         self.vertices = vertices
-        self._object_type = 'Line'
+        self._object_type = "Line"
 
         # init inheritance
         BaseGeo.__init__(self, position, orientation, style=style)
@@ -102,17 +104,15 @@ class Line(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseCurrent):
     # property getters and setters
     @property
     def vertices(self):
-        """ Object vertices attribute getter and setter.
-        """
+        """Object vertices attribute getter and setter."""
         return self._vertices
 
     @vertices.setter
     def vertices(self, vert):
-        """ Set Line vertices, array_like, [mm].
-        """
+        """Set Line vertices, array_like, [mm]."""
         # input type check
         if Config.checkinputs:
-            check_vector_type(vert, 'vertices')
+            check_vector_type(vert, "vertices")
 
         # input type -> ndarray
         vert = np.array(vert)

--- a/magpylib/_src/obj_classes/class_current_Loop.py
+++ b/magpylib/_src/obj_classes/class_current_Loop.py
@@ -8,8 +8,8 @@ from magpylib._src.default_classes import default_settings as Config
 from magpylib._src.input_checks import check_scalar_type
 
 # init for tool tips
-i0=None
-d=None
+i0 = None
+d = None
 
 # ON INTERFACE
 class Loop(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseCurrent):
@@ -80,37 +80,30 @@ class Loop(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseCurrent):
     """
 
     def __init__(
-            self,
-            current = i0,
-            diameter = d,
-            position = (0,0,0),
-            orientation = None,
-            style = None):
+        self, current=i0, diameter=d, position=(0, 0, 0), orientation=None, style=None
+    ):
 
         # instance attributes
         self.diameter = diameter
-        self._object_type = 'Loop'
+        self._object_type = "Loop"
 
         # init inheritance
         BaseGeo.__init__(self, position, orientation, style=style)
         BaseDisplayRepr.__init__(self)
         BaseCurrent.__init__(self, current)
 
-
     # property getters and setters
     @property
     def diameter(self):
-        """ Object diameter attribute getter and setter.
-        """
+        """Object diameter attribute getter and setter."""
         return self._diameter
 
     @diameter.setter
     def diameter(self, dia):
-        """ Set Loop loop diameter, float, [mm].
-        """
+        """Set Loop loop diameter, float, [mm]."""
         # input type check
         if Config.checkinputs:
-            check_scalar_type(dia, 'diameter')
+            check_scalar_type(dia, "diameter")
 
         # secure type
         if dia is None:

--- a/magpylib/_src/obj_classes/class_current_Loop.py
+++ b/magpylib/_src/obj_classes/class_current_Loop.py
@@ -80,7 +80,13 @@ class Loop(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseCurrent):
     """
 
     def __init__(
-        self, current=i0, diameter=d, position=(0, 0, 0), orientation=None, style=None
+        self,
+        current=i0,
+        diameter=d,
+        position=(0, 0, 0),
+        orientation=None,
+        style=None,
+        **kwargs,
     ):
 
         # instance attributes
@@ -88,7 +94,7 @@ class Loop(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseCurrent):
         self._object_type = "Loop"
 
         # init inheritance
-        BaseGeo.__init__(self, position, orientation, style=style)
+        BaseGeo.__init__(self, position, orientation, style=style, **kwargs)
         BaseDisplayRepr.__init__(self)
         BaseCurrent.__init__(self, current)
 

--- a/magpylib/_src/obj_classes/class_mag_Cuboid.py
+++ b/magpylib/_src/obj_classes/class_mag_Cuboid.py
@@ -89,6 +89,7 @@ class Cuboid(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
         position=(0, 0, 0),
         orientation=None,
         style=None,
+        **kwargs,
     ):
 
         # instance attributes
@@ -96,7 +97,7 @@ class Cuboid(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
         self._object_type = "Cuboid"
 
         # init inheritance
-        BaseGeo.__init__(self, position, orientation, style=style)
+        BaseGeo.__init__(self, position, orientation, style=style, **kwargs)
         BaseDisplayRepr.__init__(self)
         BaseHomMag.__init__(self, magnetization)
 

--- a/magpylib/_src/obj_classes/class_mag_Cuboid.py
+++ b/magpylib/_src/obj_classes/class_mag_Cuboid.py
@@ -9,8 +9,8 @@ from magpylib._src.default_classes import default_settings as Config
 from magpylib._src.input_checks import check_vector_format, check_vector_type
 
 # init for tool tips
-a=b=c=None
-mx=my=mz=None
+a = b = c = None
+mx = my = mz = None
 
 # ON INTERFACE
 class Cuboid(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
@@ -83,16 +83,17 @@ class Cuboid(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
     """
 
     def __init__(
-            self,
-            magnetization = (mx,my,mz),
-            dimension = (a,b,c),
-            position = (0,0,0),
-            orientation = None,
-            style=None):
+        self,
+        magnetization=(mx, my, mz),
+        dimension=(a, b, c),
+        position=(0, 0, 0),
+        orientation=None,
+        style=None,
+    ):
 
         # instance attributes
         self.dimension = dimension
-        self._object_type = 'Cuboid'
+        self._object_type = "Cuboid"
 
         # init inheritance
         BaseGeo.__init__(self, position, orientation, style=style)
@@ -102,23 +103,21 @@ class Cuboid(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
     # property getters and setters
     @property
     def dimension(self):
-        """ Object dimension attribute getter and setter.
-        """
+        """Object dimension attribute getter and setter."""
         return self._dimension
 
     @dimension.setter
     def dimension(self, dim):
-        """ Set Cuboid dimension (a,b,c), shape (3,), [mm].
-        """
+        """Set Cuboid dimension (a,b,c), shape (3,), [mm]."""
         # input type check
         if Config.checkinputs:
-            check_vector_type(dim, 'dimension')
+            check_vector_type(dim, "dimension")
 
         # input type -> ndarray
-        dim = np.array(dim,dtype=float)
+        dim = np.array(dim, dtype=float)
 
         # input format check
         if Config.checkinputs:
-            check_vector_format(dim, (3,), 'dimension')
+            check_vector_format(dim, (3,), "dimension")
 
         self._dimension = dim

--- a/magpylib/_src/obj_classes/class_mag_Cylinder.py
+++ b/magpylib/_src/obj_classes/class_mag_Cylinder.py
@@ -9,8 +9,8 @@ from magpylib._src.default_classes import default_settings as Config
 from magpylib._src.input_checks import check_vector_type, check_vector_format
 
 # init for tool tips
-d=h=None
-mx=my=mz=None
+d = h = None
+mx = my = mz = None
 
 # ON INTERFACE
 class Cylinder(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
@@ -83,16 +83,17 @@ class Cylinder(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
     """
 
     def __init__(
-            self,
-            magnetization = (mx,my,mz),
-            dimension = (d,h),
-            position = (0,0,0),
-            orientation = None,
-            style = None):
+        self,
+        magnetization=(mx, my, mz),
+        dimension=(d, h),
+        position=(0, 0, 0),
+        orientation=None,
+        style=None,
+    ):
 
         # instance attributes
         self.dimension = dimension
-        self._object_type = 'Cylinder'
+        self._object_type = "Cylinder"
 
         # init inheritance
         BaseGeo.__init__(self, position, orientation, style=style)
@@ -102,23 +103,21 @@ class Cylinder(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
     # property getters and setters
     @property
     def dimension(self):
-        """ Object dimension attribute getter and setter.
-        """
+        """Object dimension attribute getter and setter."""
         return self._dimension
 
     @dimension.setter
     def dimension(self, dim):
-        """ Set Cylinder dimension (d,h) in units of [mm].
-        """
+        """Set Cylinder dimension (d,h) in units of [mm]."""
         # input type check
         if Config.checkinputs:
-            check_vector_type(dim, 'dimension')
+            check_vector_type(dim, "dimension")
 
         # input type -> ndarray
-        dim = np.array(dim,dtype=float)
+        dim = np.array(dim, dtype=float)
 
         # input format check
         if Config.checkinputs:
-            check_vector_format(dim, (2,), 'Cylinder')
+            check_vector_format(dim, (2,), "Cylinder")
 
         self._dimension = dim

--- a/magpylib/_src/obj_classes/class_mag_Cylinder.py
+++ b/magpylib/_src/obj_classes/class_mag_Cylinder.py
@@ -89,6 +89,7 @@ class Cylinder(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
         position=(0, 0, 0),
         orientation=None,
         style=None,
+        **kwargs,
     ):
 
         # instance attributes
@@ -96,7 +97,7 @@ class Cylinder(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
         self._object_type = "Cylinder"
 
         # init inheritance
-        BaseGeo.__init__(self, position, orientation, style=style)
+        BaseGeo.__init__(self, position, orientation, style=style, **kwargs)
         BaseDisplayRepr.__init__(self)
         BaseHomMag.__init__(self, magnetization)
 

--- a/magpylib/_src/obj_classes/class_mag_CylinderSegment.py
+++ b/magpylib/_src/obj_classes/class_mag_CylinderSegment.py
@@ -95,6 +95,7 @@ class CylinderSegment(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
         position=(0, 0, 0),
         orientation=None,
         style=None,
+        **kwargs,
     ):
 
         # instance attributes
@@ -102,7 +103,7 @@ class CylinderSegment(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
         self._object_type = "CylinderSegment"
 
         # init inheritance
-        BaseGeo.__init__(self, position, orientation, style=style)
+        BaseGeo.__init__(self, position, orientation, style=style, **kwargs)
         BaseDisplayRepr.__init__(self)
         BaseHomMag.__init__(self, magnetization)
 

--- a/magpylib/_src/obj_classes/class_mag_CylinderSegment.py
+++ b/magpylib/_src/obj_classes/class_mag_CylinderSegment.py
@@ -9,8 +9,8 @@ from magpylib._src.default_classes import default_settings as Config
 from magpylib._src.input_checks import check_input_cyl_sect, check_vector_type
 
 # init for tool tips
-d1=d2=h=phi1=phi2=None
-mx=my=mz=None
+d1 = d2 = h = phi1 = phi2 = None
+mx = my = mz = None
 
 # ON INTERFACE
 class CylinderSegment(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
@@ -89,16 +89,17 @@ class CylinderSegment(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
     """
 
     def __init__(
-            self,
-            magnetization = (mx,my,mz),
-            dimension = (d1,d2,h,phi1,phi2),
-            position = (0,0,0),
-            orientation = None,
-            style = None):
+        self,
+        magnetization=(mx, my, mz),
+        dimension=(d1, d2, h, phi1, phi2),
+        position=(0, 0, 0),
+        orientation=None,
+        style=None,
+    ):
 
         # instance attributes
         self.dimension = dimension
-        self._object_type = 'CylinderSegment'
+        self._object_type = "CylinderSegment"
 
         # init inheritance
         BaseGeo.__init__(self, position, orientation, style=style)
@@ -108,20 +109,18 @@ class CylinderSegment(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
     # property getters and setters
     @property
     def dimension(self):
-        """ Object dimension attribute getter and setter.
-        """
+        """Object dimension attribute getter and setter."""
         return self._dimension
 
     @dimension.setter
     def dimension(self, dim):
-        """ Set Cylinder dimension (d1,d2,h,phi1,phi2), shape (5,), [mm, deg].
-        """
+        """Set Cylinder dimension (d1,d2,h,phi1,phi2), shape (5,), [mm, deg]."""
         # input type check
         if Config.checkinputs:
-            check_vector_type(dim, 'dimension')
+            check_vector_type(dim, "dimension")
 
         # input type -> ndarray
-        dim = np.array(dim,dtype=float)
+        dim = np.array(dim, dtype=float)
 
         # input format check
         if Config.checkinputs:

--- a/magpylib/_src/obj_classes/class_mag_Sphere.py
+++ b/magpylib/_src/obj_classes/class_mag_Sphere.py
@@ -8,7 +8,7 @@ from magpylib._src.default_classes import default_settings as Config
 from magpylib._src.input_checks import check_scalar_type
 
 # init for tool tips
-mx=my=mz=d=None
+mx = my = mz = d = None
 
 # ON INTERFACE
 class Sphere(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
@@ -80,16 +80,17 @@ class Sphere(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
     """
 
     def __init__(
-            self,
-            magnetization = (mx,my,mz),
-            diameter = d,
-            position = (0,0,0),
-            orientation = None,
-            style = None):
+        self,
+        magnetization=(mx, my, mz),
+        diameter=d,
+        position=(0, 0, 0),
+        orientation=None,
+        style=None,
+    ):
 
         # instance attributes
         self.diameter = diameter
-        self._object_type = 'Sphere'
+        self._object_type = "Sphere"
 
         # init inheritance
         BaseGeo.__init__(self, position, orientation, style=style)
@@ -99,17 +100,15 @@ class Sphere(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
     # property getters and setters
     @property
     def diameter(self):
-        """ Object diameter attribute getter and setter.
-        """
+        """Object diameter attribute getter and setter."""
         return self._diameter
 
     @diameter.setter
     def diameter(self, dia):
-        """ Set Sphere diameter, float, [mm].
-        """
+        """Set Sphere diameter, float, [mm]."""
         # input type check
         if Config.checkinputs:
-            check_scalar_type(dia, 'diameter')
+            check_scalar_type(dia, "diameter")
 
         # secure type
         if dia is None:

--- a/magpylib/_src/obj_classes/class_mag_Sphere.py
+++ b/magpylib/_src/obj_classes/class_mag_Sphere.py
@@ -86,6 +86,7 @@ class Sphere(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
         position=(0, 0, 0),
         orientation=None,
         style=None,
+        **kwargs,
     ):
 
         # instance attributes
@@ -93,7 +94,7 @@ class Sphere(BaseGeo, BaseDisplayRepr, BaseGetBH, BaseHomMag):
         self._object_type = "Sphere"
 
         # init inheritance
-        BaseGeo.__init__(self, position, orientation, style=style)
+        BaseGeo.__init__(self, position, orientation, style=style, **kwargs)
         BaseDisplayRepr.__init__(self)
         BaseHomMag.__init__(self, magnetization)
 

--- a/magpylib/_src/obj_classes/class_misc_Custom.py
+++ b/magpylib/_src/obj_classes/class_misc_Custom.py
@@ -66,6 +66,7 @@ class CustomSource(BaseGeo, BaseDisplayRepr, BaseGetBH):
         position=(0, 0, 0),
         orientation=None,
         style=None,
+        **kwargs,
     ):
         # instance attributes
         self.field_B_lambda = field_B_lambda
@@ -73,7 +74,7 @@ class CustomSource(BaseGeo, BaseDisplayRepr, BaseGetBH):
         self._object_type = "CustomSource"
 
         # init inheritance
-        BaseGeo.__init__(self, position, orientation, style=style)
+        BaseGeo.__init__(self, position, orientation, style=style, **kwargs)
         BaseDisplayRepr.__init__(self)
 
     @property

--- a/magpylib/_src/obj_classes/class_misc_Dipole.py
+++ b/magpylib/_src/obj_classes/class_misc_Dipole.py
@@ -77,14 +77,19 @@ class Dipole(BaseGeo, BaseDisplayRepr, BaseGetBH):
     """
 
     def __init__(
-        self, moment=(mx, my, mz), position=(0, 0, 0), orientation=None, style=None
+        self,
+        moment=(mx, my, mz),
+        position=(0, 0, 0),
+        orientation=None,
+        style=None,
+        **kwargs,
     ):
         # instance attributes
         self.moment = moment
         self._object_type = "Dipole"
 
         # init inheritance
-        BaseGeo.__init__(self, position, orientation, style=style)
+        BaseGeo.__init__(self, position, orientation, style=style, **kwargs)
         BaseDisplayRepr.__init__(self)
 
     # property getters and setters

--- a/tests/test_obj_BaseGeo.py
+++ b/tests/test_obj_BaseGeo.py
@@ -251,3 +251,16 @@ def test_style():
     bg = BaseGeo((0,0,0),None)
     with pytest.raises(ValueError):
         bg.style = "wrong class"
+
+def test_kwargs():
+    """test kwargs inputs, only relevant for styles"""
+    bg = BaseGeo((0,0,0),None,
+        style=dict(name='name_01'),
+        style_name='name_02'
+    )
+    assert bg.style.name == 'name_02'
+
+    with pytest.raises(TypeError):
+        bg = BaseGeo((0,0,0),None,
+            styl_name='name_02'
+        )


### PR DESCRIPTION
This PR allows the style properties to be set via underscore magic also at initialization. So far it was only possible explicitly via a dictionary.

# Before

```python
pm = magpy.magnet.Cuboid((
    1,2,3),(1,2,3), 
    style=dict(name='name_01')
)
print(pm.style.name)

# Output
# 'name_01'
```

# After

```python
pm = magpy.magnet.Cuboid((
    1,2,3),(1,2,3), 
    style_name='name_01')
)
print(pm.style.name)

# Output
# 'name_01'
```

# Bad input raises `TypeError`
```python
pm = magpy.magnet.Cuboid((
    1,2,3),(1,2,3), 
    stylee_name='name_01')
)
print(pm.style.name)

# Output
#  TypeError: __init__() got an unexpected keyword argument 'stylee_name'
```

# Note

`style magic` updates `style dict` as shown below

```python
pm = magpy.magnet.Cuboid((
    1,2,3),(1,2,3), 
    style=dict(name='name_01'), 
    style_name='name_02'
)
print(pm.style.name)

# Output
# 'name_02'
```

