### PR TITLE
improve extra model3d to accommodate positional arguments in plotting function

### DIFF
--- a/magpylib/_src/display/disp_utility.py
+++ b/magpylib/_src/display/disp_utility.py
@@ -30,7 +30,11 @@ def place_and_orient_model3d(
     useargs = False
     for k in "xyz":
         key = coordsargs[k]
-        if key in "xyz":
+        if key.startswith("args"):
+            useargs = True
+            ind = int(key[5])
+            v = model_dict["args"][ind]
+        else:
             if key in model_dict:
                 v = model_dict[key]
             else:
@@ -39,12 +43,6 @@ def place_and_orient_model3d(
                     f"has no argument {k!r}, use `coordsargs` to specify the names of the "
                     "coordinates to be used"
                 )
-        elif key.startswith("args"):
-            useargs = True
-            ind = int(key[5])
-            v = model_dict["args"][ind]
-        else:
-            raise ValueError("Bad coorsargs given")
         vertices.append(v)
     vertices = np.array(vertices).T
     if orientation is not None:

--- a/magpylib/_src/display/disp_utility.py
+++ b/magpylib/_src/display/disp_utility.py
@@ -31,7 +31,14 @@ def place_and_orient_model3d(
     for k in "xyz":
         key = coordsargs[k]
         if key in "xyz":
-            v = model_dict[key]
+            if key in model_dict:
+                v = model_dict[key]
+            else:
+                raise ValueError(
+                    "Rotating/Moving of provided model failed, trace dictionary"
+                    f"has no argument {k!r}, use `coordsargs` to specify the names of the "
+                    "coordinates to be used"
+                )
         elif key.startswith("args"):
             useargs = True
             ind = int(key[5])

--- a/magpylib/_src/display/disp_utility.py
+++ b/magpylib/_src/display/disp_utility.py
@@ -17,18 +17,40 @@ class MagpyMarkers:
 
 
 def place_and_orient_model3d(
-    model_dict, orientation=None, position=(0.0, 0.0, 0.0), **kwargs
+    model_dict, orientation=None, position=(0.0, 0.0, 0.0), coordsargs=None, **kwargs
 ):
     """places and orients mesh3d dict"""
+    new_model_dict = {}
+    if "args" in model_dict:
+        new_model_dict["args"] = list(model_dict["args"])
     position = np.array(position)
-    xyz = ["x", "y", "z"]
-    if all(key in model_dict for key in ["xs", "ys", "zs"]):
-        xyz = ["xs", "ys", "zs"]
-    vertices = np.array([model_dict[k] for k in xyz]).T
+    vertices = []
+    if coordsargs is None:
+        coordsargs = {"x": "x", "y": "y", "z": "z"}
+    useargs = False
+    for k in "xyz":
+        key = coordsargs[k]
+        if key in "xyz":
+            v = model_dict[key]
+        elif key.startswith("args"):
+            useargs = True
+            ind = int(key[5])
+            v = model_dict["args"][ind]
+        else:
+            raise ValueError("Bad coorsargs given")
+        vertices.append(v)
+    vertices = np.array(vertices).T
     if orientation is not None:
         vertices = orientation.apply(vertices)
-    x, y, z = (vertices + position).T
-    return {**model_dict, xyz[0]: x, xyz[1]: y, xyz[2]: z, **kwargs}
+    new_vertices = (vertices + position).T
+    for i, k in enumerate("xyz"):
+        key = coordsargs[k]
+        if useargs:
+            ind = int(key[5])
+            new_model_dict["args"][ind] = new_vertices[i]
+        else:
+            new_model_dict[key] = new_vertices[i]
+    return {**model_dict, **new_model_dict, **kwargs}
 
 
 def draw_arrowed_line(vec, pos, sign=1, arrow_size=1) -> Tuple:
@@ -43,7 +65,7 @@ def draw_arrowed_line(vec, pos, sign=1, arrow_size=1) -> Tuple:
     cross = np.cross(nvec, yaxis)
     dot = np.dot(nvec, yaxis)
     n = np.linalg.norm(cross)
-    if dot==-1:
+    if dot == -1:
         sign *= -1
     hy = sign * 0.1 * arrow_size
     hx = 0.06 * arrow_size

--- a/magpylib/_src/display/mpl_draw.py
+++ b/magpylib/_src/display/mpl_draw.py
@@ -296,6 +296,7 @@ def draw_model3d_extra(obj, style, show_path, ax, color):
                     extr.trace,
                     orientation=orient,
                     position=pos,
+                    coordsargs=extr.coordsargs
                 )
                 ttype = extr.trace["type"]
                 if ttype not in path_traces_extra:
@@ -305,5 +306,6 @@ def draw_model3d_extra(obj, style, show_path, ax, color):
     for traces_extra in path_traces_extra.values():
         for tr in traces_extra:
             kwargs = {"color": color}
-            kwargs.update({k: v for k, v in tr.items() if k != "type"})
-            getattr(ax, tr["type"])(**kwargs)
+            kwargs.update({k: v for k, v in tr.items() if k not in ("type", "args")})
+            args = tr.get("args", [])
+            getattr(ax, tr["type"])(*args, **kwargs)

--- a/magpylib/_src/display/mpl_draw.py
+++ b/magpylib/_src/display/mpl_draw.py
@@ -113,11 +113,7 @@ def draw_path(
 def draw_faces(faces, col, lw, alpha, ax):
     """draw faces in respective color and return list of vertex-points"""
     cuboidf = Poly3DCollection(
-        faces,
-        facecolors=col,
-        linewidths=lw,
-        edgecolors="k",
-        alpha=alpha,
+        faces, facecolors=col, linewidths=lw, edgecolors="k", alpha=alpha,
     )
     ax.add_collection3d(cuboidf)
     return faces
@@ -296,7 +292,7 @@ def draw_model3d_extra(obj, style, show_path, ax, color):
                     extr.trace,
                     orientation=orient,
                     position=pos,
-                    coordsargs=extr.coordsargs
+                    coordsargs=extr.coordsargs,
                 )
                 ttype = extr.trace["type"]
                 if ttype not in path_traces_extra:

--- a/magpylib/_src/style.py
+++ b/magpylib/_src/style.py
@@ -331,8 +331,12 @@ class Trace3d(MagicProperties):
 
     """
 
-    def __init__(self, trace=None, show=True, backend="matplotlib", **kwargs):
-        super().__init__(trace=trace, show=show, backend=backend, **kwargs)
+    def __init__(
+        self, trace=None, show=True, backend="matplotlib", coordsargs=None, **kwargs
+    ):
+        super().__init__(
+            trace=trace, show=show, backend=backend, coordsargs=coordsargs, **kwargs
+        )
 
     @property
     def show(self):
@@ -351,6 +355,21 @@ class Trace3d(MagicProperties):
         self._show = val
 
     @property
+    def coordsargs(self):
+        return self._coordsargs
+
+    @coordsargs.setter
+    def coordsargs(self, val):
+        if val is None:
+            val = {"x": "x", "y": "y", "z": "z"}
+        assert isinstance(val, dict) and all(key in val for key in "xyz"), (
+            f"the `coordsargs` property of {type(self).__name__} must be "
+            f"a dictionary with `'x', 'y', 'z'` keys"
+            f" but received {repr(val)} instead"
+        )
+        self._coordsargs = val
+
+    @property
     def trace(self):
         """dictionary keys/values pairs for a model3d object"""
         return self._trace
@@ -363,9 +382,6 @@ class Trace3d(MagicProperties):
                 f" but received {type(val).__name__} instead"
             )
             assert "type" in val, "explicit trace `type` must be defined"
-            assert all(key in val for key in "xyz") or all(
-                key in val for key in ("xs", "ys", "zs")
-            ), "trace must contain the `x,y,z` or `xs,ys,zs` keys/values pairs"
         self._trace = val
 
     @property

--- a/magpylib/_src/style.py
+++ b/magpylib/_src/style.py
@@ -89,19 +89,10 @@ class BaseStyle(MagicProperties):
     """
 
     def __init__(
-        self,
-        name=None,
-        description=None,
-        color=None,
-        opacity=None,
-        **kwargs,
+        self, name=None, description=None, color=None, opacity=None, **kwargs,
     ):
         super().__init__(
-            name=name,
-            description=description,
-            color=color,
-            opacity=opacity,
-            **kwargs,
+            name=name, description=description, color=color, opacity=opacity, **kwargs,
         )
 
     @property
@@ -329,6 +320,12 @@ class Trace3d(MagicProperties):
         plotting backend corresponding to the trace.
         Can be one of `['matplotlib', 'plotly']`
 
+    coordsargs: dict
+        tells magpylib the name of the coordinate arrays to be moved or rotated.
+        by default: `{"x": "x", "y": "y", "z": "z"}`
+        if False, object is not rotated
+
+
     """
 
     def __init__(
@@ -356,6 +353,9 @@ class Trace3d(MagicProperties):
 
     @property
     def coordsargs(self):
+        """tells magpylib the name of the coordinate arrays to be moved or rotated.
+        by default: `{"x": "x", "y": "y", "z": "z"}`
+        if False, object is not rotated"""
         return self._coordsargs
 
     @coordsargs.setter

--- a/tests/test_display_matplotlib.py
+++ b/tests/test_display_matplotlib.py
@@ -1,7 +1,9 @@
 import pytest
+import numpy as np
 import matplotlib.pyplot as plt
 import magpylib as magpy
 from magpylib.magnet import Cylinder, Cuboid, Sphere, CylinderSegment
+from magpylib._src.display.plotly_draw import make_BaseCuboid
 
 # pylint: disable=assignment-from-no-return
 
@@ -153,6 +155,7 @@ def test_matplotlib_model3d_extra():
         magnetization=(1, 0, 0), dimension=(3, 3, 3), position=(10, 0, 0)
     ).rotate_from_angax([72] * 5, "z", anchor=(0, 0, 0), start=0, increment=True)
     cuboid.style.model3d.show = False
+    ax = plt.subplot(projection="3d")
     cuboid.style.model3d.extra = [
         {
             "backend": "matplotlib",
@@ -166,7 +169,26 @@ def test_matplotlib_model3d_extra():
             "show": True,
         }
     ]
-    ax = plt.subplot(projection="3d")
+    with pytest.raises(ValueError): # should fail because of invalid coordsargs
+        x = cuboid.display(canvas=ax, path=1)
+    cuboid.style.model3d.extra[0].coordsargs = {"x": "xs", "y": "ys", "z": "zs"}
+    x = cuboid.display(canvas=ax, path=1)
+
+    assert x is None, "display test fail"
+
+    cube = make_BaseCuboid()
+    i,j,k = [cube[k] for k in 'ijk']
+    x,y,z = [cube[k] for k in 'xyz']
+    triangles = np.array([i, j, k]).T
+    trace = dict(type="plot_trisurf", args=(x, y, z), triangles=triangles)
+    cuboid.style.model3d.extra = [
+        {
+            "backend": "matplotlib",
+            "coordsargs": {"x": "args[0]", "y": "args[1]", "z": "args[2]"},
+            "trace": trace,
+            "show": True,
+        }
+    ]
     x = cuboid.display(canvas=ax, path=1)
     assert x is None, "display test fail"
 


### PR DESCRIPTION
Some matplotlib functions such as `plot_trisurf` only allow coordinates to be provided via positional arguments. When providing an extra model3d, one needs a way to provide such arguments via a dictionary while allowing the magpylib library take care of the positioning and orienting of the provied trace.
This is useful if we want to provide a complex model originating from a CAD model and plot it with the magpylib display function. For example a complex mesh object representing a 3d-model of  sensor can be attached to a magpylib sensor and moved automatically with it. 

```python
import os
import tempfile

import magpylib as magpy
import numpy as np
import plotly.graph_objects as go
import requests
from stl import mesh  # needs numpy-stl installed

def get_stl_color(x, return_rgb_string=True):
    sb = f"{x:015b}"[::-1]
    r = int(255 / 31 * int(sb[:5], base=2))
    g = int(255 / 31 * int(sb[5:10], base=2))
    b = int(255 / 31 * int(sb[10:15], base=2))
    if return_rgb_string:
        color = f'rgb({r},{g},{b})'
    else:
        color = (r,g,b)
    return color

# define stl to mesh3d function
def stl2mesh3d(stl_file, recenter=False, backend='matplotlib'):
    stl_mesh = mesh.Mesh.from_file(stl_file)
    # stl_mesh is read by nympy-stl from a stl file; it is  an array of faces/triangles
    # this function extracts the unique vertices and the lists I, J, K to define a Plotly mesh3d
    p, q, r = stl_mesh.vectors.shape  # (p, 3, 3)
    # the array stl_mesh.vectors.reshape(p*q, r) can contain multiple copies of the same vertex;
    # extract unique vertices from all mesh triangles
    vertices, ixr = np.unique(
        stl_mesh.vectors.reshape(p * q, r), return_inverse=True, axis=0
    )
    i = np.take(ixr, [3 * k for k in range(p)])
    j = np.take(ixr, [3 * k + 1 for k in range(p)])
    k = np.take(ixr, [3 * k + 2 for k in range(p)])
    if recenter:
        vertices = vertices - 0.5 * (vertices.max(axis=0) + vertices.min(axis=0))
    colors = stl_mesh.attr.flatten()
    x, y, z = vertices.T
    model3d = {"backend": backend}
    if backend == "matplotlib":
        triangles = np.array([i, j, k]).T
        model3d.update(
            trace=dict(type="plot_trisurf", args=(x, y, z), triangles=triangles),
            coordsargs={"x": "args[0]", "y": "args[1]", "z": "args[2]"},
        )
    elif backend == "plotly":
        facecolor = np.array([get_stl_color(x, return_rgb_string=True) for x in colors]).T
        model3d.update(
            trace=dict(
                type="mesh3d", x=x, y=y, z=z, i=i, j=j, k=k, facecolor=facecolor
            ),
        )
    else:
        raise ValueError(
            """Backend type not understood, must be one of ['matplotlib', 'plotly']"""
        )
    return model3d


# import stl file
url = "https://raw.githubusercontent.com/magpylib/magpylib-files/main/PG-SSO-3-2.stl"
file = url.split("/")[-1]
with tempfile.TemporaryDirectory() as tmpdirname:
    fn = os.path.join(tmpdirname, file)
    with open(fn, "wb") as f:
        response = requests.get(url)
        f.write(response.content)

    # create mesh3d
    model3d_matplotlib = stl2mesh3d(fn, backend="matplotlib")
    model3d_plotly = stl2mesh3d(fn, backend="plotly")
# create sensor, add extra 3d-model, create path
sensor = magpy.Sensor(position=(-15, 0, -6))
sensor.style = dict(model3d_extra=[model3d_matplotlib, model3d_plotly])
sensor.rotate_from_angax([5] * 30, "z", increment=True, anchor=(0, 0, 0))
sensor.move([[0, 0, 0.5]] * 30, increment=True, start=0)

# create source, and Collection
cuboid = magpy.magnet.Cylinder(magnetization=(0, 0, 1000), dimension=(20, 30))
collection = sensor + cuboid

# display animated system with plotly backend
magpy.display(collection, path=8, style_magnetization_size=0.4, backend="matplotlib")
magpy.display(collection, path=8, backend="plotly")
```

![image](https://user-images.githubusercontent.com/29252289/146795155-bfb4839a-daee-405a-b87d-a8e92dbe2341.png)

![image](https://user-images.githubusercontent.com/29252289/146795196-bb3f63a4-36f5-418d-8f4e-fcdf7a6366d0.png)
