### PR TITLE
Path style improvements

### DIFF
--- a/magpylib/_src/default_utils.py
+++ b/magpylib/_src/default_utils.py
@@ -38,6 +38,7 @@ LINESTYLES_MATPLOTLIB_TO_PLOTLY = {
     "-.": "dashdot",
     "dotted": "dot",
     ".": "dot",
+    ":": "dot",
     (0, (1, 1)): "dot",
     "loosely dotted": "longdash",
     "loosely dashdotted": "longdashdot",

--- a/magpylib/_src/defaults.py
+++ b/magpylib/_src/defaults.py
@@ -39,6 +39,7 @@ DEFAULTS = {
                 "path": {
                     "line": {"width": 1, "style": "solid", "color": None},
                     "marker": {"size": 2, "symbol": "o", "color": None},
+                    "show": True,
                 },
                 "description": {"show": True, "text": None},
                 "opacity": 1,

--- a/magpylib/_src/display/display.py
+++ b/magpylib/_src/display/display.py
@@ -220,6 +220,7 @@ def display_matplotlib(
     for obj, color in zip(obj_list, cycle(color_sequence)):
         style = get_style(obj, Config, **kwargs)
         color = style.color if style.color is not None else color
+        show_path = style.path.show
         lw = 0.25
         faces = None
         if obj.style.model3d.extra:

--- a/magpylib/_src/display/plotly_draw.py
+++ b/magpylib/_src/display/plotly_draw.py
@@ -966,7 +966,11 @@ def get_plotly_traces(
             trace.update({"legendgroup": f"{input_obj}", "showlegend": True})
             traces.append(trace)
 
-        if np.array(input_obj.position).ndim > 1 and show_path is not False:
+        if (
+            np.array(input_obj.position).ndim > 1
+            and show_path is not False
+            and style.path.show is not False
+        ):
             x, y, z = input_obj.position.T
             txt_kwargs = (
                 {"mode": "markers+text+lines", "text": list(range(len(x)))}

--- a/magpylib/_src/style.py
+++ b/magpylib/_src/style.py
@@ -994,10 +994,12 @@ class Path(MagicProperties):
         Line class with 'color', 'symbol', 'size' properties, or dictionary with equivalent
         key/value pairs
 
+    show: bool, default=None
+        show/hide path
     """
 
-    def __init__(self, marker=None, line=None, **kwargs):
-        super().__init__(marker=marker, line=line, **kwargs)
+    def __init__(self, marker=None, line=None, show=None, **kwargs):
+        super().__init__(marker=marker, line=line, show=show, **kwargs)
 
     @property
     def marker(self):
@@ -1016,6 +1018,19 @@ class Path(MagicProperties):
     @line.setter
     def line(self, val):
         self._line = validate_property_class(val, "line", Line, self)
+
+    @property
+    def show(self):
+        """show/hide path"""
+        return self._show
+
+    @show.setter
+    def show(self, val):
+        assert val is None or isinstance(val, bool), (
+            f"the `show` property of {type(self).__name__} must be either `True` or `False`"
+            f" but received {repr(val)} instead"
+        )
+        self._show = val
 
 
 class Line(MagicProperties):

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -23,6 +23,7 @@ bad_inputs = {
     "display_style_base_path_marker_size": (-1,),  # float>=0
     "display_style_base_path_marker_symbol": ("wrongsymbol",),
     "display_style_base_path_marker_color": ("wrongcolor",),  # color
+    "display_style_base_path_show": ("notbool",),  # bool
     "display_style_base_description_show": ("notbool",),  # bool
     "display_style_base_description_text": (
         False,
@@ -75,6 +76,7 @@ good_inputs = {
     "display_style_base_path_marker_size": (0, 1),  # float>=0
     "display_style_base_path_marker_symbol": SYMBOLS_MATPLOTLIB_TO_PLOTLY.keys(),
     "display_style_base_path_marker_color": ("blue", "#2E91E5"),  # color
+    "display_style_base_path_show": (True, False),  # bool
     "display_style_base_description_show": (True, False),  # bool
     "display_style_base_description_text": (
         True,


### PR DESCRIPTION
# Related Issues
#432 

# Notes

- [x] `style_path_show=bool` would be cool to have
- [x] `style_path_line_style=''` this should really work -> what is meant here @OrtnerMichael 
- [x] `style_path_line_style=':'` should be accepted as dotted
- [x] `style_path_line_width=0` should not show a line -> not a bug, backend specific handling, independent of magpylib
- [x] `style_path_marker_size=0` should show no markers -> not a bug, backend specific handling, independent of magpylib
- [x] implement for all backends
- [x] write tests
- [x] docstrings
- [x] update defaults