### PR TITLE
Include magnetization arrows in display range calculation

### DIFF
--- a/magpylib/_src/display/display.py
+++ b/magpylib/_src/display/display.py
@@ -280,9 +280,10 @@ def display_matplotlib(
                 points += [np.vstack(pts).reshape(-1, 3)]
                 if style.magnetization.show:
                     check_excitations([obj])
-                    draw_directs_faced(
+                    pts = draw_directs_faced(
                         [obj], [color], ax, show_path, style.magnetization.size
                     )
+                    points += pts
         if show_path:
             marker, line = style.path.marker, style.path.line
             points += draw_path(

--- a/magpylib/_src/display/mpl_draw.py
+++ b/magpylib/_src/display/mpl_draw.py
@@ -23,7 +23,7 @@ def draw_directs_faced(faced_objects, colors, ax, show_path, size_direction):
     """
     # pylint: disable=protected-access
     # pylint: disable=too-many-branches
-
+    points = []
     for col, obj in zip(colors, faced_objects):
 
         # add src attributes position and orientation depending on show_path
@@ -70,6 +70,9 @@ def draw_directs_faced(faced_objects, colors, ax, show_path, size_direction):
             length=length * size_direction,
             color=col,
         )
+        arrow_tip_pos = ((draw_direc * length * size_direction) - draw_pos)[0]
+        points.append(arrow_tip_pos)
+    return points
 
 
 def draw_markers(markers, ax, color, symbol, size):


### PR DESCRIPTION
When calculating the system range, magnetization arrows are not accounted for.  In this PR arrow tips are included in the range calculation.

The only question which remains is: **do we want this behavior ?**

```python
import magpylib as magpy
s1 = magpy.magnet.Cuboid((0,0,1), (1,1,1), (0,1,0), style_magnetization_size=1.5)
s2 = magpy.magnet.Cuboid((1,0,0), (1,1,1), (0,0,0), style_magnetization_size=1.5)
magpy.display(s1, s2, zoom=0)
```

# Before
![image](https://user-images.githubusercontent.com/29252289/146930350-77960215-6be1-467e-b5ce-db266c63e2af.png)

# After
![image](https://user-images.githubusercontent.com/29252289/146930259-4b2943d3-a51b-4e89-9d91-72932b09a6d6.png)


