### PR TITLE
Style model3d rework

### DIFF
--- a/docs/examples/plot_02_display_backends.md
+++ b/docs/examples/plot_02_display_backends.md
@@ -38,13 +38,30 @@ import numpy as np
 import matplotlib.pyplot as plt
 import magpylib as magpy
 
-my_axis = plt.axes(projection="3d")
-src = magpy.magnet.Sphere(magnetization=(0, 0, 1), diameter=1)
-src.move(np.linspace((0.1, 0, 0), (5,0,0), 50))
-src.rotate_from_angax(angle=np.linspace(10, 500, 50), axis="z", anchor=0, start=1)
-ts = [-0.4, 0, 0.4]
-sens = magpy.Sensor(position=(0, 0, 2), pixel=[(x, y, 0) for x in ts for y in ts])
-magpy.show(src, sens, canvas=my_axis)
+# setup matplotlib figure and subplots
+fig = plt.figure(figsize=(12,4))
+ax1 = fig.add_subplot(131, projection='3d')  # 3D-axis
+ax2 = fig.add_subplot(132, projection='3d')  # 3D-axis
+ax3 = fig.add_subplot(133, projection='3d')  # 3D-axis
+
+# define sources
+src1 = magpy.magnet.Sphere(magnetization=(0, 0, 1), diameter=1)
+src2 = magpy.magnet.Cylinder(magnetization=(0, 0, 1), dimension=(1,2))
+
+# manipulate first source to create a path
+src1.move(np.linspace((0,0,0.1), (0,0,8), 20))
+
+# manipulate second source
+src2.move(np.linspace((0.1, 0, 0.1), (5,0,5), 50))
+src2.rotate_from_angax(angle=np.linspace(10, 600, 50), axis="z", anchor=0, start=1)
+
+# draw the objects
+magpy.show(src1, canvas=ax1)
+magpy.show(src2, canvas=ax2)
+magpy.show(src1, src2, canvas=ax3)
+
+# display the system
+plt.tight_layout()
 plt.show()
 ```
 
@@ -52,14 +69,22 @@ The same objects can also be displayed using the `plotly` plotting backend
 
 ```{code-cell} ipython3
 import numpy as np
+import matplotlib.pyplot as plt
 import magpylib as magpy
 
-src = magpy.magnet.Sphere(magnetization=(0, 0, 1), diameter=1)
-src.move(np.linspace((0.1, 0, 0), (5,0,0), 50))
-src.rotate_from_angax(angle=np.linspace(10, 500, 50), axis="z", anchor=0, start=1)
-ts = [-0.4, 0, 0.4]
-sens = magpy.Sensor(position=(0, 0, 2), pixel=[(x, y, 0) for x in ts for y in ts])
-magpy.show(src, sens, backend="plotly")
+# define sources
+src1 = magpy.magnet.Sphere(magnetization=(0, 0, 1), diameter=1)
+src2 = magpy.magnet.Cylinder(magnetization=(0, 0, 1), dimension=(1,2))
+
+# manipulate first source to create a path
+src1.move(np.linspace((0,0,0.1), (0,0,8), 20))
+
+# manipulate second source
+src2.move(np.linspace((0.1, 0, 0.1), (5,0,5), 50))
+src2.rotate_from_angax(angle=np.linspace(10, 600, 50), axis="z", anchor=0, start=1)
+
+# display the system
+magpy.show(src1, src2, backend='plotly')
 ```
 
 The `show` function is also available as a class method and can be called for every object separately.

--- a/docs/examples/plot_02_display_backends.md
+++ b/docs/examples/plot_02_display_backends.md
@@ -6,7 +6,7 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.13.1
 kernelspec:
-  display_name: Python 3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 ---
@@ -22,7 +22,17 @@ The `magpylib` package is shipped with a display function which provides a graph
 
 +++
 
-Display multiple objects, object paths, markers in 3D using Matplotlib:
+Note that the default plotting backend can be changed to plotly by setting it a the top of script:
+```python
+import magpylib as magpy
+magpy.defaults.display.backend = 'plotly'
+```
+
+All the following calls to the `show` function or method without specifying a backend will call the `'plotly'` plotting backend. if you explicitly specify `'matplotlib'` at `show` call, it will override the set defaults.
+
++++
+
+## Display multiple objects:
 
 ```{code-cell} ipython3
 import magpylib as magpy
@@ -31,7 +41,55 @@ sens = magpy.Sensor(position=(0, 0, 3))
 magpy.show(magnet, sens, zoom=1)
 ```
 
-Display figure on your own canvas (here Matplotlib 3D axis):
+## Display multiple objects with paths
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+import magpylib as magpy
+
+# define sources
+src1 = magpy.magnet.Sphere(magnetization=(0, 0, 1), diameter=1)
+src2 = magpy.magnet.Cylinder(magnetization=(0, 0, 1), dimension=(1,2))
+
+# manipulate first source to create a path
+src1.move(np.linspace((0,0,0.1), (0,0,8), 20))
+
+# manipulate second source
+src2.move(np.linspace((0.1, 0, 0.1), (5,0,5), 50))
+src2.rotate_from_angax(angle=np.linspace(10, 600, 50), axis="z", anchor=0, start=1)
+
+# display the system
+magpy.show(src1, src2)
+```
+
++++ {"tags": []}
+
+## Display objects with a different plotting backend
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+import magpylib as magpy
+
+# define sources
+src1 = magpy.magnet.Sphere(magnetization=(0, 0, 1), diameter=1)
+src2 = magpy.magnet.Cylinder(magnetization=(0, 0, 1), dimension=(1,2))
+
+# manipulate first source to create a path
+src1.move(np.linspace((0,0,0.1), (0,0,8), 20))
+
+# manipulate second source
+src2.move(np.linspace((0.1, 0, 0.1), (5,0,5), 50))
+src2.rotate_from_angax(angle=np.linspace(10, 600, 50), axis="z", anchor=0, start=1)
+
+# display the system
+magpy.show(src1, src2, backend='plotly')
+```
+
+## Display figure on your own canvas
+
+### With a matplotlib canvas
 
 ```{code-cell} ipython3
 import numpy as np
@@ -65,37 +123,23 @@ plt.tight_layout()
 plt.show()
 ```
 
-The same objects can also be displayed using the `plotly` plotting backend
-
-```{code-cell} ipython3
-import numpy as np
-import matplotlib.pyplot as plt
-import magpylib as magpy
-
-# define sources
-src1 = magpy.magnet.Sphere(magnetization=(0, 0, 1), diameter=1)
-src2 = magpy.magnet.Cylinder(magnetization=(0, 0, 1), dimension=(1,2))
-
-# manipulate first source to create a path
-src1.move(np.linspace((0,0,0.1), (0,0,8), 20))
-
-# manipulate second source
-src2.move(np.linspace((0.1, 0, 0.1), (5,0,5), 50))
-src2.rotate_from_angax(angle=np.linspace(10, 600, 50), axis="z", anchor=0, start=1)
-
-# display the system
-magpy.show(src1, src2, backend='plotly')
-```
-
-The `show` function is also available as a class method and can be called for every object separately.
+### With a plotly canvas 
 
 ```{code-cell} ipython3
 import plotly.graph_objects as go
 import magpylib as magpy
 
 fig = go.Figure()
-ts = [-0.4, 0, 0.4]
-sens = magpy.Sensor(position=(0, 0, 2), pixel=[(x, y, 0) for x in ts for y in ts])
+ts = [-2, -1, 0, 1, 2]
+sens = magpy.Sensor(position=(0, 0, 2), pixel=[(x, y, z) for x in ts for y in ts for z in ts])
 sens.show(canvas=fig, backend="plotly", zoom=1, style_size=5)
+fig.update_layout(
+    title_text='My own title text',
+    width=800,
+    height=600)
 fig
+```
+
+```note
+The `show` function is also available as a class method and can be called for every object separately.
 ```

--- a/docs/examples/plot_03_display_styling.md
+++ b/docs/examples/plot_03_display_styling.md
@@ -6,7 +6,7 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.13.1
 kernelspec:
-  display_name: Python 3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 ---
@@ -26,39 +26,17 @@ The styling options can be set at the library level, for an individual object di
 
 - library `defaults`
 - individual object `style` or at `Collection` level
-- in the `show` function
-
-+++
-
-## Examples
-
-```{code-cell} ipython3
-import magpylib as magpy
-import plotly.graph_objects as go
-
-from magpylib._src.style import Dipole
-
-magpy.defaults.reset()
-
-cuboid = magpy.magnet.Cuboid(
-    magnetization=(1, 0, 0), dimension=(1, 1, 1), position=(0, 0, 0)
-)
-cylinder = magpy.magnet.Cylinder(
-    magnetization=(0, 1, 0), dimension=(1, 1), position=(2, 0, 0)
-)
-sphere = magpy.magnet.Sphere(magnetization=(0, 1, 1), diameter=1, position=(4, 0, 0))
-col = magpy.Collection(cuboid, cylinder, sphere)
-```
+- in the `show` function or method
 
 +++ {"tags": []}
 
-### Setting library defaults
+## Setting library defaults
 
 +++ {"tags": []}
 
-#### Base defaults structure
+### Defaults style structure
 
-Display styles can be set at the library default level at `magpy.defaults.display.style`. The default styles are separated into the following object families:
+General Magpylib defaults can be set from the top library level by settings `magpylib.defaults` properties and default display styling properties can be accessed with `magpylib.defaults.display.style`. The default styles are separated into the following object families:
 
 - **base** : common properties for all families
 - **magnet**: `Cuboid, Cylinder, Sphere, CylinderSegment`
@@ -66,58 +44,71 @@ Display styles can be set at the library default level at `magpy.defaults.displa
 - **sensor**: `Sensor`
 - **markers**: markers in the `show` function
 
-+++ {"jp-MarkdownHeadingCollapsed": true, "tags": []}
++++ {"tags": [], "jp-MarkdownHeadingCollapsed": true}
 
-#### Changing defaults and Magic underscore notation
-Nested properties can be set with directly by accessing style attributes with the dot notation, or by assigning a dictionary with equivalent keys.
+### Accessing nested properties
 
-+++
-
-by defining the `magnet_style` variable as:
-
-```{code-cell} ipython3
-magnet_style = magpy.defaults.display.style.magnet
+Nested properties can be set by accessing style attributes with the dot notation:
+```python
+import magpylib as magpy
+magpy.defaults.display.style.magnet.magnetization.show = True
+magpy.defaults.display.style.magnet.magnetization.color.middle = "grey"
+magpy.defaults.display.style.magnet.magnetization.color.mode = "bicolor"
 ```
 
-the following examples are equivalent
+or by assigning a dictionary with equivalent keys:
 
-```{code-cell} ipython3
-magnet_style.magnetization.show = True
-magnet_style.magnetization.color.middle = "grey"
-magnet_style.magnetization.color.mode = "tricolor"
-```
-
-and
-
-```{code-cell} ipython3
-magnet_style = {
+```python
+import magpylib as magpy
+magpy.defaults.display.style.magnet = {
     "magnetization": {"show": True, "color": {"middle": "grey", "mode": "tricolor"}}
 }
 ```
 
-To make it easier to work with nested properties, style constructors and object style method support magic underscore notation. This allows you to reference nested properties by joining together multiple nested property names with underscores.This feature mainly helps reduce the code verbosity and is heavily inspired by the `plotly` implementation (see [plotly underscore notation](https://plotly.com/python/creating-and-updating-figures/#magic-underscore-notation)). The previous examples can also be written as:
++++ {"tags": [], "jp-MarkdownHeadingCollapsed": true}
 
-```{code-cell} ipython3
-magnet_style = {
+### Using the _magic underscore notation_
+To make it easier to work with nested properties, style constructors and object style method support magic underscore notation. This allows you to reference nested properties by joining together multiple nested property names with underscores. This feature mainly helps reduce the code verbosity and is heavily inspired by the `plotly` implementation (see [plotly underscore notation](https://plotly.com/python/creating-and-updating-figures/#magic-underscore-notation)). The previous examples can therefore, also be written as:
+
+```python
+import magpylib as magpy
+magpy.defaults.display.style.magnet = {
     "magnetization_show": True,
     "magnetization_color_middle": "grey",
     "magnetization_color_mode": "tricolor",
 }
 ```
+Additionally, instead of overriding the whole magnet style constructor, style properties can be updated. The underscore notation is also supported here:
 
-Additionally, instead of overriding the whole style constructor, style properties can be updated. The underscore notation is also supported here:
-
-```{code-cell} ipython3
-magnet_style.update(
+```python
+import magpylib as magpy
+magpy.defaults.display.style.magnet.update(
     magnetization_show=True,
     magnetization_color_middle="grey",
     magnetization_color_mode="tricolor",
 )
 ```
 
++++
+
 ### Practical example
 
 ```{code-cell} ipython3
+import magpylib as magpy
+
+magpy.defaults.reset() # can be omitted if runing as a standalone script
+
+cuboid = magpy.magnet.Cuboid(magnetization=(1, 0, 0), dimension=(1, 1, 1))
+cylinder = magpy.magnet.Cylinder(magnetization=(0, 1, 0), dimension=(1, 1))
+cylinder.move((2, 0, 0))
+sphere = magpy.magnet.Sphere(magnetization=(0, 1, 1), diameter=1)
+sphere.move((4, 0, 0))
+
+coll = magpy.Collection(cuboid, cylinder, sphere)
+
+print('Display before setting style defaults')
+magpy.show(*coll, backend="plotly")
+
 my_default_magnetization_style = {
     "show": True,
     "color": {
@@ -130,55 +121,136 @@ my_default_magnetization_style = {
 }
 magpy.defaults.display.style.magnet.magnetization = my_default_magnetization_style
 
-magpy.show(col, backend="plotly")
+print('Display after setting style defaults')
+magpy.show(*coll, backend="plotly")
 ```
 
-#### Setting style via `Collection`
+```{note}
+The defaults are only reset at the first magpylib library import call. By reruning the same cell in a jupyter notebook the `defaults.reset()` call may be need as the import will not trigger a reset on its own the second time.
+```
 
 +++
 
-```{note}
-The `Collection` object does not hold any `style` attribute on its own but the helper method
-`set_children_styles` allows setting the style of all its children where the set arguments match
-existing child style attributes.
+## Setting style via `Collection`
+
++++
+
+The `Collection` object only holds base style properties and only has priority on the children when assigning a color via `style.color`. On the other hand, the `set_children_styles` helper method modifies the style of all its children directly, as long as the set argument(s) match existing child style properties. Non-matching properties are just ignored.
+
+```{code-cell} ipython3
+import magpylib as magpy
+
+magpy.defaults.reset() # can be omitted if runing as a standalone script
+
+cuboid = magpy.magnet.Cuboid(magnetization=(1, 0, 0), dimension=(1, 1, 1))
+cylinder = magpy.magnet.Cylinder(magnetization=(0, 1, 0), dimension=(1, 1))
+cylinder.move((2, 0, 0))
+sphere = magpy.magnet.Sphere(magnetization=(0, 1, 1), diameter=1)
+sphere.move((4, 0, 0))
+
+coll = cuboid + cylinder + sphere
+
+coll.set_children_styles(magnetization_color_south="blue")
+
+magpy.show(coll, backend="plotly")
+```
+
+## Setting individual styles
+
++++
+
+Style properties can also be set for any Magpylib object instance. Note that the object family which is required for the default styles is not present when setting invidual styles.
+
+For example setting the default magnetization north color is set a the family level as:
+```python
+import magpylib as magpy
+magpy.defaults.display.style.current.arrow.size = 2
+```
+
+whereas at the individual style level it becomes:
+
+```python
+import magpylib as magpy
+loop = magpy.current.Loop(current=10, diameter=10)
+loop.style.arrow.size = 2
 ```
 
 ```{code-cell} ipython3
-col.set_children_styles(magnetization_color_south="blue")
+import magpylib as magpy
 
-magpy.show(col, backend="plotly")
-```
+magpy.defaults.reset() # can be omitted if runing as a standalone script
 
-#### Setting individual styles
+cuboid = magpy.magnet.Cuboid(magnetization=(1, 0, 0), dimension=(1, 1, 1))
+cylinder = magpy.magnet.Cylinder(magnetization=(0, 1, 0), dimension=(1, 1))
+cylinder.move((2, 0, 0))
+sphere = magpy.magnet.Sphere(magnetization=(0, 1, 1), diameter=1)
+sphere.move((4, 0, 0))
 
-```{code-cell} ipython3
+coll = cuboid + cylinder + sphere
+
+#setting individual styles
 cylinder.style.update(magnetization_color_mode="bicolor")
 cuboid.style.magnetization.color = dict(mode="tricycle")
+sphere.style.magnetization = {"color": {"mode":"tricolor"}}
 
-magpy.show(col, backend="plotly")
+
+magpy.show(*coll, backend="plotly")
 ```
 
 +++ {"tags": []}
 
-#### Overriding style at display time
+## Overriding style at display time
 
 +++
 
-```{note}
-Setting style parameters in the `show` function does not change the default styles nor the
-set object style. It only affects the current representation to be displayed.
-```
-
-+++
-
-The provided styling properties as function arguments will override temporarily the styles set by any of the aforementioned methods. All styling properties need to start with `style` and underscore magic is supported. The object family must be omitted since the style properties set at display time will apply across object families. Only matching properties to a specific object
+The provided styling properties as function arguments will temporarily override the style properties set by any of the aforementioned methods. All styling properties need to start with `style` and underscore magic is supported. The object family must be omitted since the style properties set at display time will apply across object families. Only matching properties to a specific object
 will be applied.
 
 ```{code-cell} ipython3
-magpy.show(col, backend="plotly", style_magnetization_show=False)
+import magpylib as magpy
+
+magpy.defaults.reset() # can be omitted if runing as a standalone script
+
+cuboid = magpy.magnet.Cuboid(magnetization=(1, 0, 0), dimension=(1, 1, 1))
+cylinder = magpy.magnet.Cylinder(magnetization=(0, 1, 0), dimension=(1, 1))
+cylinder.move((2, 0, 0))
+
+coll = cuboid + cylinder
+
+magpy.show(*coll, backend="plotly", style_magnetization_show=False)
 ```
 
-In the following example, both `sensor` and `dipole` have a `size` object level style property.
+```{note}
+Setting style arguments in the `show` function does not change the default styles nor does it modify individual object styles,  only the current representation to be displayed is affected.
+```
+
++++
+
+In the following example, both `sensor` and `dipole` have a `size` object level style property that has be set explicitly at object creation.
+
+```{code-cell} ipython3
+import magpylib as magpy
+import plotly.graph_objects as go
+
+magpy.defaults.reset()
+
+cuboid = magpy.magnet.Cuboid(
+    magnetization=(1, 0, 0), dimension=(1, 1, 1), position=(0, 0, 0)
+)
+sensor = magpy.Sensor(position=((-2, 0, 0)), style_size=1)
+sensor2 = magpy.Sensor(position=((2, 0, 0)), style=dict(size=10))
+dipole = magpy.misc.Dipole(moment=(1, 1, 1), position=(0, 0, 2), style=dict(size=2))
+
+magpy.show(cuboid, dipole, sensor, sensor2, zoom=1)
+```
+
+```{note}
+Note that in the previous example, the individual sensor style is set at object creation level, which also supports the magic underscore notation.
+```
+
++++
+
+The size property can be overridden at display time with `style_size=5`
 
 ```{code-cell} ipython3
 import magpylib as magpy
@@ -193,20 +265,13 @@ sensor = magpy.Sensor(position=((-2, 0, 0)), style=dict(size=1))
 sensor2 = magpy.Sensor(position=((2, 0, 0)), style=dict(size=10))
 dipole = magpy.misc.Dipole(moment=(1, 1, 1), position=(0, 0, 2), style=dict(size=2))
 
-magpy.show(cuboid, dipole, sensor, sensor2, zoom=1)
-```
-
-The size property can be overridden at display time with `style_size=5`
-
-```{code-cell} ipython3
-magpy.show(cuboid, dipole, sensor, sensor2, style_size=1, zoom=1)
+magpy.show(cuboid, dipole, sensor, sensor2, style_size=1, zoom=0)
 ```
 
 ## List of available styles
 
 ```{code-cell} ipython3
-style = magpy.defaults.display.style.as_dict(flatten=True)
-print("\n".join(f"{k!r}: {v!r}" for k, v in style.items()))
+magpy.defaults.display.style.as_dict(flatten=True)
 ```
 
 ```{warning}

--- a/docs/examples/plot_07_custom_source.md
+++ b/docs/examples/plot_07_custom_source.md
@@ -147,17 +147,16 @@ plotly_trace = {
 }
 
 # define user defined 3d representation for each plotting backend
+interp_cube.style.model3d.showdefault = False # hide default 3D-model
 interp_cube.style.model3d.add_trace(
     backend='matplotlib', 
     trace=matplotlib_trace, 
     show=True,
-    makedefault=True, # replaces default 3d-model
     coordsargs={'x':'xs', 'y':'ys', 'z':'zs'}
 )
 interp_cube.style.model3d.add_trace(
     backend='plotly', 
     trace=plotly_trace,
-    makedefault=True, # replaces default 3d-model
     show=True
 )
 interp_cube.style.name = 'Interpolated cuboid field'

--- a/docs/examples/plot_07_custom_source.md
+++ b/docs/examples/plot_07_custom_source.md
@@ -147,11 +147,19 @@ plotly_trace = {
 }
 
 # define user defined 3d representation for each plotting backend
-interp_cube.style.model3d.data = [
-    dict(backend='matplotlib', trace=matplotlib_trace, show=True, coordsargs={'x':'xs', 'y':'ys', 'z':'zs'}),
-    dict(backend='plotly', trace=plotly_trace, show=True),
-]
-interp_cube.style.model3d.show = False # hide default 3d-model
+interp_cube.style.model3d.add_trace(
+    backend='matplotlib', 
+    trace=matplotlib_trace, 
+    show=True,
+    makedefault=True, # replaces default 3d-model
+    coordsargs={'x':'xs', 'y':'ys', 'z':'zs'}
+)
+interp_cube.style.model3d.add_trace(
+    backend='plotly', 
+    trace=plotly_trace,
+    makedefault=True, # replaces default 3d-model
+    show=True
+)
 interp_cube.style.name = 'Interpolated cuboid field'
 ```
 

--- a/docs/examples/plot_07_custom_source.md
+++ b/docs/examples/plot_07_custom_source.md
@@ -147,7 +147,7 @@ plotly_trace = {
 }
 
 # define user defined 3d representation for each plotting backend
-interp_cube.style.model3d.extra = [
+interp_cube.style.model3d.data = [
     dict(backend='matplotlib', trace=matplotlib_trace, show=True, coordsargs={'x':'xs', 'y':'ys', 'z':'zs'}),
     dict(backend='plotly', trace=plotly_trace, show=True),
 ]

--- a/docs/examples/plot_08_complex_extra_model3d.md
+++ b/docs/examples/plot_08_complex_extra_model3d.md
@@ -13,7 +13,7 @@ kernelspec:
 
 # Complex extra 3d-model
 
-With the `model3d.extra` style property, it is possible to attach an extra 3d-model representation for any `magpylib` object, as long as it is supported by the chosen plotting backend. The `plotly` backend supports `mesh3d` objects and with the `numpy-stl` package, it becomes possible to import a STL CAD file and transform it to a `mesh3d` object with a little helper function.
+With the `model3d.data` style property, it is possible to attach an extra 3d-model representation for any `magpylib` object, as long as it is supported by the chosen plotting backend. The `plotly` backend supports `mesh3d` objects and with the `numpy-stl` package, it becomes possible to import a STL CAD file and transform it to a `mesh3d` object with a little helper function.
 
 ```{note}
 In order to use this functionality the `numpy-stl` package needs to be installed.
@@ -109,7 +109,7 @@ with tempfile.TemporaryDirectory() as tmpdirname:
     model3d_plotly = stl2mesh3d(fn, backend="plotly")
 # create sensor, add extra 3d-model, create path
 sensor = magpy.Sensor(position=(-15, 0, -6))
-sensor.style = dict(model3d_extra=[model3d_matplotlib, model3d_plotly])
+sensor.style = dict(model3d_data=[model3d_matplotlib, model3d_plotly])
 sensor.rotate_from_angax(np.linspace(0, 150, 33), "z", anchor=0, start=0)
 sensor.move(np.linspace((0, 0, 0), (0, 0, 15), 33), start=0)
 # create source, and Collection

--- a/magpylib/_src/defaults/defaults_utility.py
+++ b/magpylib/_src/defaults/defaults_utility.py
@@ -390,7 +390,20 @@ class MagicProperties:
         self, arg=None, _match_properties=True, _replace_None_only=False, **kwargs
     ):
         """
-        updates the class properties with provided arguments, supports magic underscore notation
+        Updates the class properties with provided arguments, supports magic underscore notation
+
+        Parameters
+        ----------
+
+        _match_properties: bool
+            If `True`, checks if provided properties over keyword arguments are matching the current
+            object properties. An error is raised if a non-matching property is found.
+            If `False`, the `update` method does not raise any error when an argument is not
+            matching a property.
+
+        _replace_None_only:
+            updates matching properties that are equal to `None` (not already been set)
+
 
         Returns
         -------

--- a/magpylib/_src/defaults/defaults_values.py
+++ b/magpylib/_src/defaults/defaults_values.py
@@ -45,7 +45,7 @@ DEFAULTS = {
                 },
                 "description": {"show": True, "text": None},
                 "opacity": 1,
-                "model3d": {"show": True, "extra": []},
+                "model3d": {"show": True, "data": []},
                 "color": None,
             },
             "magnet": {

--- a/magpylib/_src/defaults/defaults_values.py
+++ b/magpylib/_src/defaults/defaults_values.py
@@ -45,7 +45,7 @@ DEFAULTS = {
                 },
                 "description": {"show": True, "text": None},
                 "opacity": 1,
-                "model3d": {"show": True, "data": []},
+                "model3d": {"showdefault": True, "data": []},
                 "color": None,
             },
             "magnet": {

--- a/magpylib/_src/display/__init__.py
+++ b/magpylib/_src/display/__init__.py
@@ -1,1 +1,1 @@
-"""_src.display"""
+"""display package"""

--- a/magpylib/_src/display/display_matplotlib.py
+++ b/magpylib/_src/display/display_matplotlib.py
@@ -321,8 +321,9 @@ def draw_model3d_extra(obj, style, show_path, ax, color):
 
     for traces_extra in path_traces_extra.values():
         for tr in traces_extra:
-            kwargs = {"color": color}
-            kwargs.update({k: v for k, v in tr.items() if k not in ("type", "args")})
+            kwargs = {k: v for k, v in tr.items() if k not in ("type", "args")}
+            if "color" not in kwargs or kwargs["color"] is None:
+                kwargs.update(color=color)
             args = tr.get("args", [])
             getattr(ax, tr["type"])(*args, **kwargs)
     return is_extra_now_default, points

--- a/magpylib/_src/display/display_matplotlib.py
+++ b/magpylib/_src/display/display_matplotlib.py
@@ -377,6 +377,7 @@ def display_matplotlib(
             obj_color = style.color if style.color is not None else color
             lw = 0.25
             faces = None
+            is_extra_now_default = False
             if obj.style.model3d.data:
                 is_extra_now_default = draw_model3d_extra(obj, style, path, ax, obj_color)
             if obj.style.model3d.show and not is_extra_now_default:

--- a/magpylib/_src/display/display_matplotlib.py
+++ b/magpylib/_src/display/display_matplotlib.py
@@ -20,6 +20,7 @@ from magpylib._src.input_checks import check_excitations
 from magpylib._src.style import get_style
 from magpylib._src.display.display_utility import MagpyMarkers
 
+
 def draw_directs_faced(faced_objects, colors, ax, show_path, size_direction):
     """draw direction of magnetization of faced magnets
 
@@ -289,24 +290,27 @@ def draw_line(lines, show_path, col, size, width, ax) -> list:
 
 
 def draw_model3d_extra(obj, style, show_path, ax, color):
-    """positions, orients and draws extra 3d model including path positions"""
-    extra_model3d_traces = (
-        style.model3d.extra if style.model3d.extra is not None else []
-    )
+    """positions, orients and draws extra 3d model including path positions
+    returns True if at least one the traces is now new default"""
+    is_extra_now_default = False
+    extra_model3d_traces = style.model3d.data if style.model3d.data is not None else []
     extra_model3d_traces = [
         t for t in extra_model3d_traces if t.backend == "matplotlib"
     ]
     path_traces_extra = {}
     for orient, pos in zip(*get_rot_pos_from_path(obj, show_path)):
         for extr in extra_model3d_traces:
+            obj_extra_trace = extr.trace() if callable(extr.trace) else extr.trace
             if extr.show:
+                if extr.makedefault is True:
+                    is_extra_now_default = True
                 trace3d = place_and_orient_model3d(
-                    extr.trace,
+                    obj_extra_trace,
                     orientation=orient,
                     position=pos,
                     coordsargs=extr.coordsargs,
                 )
-                ttype = extr.trace["type"]
+                ttype = obj_extra_trace["type"]
                 if ttype not in path_traces_extra:
                     path_traces_extra[ttype] = []
                 path_traces_extra[ttype].append(trace3d)
@@ -317,15 +321,10 @@ def draw_model3d_extra(obj, style, show_path, ax, color):
             kwargs.update({k: v for k, v in tr.items() if k not in ("type", "args")})
             args = tr.get("args", [])
             getattr(ax, tr["type"])(*args, **kwargs)
-
+    return is_extra_now_default
 
 def display_matplotlib(
-    *obj_list_semi_flat,
-    axis=None,
-    markers=None,
-    zoom=0,
-    color_sequence=None,
-    **kwargs,
+    *obj_list_semi_flat, axis=None, markers=None, zoom=0, color_sequence=None, **kwargs,
 ):
     """
     Display objects and paths graphically with the matplotlib backend.
@@ -366,7 +365,11 @@ def display_matplotlib(
         if getattr(semi_flat_obj, "children", None) is not None:
             flat_objs.extend(semi_flat_obj.children)
             if getattr(semi_flat_obj, "position", None) is not None:
-                color = color if semi_flat_obj.style.color is None else semi_flat_obj.style.color
+                color = (
+                    color
+                    if semi_flat_obj.style.color is None
+                    else semi_flat_obj.style.color
+                )
 
         for obj in flat_objs:
             style = get_style(obj, Config, **kwargs)
@@ -374,9 +377,9 @@ def display_matplotlib(
             obj_color = style.color if style.color is not None else color
             lw = 0.25
             faces = None
-            if obj.style.model3d.extra:
-                draw_model3d_extra(obj, style, path, ax, obj_color)
-            if obj.style.model3d.show:
+            if obj.style.model3d.data:
+                is_extra_now_default = draw_model3d_extra(obj, style, path, ax, obj_color)
+            if obj.style.model3d.show and not is_extra_now_default:
                 if obj._object_type == "Cuboid":
                     lw = 0.5
                     faces = faces_cuboid(obj, path)
@@ -417,7 +420,9 @@ def display_matplotlib(
                     dipoles.append((obj, obj_color))
                     points += [obj.position]
                 elif obj._object_type == "CustomSource":
-                    draw_markers(np.array([obj.position]), ax, obj_color, symbol="*", size=10)
+                    draw_markers(
+                        np.array([obj.position]), ax, obj_color, symbol="*", size=10
+                    )
                     name = (
                         obj.style.name
                         if obj.style.name is not None

--- a/magpylib/_src/display/display_matplotlib.py
+++ b/magpylib/_src/display/display_matplotlib.py
@@ -292,7 +292,6 @@ def draw_line(lines, show_path, col, size, width, ax) -> list:
 def draw_model3d_extra(obj, style, show_path, ax, color):
     """positions, orients and draws extra 3d model including path positions
     returns True if at least one the traces is now new default"""
-    is_extra_now_default = False
     extra_model3d_traces = style.model3d.data if style.model3d.data is not None else []
     extra_model3d_traces = [
         t for t in extra_model3d_traces if t.backend == "matplotlib"
@@ -303,8 +302,6 @@ def draw_model3d_extra(obj, style, show_path, ax, color):
         for extr in extra_model3d_traces:
             obj_extra_trace = extr.trace() if callable(extr.trace) else extr.trace
             if extr.show:
-                if extr.makedefault is True:
-                    is_extra_now_default = True
                 trace3d, vertices = place_and_orient_model3d(
                     obj_extra_trace,
                     orientation=orient,
@@ -326,7 +323,7 @@ def draw_model3d_extra(obj, style, show_path, ax, color):
                 kwargs.update(color=color)
             args = tr.get("args", [])
             getattr(ax, tr["type"])(*args, **kwargs)
-    return is_extra_now_default, points
+    return points
 
 
 def display_matplotlib(
@@ -383,13 +380,12 @@ def display_matplotlib(
             obj_color = style.color if style.color is not None else color
             lw = 0.25
             faces = None
-            is_extra_now_default = False
             if obj.style.model3d.data:
-                is_extra_now_default, pts = draw_model3d_extra(
+                pts = draw_model3d_extra(
                     obj, style, path, ax, obj_color
                 )
                 points += pts
-            if obj.style.model3d.show and not is_extra_now_default:
+            if obj.style.model3d.showdefault:
                 if obj._object_type == "Cuboid":
                     lw = 0.5
                     faces = faces_cuboid(obj, path)

--- a/magpylib/_src/display/display_utility.py
+++ b/magpylib/_src/display/display_utility.py
@@ -17,12 +17,18 @@ class MagpyMarkers:
 
 
 def place_and_orient_model3d(
-    model_dict, orientation=None, position=None, coordsargs=None, **kwargs
+    model_dict,
+    orientation=None,
+    position=None,
+    coordsargs=None,
+    scale=1,
+    return_vertices=False,
+    **kwargs,
 ):
     """places and orients mesh3d dict"""
     if orientation is None and position is None:
         return {**model_dict, **kwargs}
-    position = (0.,0.,0.) if position is None else position
+    position = (0.0, 0.0, 0.0) if position is None else position
     position = np.array(position, dtype=float)
     new_model_dict = {}
     if "args" in model_dict:
@@ -50,7 +56,7 @@ def place_and_orient_model3d(
     vertices = np.array(vertices).T
     if orientation is not None:
         vertices = orientation.apply(vertices)
-    new_vertices = (vertices + position).T
+    new_vertices = (vertices * scale + position).T
     for i, k in enumerate("xyz"):
         key = coordsargs[k]
         if useargs:
@@ -58,7 +64,10 @@ def place_and_orient_model3d(
             new_model_dict["args"][ind] = new_vertices[i]
         else:
             new_model_dict[key] = new_vertices[i]
-    return {**model_dict, **new_model_dict, **kwargs}
+    new_dict = {**model_dict, **new_model_dict, **kwargs}
+    if return_vertices:
+        return new_dict, new_vertices
+    return new_dict
 
 
 def draw_arrowed_line(vec, pos, sign=1, arrow_size=1) -> Tuple:

--- a/magpylib/_src/display/display_utility.py
+++ b/magpylib/_src/display/display_utility.py
@@ -162,7 +162,7 @@ def get_rot_pos_from_path(obj, show_path=None):
         orient = RotScipy.from_rotvec([[0, 0, 1]])
     pos = np.array([pos]) if pos.ndim == 1 else pos
     path_len = pos.shape[0]
-    if show_path is True or show_path is False:
+    if show_path is True or show_path is False or show_path==0:
         inds = np.array([-1])
     elif isinstance(show_path, int):
         inds = np.arange(path_len, dtype=int)[::-show_path]

--- a/magpylib/_src/display/plotly/plotly_display.py
+++ b/magpylib/_src/display/plotly/plotly_display.py
@@ -137,12 +137,7 @@ def make_Loop(
 
 
 def make_DefaultTrace(
-    obj,
-    position=(0.0, 0.0, 0.0),
-    orientation=None,
-    color=None,
-    style=None,
-    **kwargs,
+    obj, position=(0.0, 0.0, 0.0), orientation=None, color=None, style=None, **kwargs,
 ) -> dict:
     """
     Creates the plotly scatter3d parameters for an object with no specifically supported
@@ -205,14 +200,7 @@ def make_Dipole(
     orientation = orientation * mag_orient
     mag = np.array((0, 0, 1))
     return _update_mag_mesh(
-        dipole,
-        name,
-        name_suffix,
-        mag,
-        orientation,
-        position,
-        style,
-        **kwargs,
+        dipole, name, name_suffix, mag, orientation, position, style, **kwargs,
     )
 
 
@@ -233,14 +221,7 @@ def make_Cuboid(
     name, name_suffix = get_name_and_suffix("Cuboid", default_suffix, style)
     cuboid = make_BaseCuboid(dimension=dimension)
     return _update_mag_mesh(
-        cuboid,
-        name,
-        name_suffix,
-        mag,
-        orientation,
-        position,
-        style,
-        **kwargs,
+        cuboid, name, name_suffix, mag, orientation, position, style, **kwargs,
     )
 
 
@@ -262,19 +243,10 @@ def make_Cylinder(
     default_suffix = f" (D={d[0]}m, H={d[1]}m)"
     name, name_suffix = get_name_and_suffix("Cylinder", default_suffix, style)
     cylinder = make_BasePrism(
-        base_vertices=base_vertices,
-        diameter=diameter,
-        height=height,
+        base_vertices=base_vertices, diameter=diameter, height=height,
     )
     return _update_mag_mesh(
-        cylinder,
-        name,
-        name_suffix,
-        mag,
-        orientation,
-        position,
-        style,
-        **kwargs,
+        cylinder, name, name_suffix, mag, orientation, position, style, **kwargs,
     )
 
 
@@ -325,14 +297,7 @@ def make_Sphere(
     vert = min(max(vert, 3), 20)
     sphere = make_BaseEllipsoid(vert=vert, dimension=[diameter] * 3)
     return _update_mag_mesh(
-        sphere,
-        name,
-        name_suffix,
-        mag,
-        orientation,
-        position,
-        style,
-        **kwargs,
+        sphere, name, name_suffix, mag, orientation, position, style, **kwargs,
     )
 
 
@@ -446,15 +411,10 @@ def _update_mag_mesh(
                 color_south=color.south,
             )
             mesh_dict["intensity"] = getIntensity(
-                vertices=vertices,
-                axis=magnetization,
+                vertices=vertices, axis=magnetization,
             )
     mesh_dict = place_and_orient_model3d(
-        mesh_dict,
-        orientation,
-        position,
-        showscale=False,
-        name=f"{name}{name_suffix}",
+        mesh_dict, orientation, position, showscale=False, name=f"{name}{name_suffix}",
     )
     return {**mesh_dict, **kwargs}
 
@@ -554,8 +514,7 @@ def get_plotly_traces(
             make_func = make_Sensor
         elif isinstance(input_obj, Cuboid):
             kwargs.update(
-                mag=input_obj.magnetization,
-                dimension=input_obj.dimension,
+                mag=input_obj.magnetization, dimension=input_obj.dimension,
             )
             make_func = make_Cuboid
         elif isinstance(input_obj, Cylinder):
@@ -574,33 +533,27 @@ def get_plotly_traces(
                 50, Config.itercylinder
             )  # no need to render more than 50 vertices
             kwargs.update(
-                mag=input_obj.magnetization,
-                dimension=input_obj.dimension,
-                vert=vert,
+                mag=input_obj.magnetization, dimension=input_obj.dimension, vert=vert,
             )
             make_func = make_CylinderSegment
         elif isinstance(input_obj, Sphere):
             kwargs.update(
-                mag=input_obj.magnetization,
-                diameter=input_obj.diameter,
+                mag=input_obj.magnetization, diameter=input_obj.diameter,
             )
             make_func = make_Sphere
         elif isinstance(input_obj, Dipole):
             kwargs.update(
-                moment=input_obj.moment,
-                autosize=autosize,
+                moment=input_obj.moment, autosize=autosize,
             )
             make_func = make_Dipole
         elif isinstance(input_obj, Line):
             kwargs.update(
-                vertices=input_obj.vertices,
-                current=input_obj.current,
+                vertices=input_obj.vertices, current=input_obj.current,
             )
             make_func = make_Line
         elif isinstance(input_obj, Loop):
             kwargs.update(
-                diameter=input_obj.diameter,
-                current=input_obj.current,
+                diameter=input_obj.diameter, current=input_obj.current,
             )
             make_func = make_Loop
         elif getattr(input_obj, "children", None) is not None:
@@ -625,7 +578,9 @@ def get_plotly_traces(
                         if extr.makedefault is True:
                             is_extra_now_default = True
                         trace3d = {}
-                        obj_extr_trace = extr.trace() if callable(extr.trace) else extr.trace
+                        obj_extr_trace = (
+                            extr.trace() if callable(extr.trace) else extr.trace
+                        )
                         ttype = obj_extr_trace["type"]
                         if ttype == "mesh3d":
                             trace3d["showscale"] = False
@@ -639,7 +594,10 @@ def get_plotly_traces(
                         trace3d.update(
                             linearize_dict(
                                 place_and_orient_model3d(
-                                    obj_extr_trace, orientation=orient, position=pos
+                                    obj_extr_trace,
+                                    orientation=orient,
+                                    position=pos,
+                                    scale=extr.scale,
                                 ),
                                 separator="_",
                             )
@@ -775,7 +733,7 @@ def draw_frame(objs, color_sequence, zoom, autosize=None, **kwargs) -> Tuple:
                     showlegend=showlegend,
                     legendtext=legendtext,
                 ),
-                ** kwargs
+                **kwargs,
             }
             if isinstance(subobj, (Dipole, Sensor)):
                 traces_to_resize[subobj] = {**params}
@@ -1014,13 +972,7 @@ def animate_path(
     autosize = "return"
     for i, ind in enumerate(path_indices):
         kwargs["style_path_show"] = [ind]
-        frame = draw_frame(
-            objs,
-            color_sequence,
-            zoom,
-            autosize=autosize,
-            **kwargs,
-        )
+        frame = draw_frame(objs, color_sequence, zoom, autosize=autosize, **kwargs,)
         if i == 0:  # get the dipoles and sensors autosize from first frame
             traces_dicts, autosize = frame
         else:
@@ -1037,10 +989,7 @@ def animate_path(
             slider_step = {
                 "args": [
                     [str(ind + 1)],
-                    {
-                        "frame": {"duration": 0, "redraw": True},
-                        "mode": "immediate",
-                    },
+                    {"frame": {"duration": 0, "redraw": True}, "mode": "immediate",},
                 ],
                 "label": str(ind + 1),
                 "method": "animate",

--- a/magpylib/_src/display/plotly/plotly_display.py
+++ b/magpylib/_src/display/plotly/plotly_display.py
@@ -625,8 +625,7 @@ def get_plotly_traces(
                         if extr.makedefault is True:
                             is_extra_now_default = True
                         trace3d = {}
-                        if callable(extr.trace):
-                            obj_extr_trace = extr.trace()
+                        obj_extr_trace = extr.trace() if callable(extr.trace) else extr.trace
                         ttype = obj_extr_trace["type"]
                         if ttype == "mesh3d":
                             trace3d["showscale"] = False

--- a/magpylib/_src/display/plotly/plotly_display.py
+++ b/magpylib/_src/display/plotly/plotly_display.py
@@ -570,46 +570,41 @@ def get_plotly_traces(
         extra_model3d_traces = [
             t for t in extra_model3d_traces if t.backend == "plotly"
         ]
-        if style.model3d.show:
-            for orient, pos in zip(*get_rot_pos_from_path(input_obj, style.path.show)):
-                is_extra_now_default = False
-                for extr in extra_model3d_traces:
-                    if extr.show:
-                        if extr.makedefault is True:
-                            is_extra_now_default = True
-                        trace3d = {}
-                        obj_extr_trace = (
-                            extr.trace() if callable(extr.trace) else extr.trace
-                        )
-                        ttype = obj_extr_trace["type"]
-                        if ttype == "mesh3d":
-                            trace3d["showscale"] = False
-                            if "facecolor" in obj_extr_trace:
-                                ttype = "mesh3d_facecolor"
-                        if ttype == "scatter3d":
-                            trace3d["marker_color"] = kwargs["color"]
-                            trace3d["line_color"] = kwargs["color"]
-                        else:
-                            trace3d["color"] = kwargs["color"]
-                        trace3d.update(
-                            linearize_dict(
-                                place_and_orient_model3d(
-                                    obj_extr_trace,
-                                    orientation=orient,
-                                    position=pos,
-                                    scale=extr.scale,
-                                ),
-                                separator="_",
-                            )
-                        )
-                        if ttype not in path_traces_extra:
-                            path_traces_extra[ttype] = []
-                        path_traces_extra[ttype].append(trace3d)
-
-                if make_func is not None and not is_extra_now_default:
-                    path_traces.append(
-                        make_func(position=pos, orientation=orient, **kwargs)
+        for orient, pos in zip(*get_rot_pos_from_path(input_obj, style.path.show)):
+            if make_func is not None and style.model3d.showdefault:
+                path_traces.append(
+                    make_func(position=pos, orientation=orient, **kwargs)
+                )
+            for extr in extra_model3d_traces:
+                if extr.show:
+                    trace3d = {}
+                    obj_extr_trace = (
+                        extr.trace() if callable(extr.trace) else extr.trace
                     )
+                    ttype = obj_extr_trace["type"]
+                    if ttype == "mesh3d":
+                        trace3d["showscale"] = False
+                        if "facecolor" in obj_extr_trace:
+                            ttype = "mesh3d_facecolor"
+                    if ttype == "scatter3d":
+                        trace3d["marker_color"] = kwargs["color"]
+                        trace3d["line_color"] = kwargs["color"]
+                    else:
+                        trace3d["color"] = kwargs["color"]
+                    trace3d.update(
+                        linearize_dict(
+                            place_and_orient_model3d(
+                                obj_extr_trace,
+                                orientation=orient,
+                                position=pos,
+                                scale=extr.scale,
+                            ),
+                            separator="_",
+                        )
+                    )
+                    if ttype not in path_traces_extra:
+                        path_traces_extra[ttype] = []
+                    path_traces_extra[ttype].append(trace3d)
         trace = merge_traces(*path_traces)
         for ind, traces_extra in enumerate(path_traces_extra.values()):
             extra_model3d_trace = merge_traces(*traces_extra)
@@ -709,7 +704,7 @@ def draw_frame(objs, color_sequence, zoom, autosize=None, **kwargs) -> Tuple:
         for ind, subobj in enumerate(subobjs):
             if legendgroup is not None:
                 if (
-                    subobj.style.model3d.show or ind + 1 == len(subobjs)
+                    subobj.style.model3d.showdefault or ind + 1 == len(subobjs)
                 ) and not first_shown:
                     # take name of parent
                     first_shown = True

--- a/magpylib/_src/display/plotly/plotly_utility.py
+++ b/magpylib/_src/display/plotly/plotly_utility.py
@@ -78,7 +78,8 @@ def getIntensity(vertices, axis) -> np.ndarray:
     """
     p = np.array(vertices).T
     pos = np.mean(p, axis=1)
-    m = np.array(axis) / np.linalg.norm(axis)
+    norm = np.linalg.norm(axis)
+    m = (np.array(axis) / norm) if norm!=0 else (0,0,0)
     intensity = (p[0] - pos[0]) * m[0] + (p[1] - pos[1]) * m[1] + (p[2] - pos[2]) * m[2]
     return intensity
 

--- a/magpylib/_src/style.py
+++ b/magpylib/_src/style.py
@@ -266,15 +266,18 @@ class Model3d(MagicProperties):
 
     @data.setter
     def data(self, val):
+        self._data = self._validate_data(val)
+
+    def _validate_data(self, val):
         if val is None:
             val = []
-        elif isinstance(val, dict):
+        elif not isinstance(val, (list,tuple)):
             val = [val]
         m3 = []
         for v in val:
             v = validate_property_class(v, "data", Trace3d, self)
             m3.append(v)
-        self._data = m3
+        return m3
 
     def add_trace(
         self, trace, show=True, backend="matplotlib", coordsargs=None, makedefault=False
@@ -311,7 +314,8 @@ class Model3d(MagicProperties):
             coordsargs=coordsargs,
             makedefault=makedefault,
         )
-        self.data = self.data + [new_trace]
+        self._data += self._validate_data(new_trace)
+        return self
 
 
 class Trace3d(MagicProperties):

--- a/magpylib/_src/style.py
+++ b/magpylib/_src/style.py
@@ -16,12 +16,12 @@ from magpylib._src.defaults.defaults_utility import (
 
 def get_style_class(obj):
     """returns style class based on object type. If class has no attribute `_object_type` or is
-    not found in `MAGPYLIB_FAMILIES` returns `Base` class."""
+    not found in `MAGPYLIB_FAMILIES` returns `BaseStyle` class."""
     obj_type = getattr(obj, "_object_type", None)
     style_fam = MAGPYLIB_FAMILIES.get(obj_type, None)
     if isinstance(style_fam, (list, tuple)):
         style_fam = style_fam[0]
-    return STYLE_CLASSES.get(style_fam, Base)
+    return STYLE_CLASSES.get(style_fam, BaseStyle)
 
 
 def get_style(obj, default_settings, **kwargs):
@@ -57,7 +57,7 @@ def get_style(obj, default_settings, **kwargs):
     style_kwargs = validate_style_keys(style_kwargs)
     # create style class instance and update based on precedence
     obj_style = getattr(obj, "style", None)
-    style = obj_style.copy() if obj_style is not None else Base()
+    style = obj_style.copy() if obj_style is not None else BaseStyle()
     style_kwargs_specific = {
         k: v for k, v in style_kwargs.items() if k.split("_")[0] in style.as_dict()
     }
@@ -70,75 +70,6 @@ def get_style(obj, default_settings, **kwargs):
 
 
 class BaseStyle(MagicProperties):
-    """
-    Base class for display styling options of all objects to be displayed
-
-    Properties
-    ----------
-    name : str, default=None
-        name of the class instance, can be any string.
-
-    description: dict or Description, default=None
-        object description properties
-
-    color: str, default=None
-        a valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`
-
-    opacity: float, default=None
-        object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
-    """
-
-    def __init__(
-        self, name=None, description=None, color=None, opacity=None, **kwargs,
-    ):
-        super().__init__(
-            name=name, description=description, color=color, opacity=opacity, **kwargs,
-        )
-
-    @property
-    def name(self):
-        """name of the class instance, can be any string"""
-        return self._name
-
-    @name.setter
-    def name(self, val):
-        self._name = val if val is None else str(val)
-
-    @property
-    def description(self):
-        """Description class with 'text' and 'show' properties"""
-        return self._description
-
-    @description.setter
-    def description(self, val):
-        self._description = validate_property_class(
-            val, "description", Description, self
-        )
-
-    @property
-    def color(self):
-        """a valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`"""
-        return self._color
-
-    @color.setter
-    def color(self, val):
-        self._color = color_validator(val, parent_name=f"{type(self).__name__}")
-
-    @property
-    def opacity(self):
-        """object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent"""
-        return self._opacity
-
-    @opacity.setter
-    def opacity(self, val):
-        assert val is None or (isinstance(val, (float, int)) and 0 <= val <= 1), (
-            "opacity must be a value betwen 0 and 1\n"
-            f"but received {repr(val)} instead"
-        )
-        self._opacity = val
-
-
-class Base(BaseStyle):
     """
     Base class for display styling options of `BaseGeo` objects
 
@@ -186,6 +117,48 @@ class Base(BaseStyle):
             model3d=model3d,
             **kwargs,
         )
+
+    @property
+    def name(self):
+        """name of the class instance, can be any string"""
+        return self._name
+
+    @name.setter
+    def name(self, val):
+        self._name = val if val is None else str(val)
+
+    @property
+    def description(self):
+        """Description class with 'text' and 'show' properties"""
+        return self._description
+
+    @description.setter
+    def description(self, val):
+        self._description = validate_property_class(
+            val, "description", Description, self
+        )
+
+    @property
+    def color(self):
+        """a valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`"""
+        return self._color
+
+    @color.setter
+    def color(self, val):
+        self._color = color_validator(val, parent_name=f"{type(self).__name__}")
+
+    @property
+    def opacity(self):
+        """object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent"""
+        return self._opacity
+
+    @opacity.setter
+    def opacity(self, val):
+        assert val is None or (isinstance(val, (float, int)) and 0 <= val <= 1), (
+            "opacity must be a value betwen 0 and 1\n"
+            f"but received {repr(val)} instead"
+        )
+        self._opacity = val
 
     @property
     def path(self):
@@ -644,13 +617,16 @@ class MagnetProperties:
     Properties
     ----------
     magnetization: dict or Magnetization, default=None
-
+        Magnetization styling with `'show'`, `'size'`, `'color'` properties
+        or a dictionary with equivalent key/value pairs
     """
 
     @property
     def magnetization(self):
-        """Magnetization class with 'north', 'south', 'middle' and 'transition' values
-        or a dictionary with equivalent key/value pairs"""
+        """
+        Magnetization styling with `'show'`, `'size'`, `'color'` properties
+        or a dictionary with equivalent key/value pairs
+        """
         return self._magnetization
 
     @magnetization.setter
@@ -674,8 +650,37 @@ class Magnet(MagicProperties, MagnetProperties):
         super().__init__(magnetization=magnetization, **kwargs)
 
 
-class MagnetStyle(Base, MagnetProperties):
-    """Defines the styling properties of objects of the `magnet` family with base properties"""
+class MagnetStyle(BaseStyle, MagnetProperties):
+    """Defines the styling properties of objects of the `magnet` family with base properties
+
+    Properties
+    ----------
+    name : str, default=None
+        name of the class instance, can be any string.
+
+    description: dict or Description, default=None
+        object description properties
+
+    color: str, default=None
+        a valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`
+
+    opacity: float, default=None
+        object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
+
+    path: dict or Path, default=None
+        an instance of `Path` or dictionary of equivalent key/value pairs, defining the object
+        path marker and path line properties.
+
+    model3d: list of Trace3d objects, default=None
+        a list of traces where each is an instance of `Trace3d` or dictionary of equivalent
+        key/value pairs. Defines properties for an additional user-defined model3d object which is
+        positioned relatively to the main object to be displayed and moved automatically with it.
+        This feature also allows the user to replace the original 3d representation of the object.
+
+    magnetization: dict or Magnetization, default=None
+        Magnetization styling with `'show'`, `'size'`, `'color'` properties
+        or a dictionary with equivalent key/value pairs
+    """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -734,8 +739,39 @@ class Sensor(MagicProperties, SensorProperties):
         super().__init__(size=size, pixel=pixel, **kwargs)
 
 
-class SensorStyle(Base, SensorProperties):
-    """Defines the styling properties of objects of the `sensor` family with base properties"""
+class SensorStyle(BaseStyle, SensorProperties):
+    """Defines the styling properties of objects of the `sensor` family with base properties
+
+    Properties
+    ----------
+    name : str, default=None
+        name of the class instance, can be any string.
+
+    description: dict or Description, default=None
+        object description properties
+
+    color: str, default=None
+        a valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`
+
+    opacity: float, default=None
+        object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
+
+    path: dict or Path, default=None
+        an instance of `Path` or dictionary of equivalent key/value pairs, defining the object
+        path marker and path line properties.
+
+    model3d: list of Trace3d objects, default=None
+        a list of traces where each is an instance of `Trace3d` or dictionary of equivalent
+        key/value pairs. Defines properties for an additional user-defined model3d object which is
+        positioned relatively to the main object to be displayed and moved automatically with it.
+        This feature also allows the user to replace the original 3d representation of the object.
+
+    size: float, default=None
+        positive float for relative sensor to canvas size
+
+    pixel: dict, Pixel, default=None
+        `Pixel` class or dict with equivalent key/value pairs (e.g. `color`, `size`)
+    """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -810,12 +846,12 @@ class CurrentProperties:
     Properties
     ----------
     arrow: dict or Arrow, default=None
-        Arrow class or dict with 'show', 'size' properties/keys
+        Arrow class or dict with `'show'`, `'size'` properties/keys
     """
 
     @property
     def arrow(self):
-        """Arrow class with 'show', 'size' properties"""
+        """Arrow class or dict with `'show'`, `'size'` properties/keys"""
         return self._arrow
 
     @arrow.setter
@@ -837,8 +873,36 @@ class Current(MagicProperties, CurrentProperties):
         super().__init__(arrow=arrow, **kwargs)
 
 
-class CurrentStyle(Base, CurrentProperties):
-    """Defines the styling properties of objects of the `current` family and base properties"""
+class CurrentStyle(BaseStyle, CurrentProperties):
+    """Defines the styling properties of objects of the `current` family and base properties
+
+    Properties
+    ----------
+    name : str, default=None
+        name of the class instance, can be any string.
+
+    description: dict or Description, default=None
+        object description properties
+
+    color: str, default=None
+        a valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`
+
+    opacity: float, default=None
+        object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
+
+    path: dict or Path, default=None
+        an instance of `Path` or dictionary of equivalent key/value pairs, defining the object
+        path marker and path line properties.
+
+    model3d: list of Trace3d objects, default=None
+        a list of traces where each is an instance of `Trace3d` or dictionary of equivalent
+        key/value pairs. Defines properties for an additional user-defined model3d object which is
+        positioned relatively to the main object to be displayed and moved automatically with it.
+        This feature also allows the user to replace the original 3d representation of the object.
+
+    arrow: dict or Arrow, default=None
+        Arrow class or dict with `'show'`, `'size'` properties/keys
+    """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -1045,8 +1109,40 @@ class Dipole(MagicProperties, DipoleProperties):
         super().__init__(size=size, pivot=pivot, **kwargs)
 
 
-class DipoleStyle(Base, DipoleProperties):
-    """Defines the styling properties of the objects of the `dipole` family and base properties"""
+class DipoleStyle(BaseStyle, DipoleProperties):
+    """Defines the styling properties of the objects of the `dipole` family and base properties
+
+    Properties
+    ----------
+    name : str, default=None
+        name of the class instance, can be any string.
+
+    description: dict or Description, default=None
+        object description properties
+
+    color: str, default=None
+        a valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`
+
+    opacity: float, default=None
+        object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
+
+    path: dict or Path, default=None
+        an instance of `Path` or dictionary of equivalent key/value pairs, defining the object
+        path marker and path line properties.
+
+    model3d: list of Trace3d objects, default=None
+        a list of traces where each is an instance of `Trace3d` or dictionary of equivalent
+        key/value pairs. Defines properties for an additional user-defined model3d object which is
+        positioned relatively to the main object to be displayed and moved automatically with it.
+        This feature also allows the user to replace the original 3d representation of the object.
+
+    size: float, default=None
+        positive float for relative dipole to size to canvas size
+
+    pivot: str, default=None
+        the part of the arrow that is anchored to the X, Y grid.
+        The arrow rotates about this point. Can be one of `['tail', 'middle', 'tip']`
+    """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -1256,7 +1352,7 @@ class DisplayStyle(MagicProperties):
 
     @base.setter
     def base(self, val):
-        self._base = validate_property_class(val, "base", Base, self)
+        self._base = validate_property_class(val, "base", BaseStyle, self)
 
     @property
     def magnet(self):

--- a/magpylib/_src/style.py
+++ b/magpylib/_src/style.py
@@ -229,35 +229,32 @@ class Model3d(MagicProperties):
 
     Properties
     ----------
-    show: bool, default=None
-        shows/hides model3d object based on provided trace:
-        - True: shows mesh
-        - False: hides mesh
+    showdefault: bool, default=True
+        Shows/hides default 3D-model
 
     data: dict or list of dicts, default=None
         a trace or list of traces where each is an instance of `Trace3d` or dictionary of equivalent
         key/value pairs. Defines properties for an additional user-defined model3d object which is
         positioned relatively to the main object to be displayed and moved automatically with it.
         This feature also allows the user to replace the original 3d representation of the object.
-
     """
 
-    def __init__(self, show=True, data=None, **kwargs):
-        super().__init__(show=show, data=data, **kwargs)
+    def __init__(self, showdefault=True, data=None, **kwargs):
+        super().__init__(showdefault=showdefault, data=data, **kwargs)
 
     @property
-    def show(self):
+    def showdefault(self):
         """shows/hides main model3d object representation"""
-        return self._show
+        return self._showdefault
 
-    @show.setter
-    def show(self, val):
+    @showdefault.setter
+    def showdefault(self, val):
         assert isinstance(val, bool), (
-            f"the `show` property of {type(self).__name__} must be "
+            f"the `showdefault` property of {type(self).__name__} must be "
             f"one of `[True, False]`"
             f" but received {repr(val)} instead"
         )
-        self._show = val
+        self._showdefault = val
 
     @property
     def data(self):
@@ -280,7 +277,7 @@ class Model3d(MagicProperties):
         return m3
 
     def add_trace(
-        self, trace, show=True, backend="matplotlib", coordsargs=None, scale=1, makedefault=False
+        self, trace, show=True, backend="matplotlib", coordsargs=None, scale=1,
     ):
         """creates an additional user-defined 3d model object which is positioned relatively
         to the main object to be displayed and moved automatically with it. This feature also allows
@@ -307,18 +304,10 @@ class Model3d(MagicProperties):
             scaling factor by which the trace vertices coordinates should be multiplied by. Be aware
             that if the object is not centered at the global CS origin, its position will
             also be scaled.
-
-        makedefault: bool
-            If `True`, it replaces the default 3D-representation.
-            If `False`, it adds the current trace to the default 3D-representation."""
+        """
 
         new_trace = Trace3d(
-            trace=trace,
-            show=show,
-            scale=scale,
-            backend=backend,
-            coordsargs=coordsargs,
-            makedefault=makedefault,
+            trace=trace, show=show, scale=scale, backend=backend, coordsargs=coordsargs,
         )
         self._data += self._validate_data(new_trace)
         return self
@@ -351,10 +340,6 @@ class Trace3d(MagicProperties):
         tells magpylib the name of the coordinate arrays to be moved or rotated.
         by default: `{"x": "x", "y": "y", "z": "z"}`
         if False, object is not rotated
-
-    makedefault: bool
-        If `True`, it replaces the default 3D-representation.
-        If `False`, it adds the current trace to the default 3D-representation.
     """
 
     def __init__(
@@ -364,7 +349,6 @@ class Trace3d(MagicProperties):
         show=True,
         backend="matplotlib",
         coordsargs=None,
-        makedefault=False,
         **kwargs,
     ):
         super().__init__(
@@ -373,7 +357,6 @@ class Trace3d(MagicProperties):
             show=show,
             backend=backend,
             coordsargs=coordsargs,
-            makedefault=makedefault,
             **kwargs,
         )
 
@@ -460,23 +443,6 @@ class Trace3d(MagicProperties):
             f" but received {repr(val)} instead"
         )
         self._backend = val
-
-    @property
-    def makedefault(self):
-        """
-        If `True`, it replaces the default 3D-representation.
-        If `False`, it adds the current trace to the default 3D-representation.
-        """
-        return self._makedefault
-
-    @makedefault.setter
-    def makedefault(self, val):
-        assert val is None or isinstance(val, bool), (
-            f"the `makedefault` property of {type(self).__name__} must be "
-            f"one of `[True, False]`"
-            f" but received {repr(val)} instead"
-        )
-        self._makedefault = val
 
 
 class Magnetization(MagicProperties):

--- a/magpylib/_src/style.py
+++ b/magpylib/_src/style.py
@@ -271,7 +271,7 @@ class Model3d(MagicProperties):
     def _validate_data(self, val):
         if val is None:
             val = []
-        elif not isinstance(val, (list,tuple)):
+        elif not isinstance(val, (list, tuple)):
             val = [val]
         m3 = []
         for v in val:
@@ -280,7 +280,7 @@ class Model3d(MagicProperties):
         return m3
 
     def add_trace(
-        self, trace, show=True, backend="matplotlib", coordsargs=None, makedefault=False
+        self, trace, show=True, backend="matplotlib", coordsargs=None, scale=1, makedefault=False
     ):
         """creates an additional user-defined 3d model object which is positioned relatively
         to the main object to be displayed and moved automatically with it. This feature also allows
@@ -303,6 +303,11 @@ class Model3d(MagicProperties):
             by default: `{"x": "x", "y": "y", "z": "z"}`
             if False, object is not rotated
 
+        scale: float, default=1
+            scaling factor by which the trace vertices coordinates should be multiplied by. Be aware
+            that if the object is not centered at the global CS origin, its position will
+            also be scaled.
+
         makedefault: bool
             If `True`, it replaces the default 3D-representation.
             If `False`, it adds the current trace to the default 3D-representation."""
@@ -310,6 +315,7 @@ class Model3d(MagicProperties):
         new_trace = Trace3d(
             trace=trace,
             show=show,
+            scale=scale,
             backend=backend,
             coordsargs=coordsargs,
             makedefault=makedefault,
@@ -332,6 +338,11 @@ class Trace3d(MagicProperties):
     trace: dict or callable, default=None
         dictionary containing the `x,y,z,i,j,k` keys/values pairs for a model3d object
 
+    scale: float, default=1
+        scaling factor by which the trace vertices coordinates should be multiplied by. Be aware
+        that if the object is not centered at the global CS origin, its position will
+        also be scaled.
+
     backend:
         plotting backend corresponding to the trace.
         Can be one of `['matplotlib', 'plotly']`
@@ -349,6 +360,7 @@ class Trace3d(MagicProperties):
     def __init__(
         self,
         trace=None,
+        scale=1,
         show=True,
         backend="matplotlib",
         coordsargs=None,
@@ -357,6 +369,7 @@ class Trace3d(MagicProperties):
     ):
         super().__init__(
             trace=trace,
+            scale=scale,
             show=show,
             backend=backend,
             coordsargs=coordsargs,
@@ -379,6 +392,23 @@ class Trace3d(MagicProperties):
             f" but received {repr(val)} instead"
         )
         self._show = val
+
+    @property
+    def scale(self):
+        """
+        scaling factor by which the trace vertices coordinates should be multiplied by. Be aware
+        that if the object is not centered at the global CS origin, its position will
+        also be scaled.
+        """
+        return self._scale
+
+    @scale.setter
+    def scale(self, val):
+        assert isinstance(val, (int, float)) and val > 0, (
+            f"the `scale` property of {type(self).__name__} must be a strictly positive number"
+            f" but received {repr(val)} instead"
+        )
+        self._scale = val
 
     @property
     def coordsargs(self):

--- a/magpylib/display/style/__init__.py
+++ b/magpylib/display/style/__init__.py
@@ -1,0 +1,15 @@
+"""style package"""
+
+__all__ = [
+    "MagnetStyle",
+    "CurrentStyle",
+    "DipoleStyle",
+    "SensorStyle",
+]
+
+from magpylib._src.style import (
+    MagnetStyle,
+    CurrentStyle,
+    DipoleStyle,
+    SensorStyle,
+)

--- a/tests/test_Coumpound_setters.py
+++ b/tests/test_Coumpound_setters.py
@@ -39,7 +39,7 @@ def make_wheel(Ncubes=6, height=10, diameter=36, path_len=5, name=None):
         base_vertices=Ncubes, diameter=diameter + height * 2, height=height * 0.5
     )
     trace_plotly = {**trace, "opacity": 0.5, "color": "blue"}
-    c.style.model3d.extra = [dict(backend="plotly", trace=trace_plotly)]
+    c.style.model3d.data = [dict(backend="plotly", trace=trace_plotly)]
     return c
 
 
@@ -54,8 +54,8 @@ def create_compound_set(show=False, **kwargs):
         magnetization_color_south="cyan",
     )
     c2 = make_wheel(name="Magnetic Wheel before")
-    c2.style.model3d.extra[0].trace["color"] = "red"
-    c2.style.model3d.extra[0].trace["opacity"] = 0.1
+    c2.style.model3d.data[0].trace["color"] = "red"
+    c2.style.model3d.data[0].trace["opacity"] = 0.1
     c2.set_children_styles(path_show=False, opacity=0.1)
     for k, v in kwargs.items():
         setattr(c1, k, eval(v))

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -32,7 +32,7 @@ bad_inputs = {
         False,
     ),  # DOES NOT RAISE, transforms everything into str
     "display_style_base_opacity": (-1,),  # 0<=float<=1
-    "display_style_base_model3d_show": ("notbool",),
+    "display_style_base_model3d_showdefault": ("notbool",),
     "display_style_base_color": ("wrongcolor",),  # color
     "display_style_magnet_magnetization_show": ("notbool",),
     "display_style_magnet_magnetization_size": (-1,),  # float>=0
@@ -113,7 +113,7 @@ good_inputs = {
     "display_style_base_description_show": (True, False),  # bool
     "display_style_base_description_text": ("a string",),  # string
     "display_style_base_opacity": (0, 0.5, 1),  # 0<=float<=1
-    "display_style_base_model3d_show": (True, False),
+    "display_style_base_model3d_showdefault": (True, False),
     "display_style_base_color": ("blue", "#2E91E5"),  # color
     "display_style_magnet_magnetization_show": (True, False),
     "display_style_magnet_magnetization_size": (0, 1),  # float>=0

--- a/tests/test_display_matplotlib.py
+++ b/tests/test_display_matplotlib.py
@@ -156,7 +156,7 @@ def test_matplotlib_model3d_extra():
     ).rotate_from_angax(np.linspace(72,360,5), "z", anchor=(0, 0, 0), start=0)
     cuboid.style.model3d.show = False
     ax = plt.subplot(projection="3d")
-    cuboid.style.model3d.extra = [
+    cuboid.style.model3d.data = [
         {
             "backend": "matplotlib",
             "trace": {
@@ -171,7 +171,7 @@ def test_matplotlib_model3d_extra():
     ]
     with pytest.raises(ValueError): # should fail because of invalid coordsargs
         x = cuboid.show(canvas=ax, style_path_show=1)
-    cuboid.style.model3d.extra[0].coordsargs = {"x": "xs", "y": "ys", "z": "zs"}
+    cuboid.style.model3d.data[0].coordsargs = {"x": "xs", "y": "ys", "z": "zs"}
     x = cuboid.show(canvas=ax, style_path_show=1)
 
     assert x is None, "display test fail"
@@ -181,7 +181,7 @@ def test_matplotlib_model3d_extra():
     x,y,z = [cube[k] for k in 'xyz']
     triangles = np.array([i, j, k]).T
     trace = dict(type="plot_trisurf", args=(x, y, z), triangles=triangles)
-    cuboid.style.model3d.extra = [
+    cuboid.style.model3d.data = [
         {
             "backend": "matplotlib",
             "coordsargs": {"x": "args[0]", "y": "args[1]", "z": "args[2]"},

--- a/tests/test_display_matplotlib.py
+++ b/tests/test_display_matplotlib.py
@@ -155,6 +155,7 @@ def test_matplotlib_model3d_extra():
         magnetization=(1, 0, 0), dimension=(3, 3, 3), position=(10, 0, 0)
     ).rotate_from_angax(np.linspace(72,360,5), "z", anchor=(0, 0, 0), start=0)
     ax = plt.subplot(projection="3d")
+    cuboid.style.model3d.showdefault = False
     cuboid.style.model3d.data = [
         {
             "backend": "matplotlib",
@@ -166,7 +167,6 @@ def test_matplotlib_model3d_extra():
                 "ls": "-",
             },
             "show": True,
-            "makedefault":True,
         }
     ]
     with pytest.raises(ValueError): # should fail because of invalid coordsargs
@@ -181,13 +181,13 @@ def test_matplotlib_model3d_extra():
     x,y,z = [cube[k] for k in 'xyz']
     triangles = np.array([i, j, k]).T
     trace = dict(type="plot_trisurf", args=(x, y, z), triangles=triangles)
+    cuboid.style.model3d.showdefault = False
     cuboid.style.model3d.data = [
         {
             "backend": "matplotlib",
             "coordsargs": {"x": "args[0]", "y": "args[1]", "z": "args[2]"},
             "trace": trace,
             "show": True,
-            "makedefault": True,
         }
     ]
     x = cuboid.show(canvas=ax, style_path_show=1)

--- a/tests/test_display_matplotlib.py
+++ b/tests/test_display_matplotlib.py
@@ -154,7 +154,6 @@ def test_matplotlib_model3d_extra():
     cuboid = magpy.magnet.Cuboid(
         magnetization=(1, 0, 0), dimension=(3, 3, 3), position=(10, 0, 0)
     ).rotate_from_angax(np.linspace(72,360,5), "z", anchor=(0, 0, 0), start=0)
-    cuboid.style.model3d.show = False
     ax = plt.subplot(projection="3d")
     cuboid.style.model3d.data = [
         {
@@ -167,6 +166,7 @@ def test_matplotlib_model3d_extra():
                 "ls": "-",
             },
             "show": True,
+            "makedefault":True,
         }
     ]
     with pytest.raises(ValueError): # should fail because of invalid coordsargs

--- a/tests/test_display_matplotlib.py
+++ b/tests/test_display_matplotlib.py
@@ -187,6 +187,7 @@ def test_matplotlib_model3d_extra():
             "coordsargs": {"x": "args[0]", "y": "args[1]", "z": "args[2]"},
             "trace": trace,
             "show": True,
+            "makedefault": True,
         }
     ]
     x = cuboid.show(canvas=ax, style_path_show=1)

--- a/tests/test_display_plotly.py
+++ b/tests/test_display_plotly.py
@@ -194,7 +194,7 @@ def test_extra_model3d():
     magpy.defaults.display.backend = "plotly"
     cuboid = Cuboid((1, 2, 3), (1, 2, 3))
     cuboid.move(np.linspace((.4,.4,.4), (12.4,12.4,12.4), 33), start=-1)
-    cuboid.style.model3d.extra = [
+    cuboid.style.model3d.data = [
         {
             "backend": "plotly",
             "trace": {
@@ -223,7 +223,7 @@ def test_extra_model3d():
     fig = go.Figure()
     x = cuboid.show(canvas=fig, style=dict(model3d_show=True))
     assert x is None, "display test fail"
-    cuboid.style.model3d.extra[0].show = False
+    cuboid.style.model3d.data[0].show = False
     x = cuboid.show(canvas=fig)
     assert x is None, "display test fail"
     coll = magpy.Collection(cuboid)
@@ -234,7 +234,7 @@ def test_extra_model3d():
         style=dict(model3d_show=False),
     )
     assert x is None, "display test fail"
-    cuboid.style.model3d.extra = {
+    cuboid.style.model3d.data = {
         "backend": "plotly",
         "trace": {
             "type": "scatter3d",
@@ -245,7 +245,7 @@ def test_extra_model3d():
         },
         "show": True,
     }
-    cuboid.style.model3d.extra[0].show = False
+    cuboid.style.model3d.data[0].show = False
     x = cuboid.show(canvas=fig, style_path_show=False, style=dict(model3d_show=False),)
     assert x is None, "display test fail"
 

--- a/tests/test_display_plotly.py
+++ b/tests/test_display_plotly.py
@@ -17,7 +17,7 @@ def test_Cylinder_display():
     x = src.show(canvas=fig, style_path_show=15)
     assert x is None, "path should revert to True"
 
-    src.move(np.linspace((.4,.4,.4), (12.4,12.4,12.4), 33), start=-1)
+    src.move(np.linspace((0.4, 0.4, 0.4), (12.4, 12.4, 12.4), 33), start=-1)
     x = src.show(
         canvas=fig,
         style_path_show=False,
@@ -35,7 +35,7 @@ def test_CylinderSegment_display():
     x = src.show(canvas=fig, style_path_show=15)
     assert x is None, "path should revert to True"
 
-    src.move(np.linspace((.4,.4,.4), (12.4,12.4,12.4), 33), start=-1)
+    src.move(np.linspace((0.4, 0.4, 0.4), (12.4, 12.4, 12.4), 33), start=-1)
     x = src.show(
         canvas=fig,
         style_path_show=False,
@@ -53,7 +53,7 @@ def test_Sphere_display():
     x = src.show(canvas=fig, style_path_show=15)
     assert x is None, "path should revert to True"
 
-    src.move(np.linspace((.4,.4,.4), (8,8,8), 33), start=-1)
+    src.move(np.linspace((0.4, 0.4, 0.4), (8, 8, 8), 33), start=-1)
     x = src.show(canvas=fig, style_path_show=False, style_magnetization_show=True)
     assert x is None, "display test fail"
 
@@ -62,7 +62,7 @@ def test_Cuboid_display():
     """testing display"""
     magpy.defaults.display.backend = "plotly"
     src = Cuboid((1, 2, 3), (1, 2, 3))
-    src.move(np.linspace((.1,.1,.1), (2,2,2), 20), start=-1)
+    src.move(np.linspace((0.1, 0.1, 0.1), (2, 2, 2), 20), start=-1)
     x = src.show(style_path_show=5, style_magnetization_show=True, renderer="json")
     assert x is None, "display test fail"
 
@@ -79,7 +79,7 @@ def test_Sensor_display():
     x = sens_nopix.show(canvas=fig, style_description_text="mysensor")
     assert x is None, "display test fail"
     sens = magpy.Sensor(pixel=[(1, 2, 3), (2, 3, 4)])
-    sens.move(np.linspace((.4,.4,.4), (12.4,12.4,12.4), 33), start=-1)
+    sens.move(np.linspace((0.4, 0.4, 0.4), (12.4, 12.4, 12.4), 33), start=-1)
     x = sens.show(canvas=fig, markers=[(100, 100, 100)], style_path_show=15)
     assert x is None, "display test fail"
     x = sens.show(canvas=fig, markers=[(100, 100, 100)], style_path_show=False)
@@ -119,7 +119,7 @@ def test_dipole_display():
     dip1 = magpy.misc.Dipole(moment=(1, 2, 3), position=(1, 1, 1))
     dip2 = magpy.misc.Dipole(moment=(1, 2, 3), position=(2, 2, 2))
     dip3 = magpy.misc.Dipole(moment=(1, 2, 3), position=(3, 3, 3))
-    dip2.move(np.linspace((.4,.4,.4), (2,2,2), 5), start=-1)
+    dip2.move(np.linspace((0.4, 0.4, 0.4), (2, 2, 2), 5), start=-1)
     x = dip1.show(canvas=fig, style_pivot="tail")
     assert x is None, "display test fail"
     x = dip2.show(canvas=fig, style_path_show=2, style_pivot="tip")
@@ -135,7 +135,7 @@ def test_circular_line_display():
     fig = go.Figure()
     src1 = magpy.current.Loop(1, 2)
     src2 = magpy.current.Loop(1, 2)
-    src1.move(np.linspace((.4,.4,.4), (2,2,2), 5), start=-1)
+    src1.move(np.linspace((0.4, 0.4, 0.4), (2, 2, 2), 5), start=-1)
     src3 = magpy.current.Line(1, [(0, 0, 0), (1, 1, 1), (2, 2, 2)])
     src4 = magpy.current.Line(1, [(0, 0, 0), (1, 1, 1), (2, 2, 2)])
     src3.move([(0.4, 0.4, 0.4)] * 5, start=-1)
@@ -193,7 +193,7 @@ def test_extra_model3d():
     """test diplay when object has an extra model object attached"""
     magpy.defaults.display.backend = "plotly"
     cuboid = Cuboid((1, 2, 3), (1, 2, 3))
-    cuboid.move(np.linspace((.4,.4,.4), (12.4,12.4,12.4), 33), start=-1)
+    cuboid.move(np.linspace((0.4, 0.4, 0.4), (12.4, 12.4, 12.4), 33), start=-1)
     cuboid.style.model3d.data = [
         {
             "backend": "plotly",
@@ -218,6 +218,7 @@ def test_extra_model3d():
                 "z": [-1, -1, -1, -1, 1, 1, 1, 1],
             },
             "show": True,
+            "makedefault":True,
         },
     ]
     fig = go.Figure()
@@ -227,24 +228,23 @@ def test_extra_model3d():
     x = cuboid.show(canvas=fig)
     assert x is None, "display test fail"
     coll = magpy.Collection(cuboid)
-    coll.rotate_from_angax(45, 'z')
-    x = magpy.show(coll,
-        canvas=fig,
-        animation=True,
-        style=dict(model3d_show=False),
-    )
-    assert x is None, "display test fail"
-    cuboid.style.model3d.data = {
-        "backend": "plotly",
-        "trace": {
-            "type": "scatter3d",
-            "x": [-1, -1, 1, 1, -1, -1, -1, -1, -1, 1, 1, 1, 1, 1, 1, -1],
-            "y": [-1, 1, 1, -1, -1, -1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1],
-            "z": [-1, -1, -1, -1, -1, 1, 1, -1, 1, 1, -1, 1, 1, -1, 1, 1],
-            "mode": "lines",
-        },
-        "show": True,
+    coll.rotate_from_angax(45, "z")
+    x = magpy.show(coll, canvas=fig, animation=True, style=dict(model3d_show=False),)
+    my_callable_trace = lambda: {
+        "type": "scatter3d",
+        "x": [-1, -1, 1, 1, -1, -1, -1, -1, -1, 1, 1, 1, 1, 1, 1, -1],
+        "y": [-1, 1, 1, -1, -1, -1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1],
+        "z": [-1, -1, -1, -1, -1, 1, 1, -1, 1, 1, -1, 1, 1, -1, 1, 1],
+        "mode": "lines",
     }
+    assert x is None, "display test fail"
+    cuboid.style.model3d.add_trace(
+        **{
+            "backend": "plotly",
+            "trace": my_callable_trace,
+            "show": True,
+        }
+    )
     cuboid.style.model3d.data[0].show = False
     x = cuboid.show(canvas=fig, style_path_show=False, style=dict(model3d_show=False),)
     assert x is None, "display test fail"
@@ -271,7 +271,7 @@ def test_display_warnings():
     magpy.defaults.display.animation.maxfps = 2
     magpy.defaults.display.animation.maxframes = 2
     src = Cuboid((1, 2, 3), (1, 2, 3))
-    src.move(np.linspace((.4,.4,.4), (4,4,4), 10), start=-1)
+    src.move(np.linspace((0.4, 0.4, 0.4), (4, 4, 4), 10), start=-1)
     fig = go.Figure()
 
     with pytest.warns(UserWarning):  # animation_fps to big warning

--- a/tests/test_display_plotly.py
+++ b/tests/test_display_plotly.py
@@ -216,6 +216,7 @@ def test_extra_model3d():
                 "x": [-1, -1, 1, 1, -1, -1, 1, 1],
                 "y": [-1, 1, 1, -1, -1, 1, 1, -1],
                 "z": [-1, -1, -1, -1, 1, 1, 1, 1],
+                "facecolor": ['red']*12,
             },
             "show": True,
             "makedefault":True,

--- a/tests/test_display_plotly.py
+++ b/tests/test_display_plotly.py
@@ -108,7 +108,7 @@ def test_col_display():
     pm2 = magpy.magnet.Cuboid((1, 2, 3), (1, 2, 3))
     col = magpy.Collection(pm1, pm2)
     x = col.show(canvas=fig)
-    assert x is None, "colletion display test fail"
+    assert x is None, "collection display test fail"
 
 
 def test_dipole_display():
@@ -194,6 +194,7 @@ def test_extra_model3d():
     magpy.defaults.display.backend = "plotly"
     cuboid = Cuboid((1, 2, 3), (1, 2, 3))
     cuboid.move(np.linspace((0.4, 0.4, 0.4), (12.4, 12.4, 12.4), 33), start=-1)
+    cuboid.style.model3d.showdefault = False
     cuboid.style.model3d.data = [
         {
             "backend": "plotly",
@@ -219,18 +220,17 @@ def test_extra_model3d():
                 "facecolor": ['red']*12,
             },
             "show": True,
-            "makedefault":True,
         },
     ]
     fig = go.Figure()
-    x = cuboid.show(canvas=fig, style=dict(model3d_show=True))
+    x = cuboid.show(canvas=fig, style=dict(model3d_showdefault=True))
     assert x is None, "display test fail"
     cuboid.style.model3d.data[0].show = False
     x = cuboid.show(canvas=fig)
     assert x is None, "display test fail"
     coll = magpy.Collection(cuboid)
     coll.rotate_from_angax(45, "z")
-    x = magpy.show(coll, canvas=fig, animation=True, style=dict(model3d_show=False),)
+    x = magpy.show(coll, canvas=fig, animation=True, style=dict(model3d_showdefault=False),)
     my_callable_trace = lambda: {
         "type": "scatter3d",
         "x": [-1, -1, 1, 1, -1, -1, -1, -1, -1, 1, 1, 1, 1, 1, 1, -1],
@@ -247,7 +247,7 @@ def test_extra_model3d():
         }
     )
     cuboid.style.model3d.data[0].show = False
-    x = cuboid.show(canvas=fig, style_path_show=False, style=dict(model3d_show=False),)
+    x = cuboid.show(canvas=fig, style_path_show=False, style=dict(model3d_showdefault=False),)
     assert x is None, "display test fail"
 
 

--- a/tests/test_missing_plotly.py
+++ b/tests/test_missing_plotly.py
@@ -1,5 +1,4 @@
 import sys
-from importlib import reload
 from unittest import mock
 import pytest
 import magpylib as magpy


### PR DESCRIPTION
# Notes
This PR aims to slightly rework the extra `model3d` syntax.

- `style.model3d.extra` is now `style.model3d.data`
- `style.model3d` has a new `add_trace` method which allows easy building of extra traces.
- 'style.model3d.show` is replaced by `style.model3d.showdefault` which hides only the default trace
- library docstrings for `Magnet`, `Current`, `Dipole` and `Sensor` styles have been updated and added to the top level library and the docs under `magpylib.display.style` 