### PR TITLE
Basegeo copy method

### DIFF
--- a/magpylib/_src/obj_classes/class_BaseGeo.py
+++ b/magpylib/_src/obj_classes/class_BaseGeo.py
@@ -103,8 +103,8 @@ class BaseGeo(BaseTransform):
         if style is not None or kwargs: #avoid style creation cost if not needed
             self.style = self._process_style_kwargs(style=style, **kwargs)
 
-    #@staticmethod
-    def _process_style_kwargs(self, style=None, **kwargs):
+    @staticmethod
+    def _process_style_kwargs(style=None, **kwargs):
         if kwargs:
             if style is None:
                 style = {}

--- a/magpylib/_src/obj_classes/class_BaseGeo.py
+++ b/magpylib/_src/obj_classes/class_BaseGeo.py
@@ -291,12 +291,35 @@ class BaseGeo(BaseTransform):
         return self
 
     def copy(self, **kwargs):
-        """returns an inpendant copy of the object"""
+        """´Returns a copy of the current object instance. The `copy` method returns a deep copy of
+        the object, that is independant of the original object.
+
+        Parameters
+        ----------
+            kwargs: dict, optional
+                keyword arguments to be transmitted to the newly created object. Can be for example
+                `'position'`,`'orientation'`, `'style'` etc.
+
+        Examples
+        --------
+        Create an object and copy to an another position
+
+        >>> import magpylib as magpy
+        >>> obj = magpy.Sensor(position=(1,2,3))
+        >>> print(obj.position)
+        [1. 2. 3.]
+        >>> obj2 = obj.copy(position=(2,6,10))
+        >>> print(obj.position)
+        [1. 2. 3.]
+        >>> print(obj2.position)
+        [2. 6. 10.]
+
+        """
         # pylint: disable=import-outside-toplevel
         from copy import deepcopy
         name = self.style.name
         if name is None:
-            name = f"{type(self).__name__}_copy_1"
+            name = f"{type(self).__name__}_01"
         else:
             name = add_iteration_suffix(name)
         obj_copy = deepcopy(self)

--- a/magpylib/_src/obj_classes/class_BaseGeo.py
+++ b/magpylib/_src/obj_classes/class_BaseGeo.py
@@ -12,6 +12,7 @@ from magpylib._src.input_checks import (
     check_vector_type,
     check_path_format,
     check_rot_type)
+from magpylib._src.utility import add_iteration_suffix
 
 
 def pad_slice_path(path1, path2):
@@ -288,3 +289,18 @@ class BaseGeo(BaseTransform):
         self.position = (0,0,0)
         self.orientation = None
         return self
+
+    def copy(self, **kwargs):
+        """returns an inpendant copy of the object"""
+        # pylint: disable=import-outside-toplevel
+        from copy import deepcopy
+        name = self.style.name
+        if name is None:
+            name = f"{type(self).__name__}_copy_1"
+        else:
+            name = add_iteration_suffix(name)
+        obj_copy = deepcopy(self)
+        obj_copy.style.name = name
+        for k,v in kwargs.items():
+            setattr(obj_copy, k,v)
+        return obj_copy

--- a/magpylib/_src/obj_classes/class_BaseGeo.py
+++ b/magpylib/_src/obj_classes/class_BaseGeo.py
@@ -100,7 +100,12 @@ class BaseGeo(BaseTransform):
 
         # style
         self.style_class = self._get_style_class()
-        if style is not None or kwargs:
+        if style is not None or kwargs: #avoid style creation cost if not needed
+            self.style = self._process_style_kwargs(style=style, **kwargs)
+
+    #@staticmethod
+    def _process_style_kwargs(self, style=None, **kwargs):
+        if kwargs:
             if style is None:
                 style = {}
             style_kwargs = {}
@@ -112,7 +117,7 @@ class BaseGeo(BaseTransform):
                         f"__init__() got an unexpected keyword argument {k!r}"
                     )
             style.update(**style_kwargs)
-            self.style = style
+        return style
 
     def _init_position_orientation(self, position, orientation):
         """
@@ -324,6 +329,13 @@ class BaseGeo(BaseTransform):
             name = add_iteration_suffix(name)
         obj_copy = deepcopy(self)
         obj_copy.style.name = name
+        style_kwargs = {}
         for k,v in kwargs.items():
-            setattr(obj_copy, k,v)
+            if k.startswith('style'):
+                style_kwargs[k] = v
+            else:
+                setattr(obj_copy, k,v)
+        if style_kwargs:
+            style_kwargs = self._process_style_kwargs(**style_kwargs)
+            obj_copy.style.update(style_kwargs)
         return obj_copy

--- a/magpylib/_src/obj_classes/class_Collection.py
+++ b/magpylib/_src/obj_classes/class_Collection.py
@@ -263,28 +263,6 @@ class BaseCollection(BaseDisplayRepr):
         self._update_src_and_sens()
         return self
 
-    def copy(self):
-        """
-        Returns a copy of the Collection.
-
-        Returns
-        -------
-        self: Collection
-
-        Examples
-        --------
-        Create a deep copy of the current Collection:
-
-        >>> import magpylib as magpy
-        >>> col = magpy.Collection()
-        >>> print(id(col))
-        2221754911040
-        >>> col2 = col.copy()
-        >>> print(id(col2))
-        2221760504160
-
-        """
-        return copy.copy(self)
 
     def set_children_styles(self, arg=None, **kwargs):
         """

--- a/magpylib/_src/obj_classes/class_Collection.py
+++ b/magpylib/_src/obj_classes/class_Collection.py
@@ -1,5 +1,4 @@
 """Collection class code"""
-import copy
 from magpylib._src.utility import (
     format_obj_input,
     check_duplicates,

--- a/magpylib/_src/utility.py
+++ b/magpylib/_src/utility.py
@@ -380,4 +380,3 @@ def cyl_field_to_cart(phi, Br, Bphi=None):
         By = Br * np.sin(phi)
 
     return Bx, By
-

--- a/magpylib/_src/utility.py
+++ b/magpylib/_src/utility.py
@@ -338,9 +338,10 @@ def add_iteration_suffix(name):
     """
     adds iteration suffix. If name already ends with an integer it will continue iteration
     examples:
-        'col' -> 'col_1'
-        'col1' -> col2
-        'col_02 -> col_03'
+        'col' -> 'col_01'
+        'col' -> 'col_01'
+        'col1' -> 'col2'
+        'col_02' -> 'col_03'
     """
     # pylint: disable=import-outside-toplevel
     import re
@@ -348,7 +349,7 @@ def add_iteration_suffix(name):
     m = re.search(r"\d+$", name)
     n = "00"
     endstr = None
-    midchar = "_"
+    midchar = "_" if name[-1]!= '_' else ""
     if m is not None:
         midchar = ""
         n = m.group()

--- a/magpylib/_src/utility.py
+++ b/magpylib/_src/utility.py
@@ -49,6 +49,7 @@ ALLOWED_SENSORS_MSG = """Sensors must be either
 - Collection with at least one Sensor
 - 1D list thereof"""
 
+
 def wrong_obj_msg(*objs, allow="sources"):
     """return error message for wrong object type provided"""
     assert len(objs) <= 1, "only max one obj allowed"
@@ -77,8 +78,7 @@ def format_star_input(inp):
     return list(inp)
 
 
-def format_obj_input(
-    *objects: Sequence, allow="sources+sensors", warn=True) -> list:
+def format_obj_input(*objects: Sequence, allow="sources+sensors", warn=True) -> list:
     """tests and flattens potential input sources (sources, Collections, sequences)
 
     ### Args:
@@ -93,7 +93,7 @@ def format_obj_input(
     # pylint: disable=protected-access
 
     obj_list = []
-    flatten_collection = not 'collections' in allow.split("+")
+    flatten_collection = not "collections" in allow.split("+")
     for obj in objects:
         if isinstance(obj, (tuple, list)):
             obj_list += format_obj_input(
@@ -270,8 +270,8 @@ def filter_objects(obj_list, allow="sources+sensors", warn=True):
             allowed_list.extend(LIBRARY_SOURCES)
         elif allowed == "sensors":
             allowed_list.extend(LIBRARY_SENSORS)
-        elif allowed =='collections':
-            allowed_list.extend(['Collection'])
+        elif allowed == "collections":
+            allowed_list.extend(["Collection"])
     new_list = []
     for obj in obj_list:
         if obj._object_type in allowed_list:
@@ -334,13 +334,36 @@ def unit_prefix(number, unit="", precision=3, char_between="") -> str:
     return f"{new_number_str}{char_between}{prefix}{unit}"
 
 
+def add_iteration_suffix(name):
+    """
+    adds iteration suffix. If name already ends with an integer it will continue iteration
+    examples:
+        'col' -> 'col_1'
+        'col1' -> col2
+        'col_02 -> col_03'
+    """
+    # pylint: disable=import-outside-toplevel
+    import re
+
+    m = re.search(r"\d+$", name)
+    n = "00"
+    endstr = None
+    midchar = "_"
+    if m is not None:
+        midchar = ""
+        n = m.group()
+        endstr = -len(n)
+    name = f"{name[:endstr]}{midchar}{int(n)+1:0{len(n)}}"
+    return name
+
+
 def cart_to_cyl_coordinates(observer):
     """
     cartesian observer positions to cylindrical coordinates
     observer: ndarray, shape (n,3)
     """
     x, y, z = observer.T
-    r, phi = np.sqrt(x**2+y**2), np.arctan2(y, x)
+    r, phi = np.sqrt(x ** 2 + y ** 2), np.arctan2(y, x)
     return r, phi, z
 
 
@@ -349,10 +372,11 @@ def cyl_field_to_cart(phi, Br, Bphi=None):
     transform Br,Bphi to Bx, By
     """
     if Bphi is not None:
-        Bx = Br*np.cos(phi) - Bphi*np.sin(phi)
-        By = Br*np.sin(phi) + Bphi*np.cos(phi)
+        Bx = Br * np.cos(phi) - Bphi * np.sin(phi)
+        By = Br * np.sin(phi) + Bphi * np.cos(phi)
     else:
-        Bx = Br*np.cos(phi)
-        By = Br*np.sin(phi)
+        Bx = Br * np.cos(phi)
+        By = Br * np.sin(phi)
 
-    return Bx,By
+    return Bx, By
+

--- a/tests/test_obj_BaseGeo.py
+++ b/tests/test_obj_BaseGeo.py
@@ -96,8 +96,7 @@ def test_rotate_vs_rotate_from():
     bg2 = BaseGeo(position=(3, 4, 5), orientation=R.from_quat((0, 0, 0, 1)))
     angs = np.linalg.norm(roz, axis=1)
     for ang, ax in zip(angs, roz):
-        bg2.rotate_from_angax(
-            angle=[ang], degrees=False, axis=ax, anchor=(-3, -2, 1))
+        bg2.rotate_from_angax(angle=[ang], degrees=False, axis=ax, anchor=(-3, -2, 1))
     pos2 = bg2.position
     ori2 = bg2.orientation.as_quat()
 
@@ -346,21 +345,21 @@ def test_kwargs():
     with pytest.raises(TypeError):
         bg = BaseGeo((0, 0, 0), None, styl_name="name_02")
 
+
 def test_bad_sum():
     """test when adding bad objects"""
-    cuboid = magpy.magnet.Cuboid((1,1,1),(1,1,1))
+    cuboid = magpy.magnet.Cuboid((1, 1, 1), (1, 1, 1))
     with pytest.raises(MagpylibBadUserInput):
         1 + cuboid
 
 
-
 def test_copy():
     """test copying object"""
-    bg = BaseGeo((0, 0, 0), None, style=dict(name="name_01"))
-    bg2 = bg.copy(position=(10,0,0))
+    bg = BaseGeo((0, 0, 0), None)
+    bg2 = bg.copy(position=(10, 0, 0))
 
     # original object should not be affected"
-    np.testing.assert_allclose(bg.position, (0,0,0))
+    np.testing.assert_allclose(bg.position, (0, 0, 0))
 
     # check if name suffix iterated correctly
-    assert bg2.style.name == "name_02"
+    assert bg2.style.name == "BaseGeo_01"

--- a/tests/test_obj_BaseGeo.py
+++ b/tests/test_obj_BaseGeo.py
@@ -351,3 +351,5 @@ def test_bad_sum():
     cuboid = magpy.magnet.Cuboid((1,1,1),(1,1,1))
     with pytest.raises(MagpylibBadUserInput):
         1 + cuboid
+
+

--- a/tests/test_obj_BaseGeo.py
+++ b/tests/test_obj_BaseGeo.py
@@ -353,3 +353,14 @@ def test_bad_sum():
         1 + cuboid
 
 
+
+def test_copy():
+    """test copying object"""
+    bg = BaseGeo((0, 0, 0), None, style=dict(name="name_01"))
+    bg2 = bg.copy(position=(10,0,0))
+
+    # original object should not be affected"
+    np.testing.assert_allclose(bg.position, (0,0,0))
+
+    # check if name suffix iterated correctly
+    assert bg2.style.name == "name_02"

--- a/tests/test_obj_BaseGeo.py
+++ b/tests/test_obj_BaseGeo.py
@@ -355,11 +355,18 @@ def test_bad_sum():
 
 def test_copy():
     """test copying object"""
-    bg = BaseGeo((0, 0, 0), None)
-    bg2 = bg.copy(position=(10, 0, 0))
+    bg1 = BaseGeo((0, 0, 0), None, style_name='name1')
+    bg2 = BaseGeo((1,2,3), None)
+    bg1c = bg1.copy()
+    bg2c = bg2.copy(position=(10, 0, 0), style=dict(color='red'), style_color='orange')
 
     # original object should not be affected"
-    np.testing.assert_allclose(bg.position, (0, 0, 0))
+    np.testing.assert_allclose(bg1.position, (0, 0, 0))
+    np.testing.assert_allclose(bg2.position, (1 ,2, 3))
 
     # check if name suffix iterated correctly
-    assert bg2.style.name == "BaseGeo_01"
+    assert bg1c.style.name == "name2"
+    assert bg2c.style.name == "BaseGeo_01"
+
+    # check if style is passed correctly
+    assert bg2c.style.color == "orange"

--- a/tests/test_obj_Collection.py
+++ b/tests/test_obj_Collection.py
@@ -75,7 +75,7 @@ def test_Collection_basics():
         col1 += col2
         col1 - pm5 - pm4
         col1.remove(pm1)
-        col3 = col1.copy() + pm5 + pm4 + pm1
+        col3 = col1 + pm5 + pm4 + pm1
         col1.add(pm5, pm4, pm1)
 
         # 18 subsequent operations

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,53 +1,67 @@
+import pytest
 import numpy as np
 import magpylib as magpy
-from magpylib._src.utility import (check_duplicates,
-    filter_objects)
+from magpylib._src.utility import (
+    check_duplicates,
+    filter_objects,
+    add_iteration_suffix,
+)
 
 
 def test_duplicates():
     """ test duplicate elimination and sorting
     """
-    pm1 = magpy.magnet.Cuboid((1,2,3),(1,2,3))
-    pm2 = magpy.magnet.Cylinder((1,2,3),(1,2))
-    src_list = [pm1,pm2,pm1]
+    pm1 = magpy.magnet.Cuboid((1, 2, 3), (1, 2, 3))
+    pm2 = magpy.magnet.Cylinder((1, 2, 3), (1, 2))
+    src_list = [pm1, pm2, pm1]
     src_list_new = check_duplicates(src_list)
-    assert src_list_new == [pm1,pm2], 'duplicate elimination failed'
+    assert src_list_new == [pm1, pm2], "duplicate elimination failed"
+
 
 def test_filter_objects():
     """ tests elimination of unwanted types
     """
-    pm1 = magpy.magnet.Cuboid((1,2,3),(1,2,3))
-    pm2 = magpy.magnet.Cylinder((1,2,3),(1,2))
+    pm1 = magpy.magnet.Cuboid((1, 2, 3), (1, 2, 3))
+    pm2 = magpy.magnet.Cylinder((1, 2, 3), (1, 2))
     sens = magpy.Sensor()
-    src_list = [pm1,pm2,sens]
-    list_new = filter_objects(src_list, allow='sources')
-    assert list_new == [pm1,pm2], 'Failed to eliminate sensor'
+    src_list = [pm1, pm2, sens]
+    list_new = filter_objects(src_list, allow="sources")
+    assert list_new == [pm1, pm2], "Failed to eliminate sensor"
 
 
 def test_format_getBH_class_inputs():
     """ special case testing of different input formats
     """
-    possis = [3,3,3]
-    sens = magpy.Sensor(position=(3,3,3))
-    pm1 = magpy.magnet.Cuboid((11,22,33),(1,2,3))
-    pm2 = magpy.magnet.Cuboid((11,22,33),(1,2,3))
+    possis = [3, 3, 3]
+    sens = magpy.Sensor(position=(3, 3, 3))
+    pm1 = magpy.magnet.Cuboid((11, 22, 33), (1, 2, 3))
+    pm2 = magpy.magnet.Cuboid((11, 22, 33), (1, 2, 3))
     col = pm1 + pm2
 
     B1 = pm1.getB(possis)
     B2 = pm1.getB(sens)
-    assert np.allclose(B1,B2), 'pos_obs should give same as sens'
+    assert np.allclose(B1, B2), "pos_obs should give same as sens"
 
-    B3 = pm1.getB(sens,sens)
-    B4 = pm1.getB([sens,sens])
-    B44 = pm1.getB((sens,sens))
-    assert np.allclose(B3, B4), 'sens,sens should give same as [sens,sens]'
-    assert np.allclose(B3, B44), 'sens,sens should give same as (sens,sens)'
+    B3 = pm1.getB(sens, sens)
+    B4 = pm1.getB([sens, sens])
+    B44 = pm1.getB((sens, sens))
+    assert np.allclose(B3, B4), "sens,sens should give same as [sens,sens]"
+    assert np.allclose(B3, B44), "sens,sens should give same as (sens,sens)"
 
-    B1 = sens.getH(pm1)*4
-    B2 = sens.getH(pm1,pm2,col, sumup=True)
-    B3 = sens.getH([col])*2
-    B4 = sens.getH([col,pm1,pm2], sumup=True)
+    B1 = sens.getH(pm1) * 4
+    B2 = sens.getH(pm1, pm2, col, sumup=True)
+    B3 = sens.getH([col]) * 2
+    B4 = sens.getH([col, pm1, pm2], sumup=True)
 
-    assert np.allclose(B1,B2), 'src,src should give same as [src,src]'
-    assert np.allclose(B1,B3), 'src should give same as [src]'
-    assert np.allclose(B1,B4), 'src,src should give same as [src,src]'
+    assert np.allclose(B1, B2), "src,src should give same as [src,src]"
+    assert np.allclose(B1, B3), "src should give same as [src]"
+    assert np.allclose(B1, B4), "src,src should give same as [src,src]"
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [("col", "col_01"), ("col_", "col_01"), ("col1", "col2"), ("col_02", "col_03"),],
+)
+def test_add_iteration_suffix(name, expected):
+    """check if iteration suffix works correctly"""
+    assert add_iteration_suffix(name) == expected


### PR DESCRIPTION
# Description
This PR adds the `copy` method to the `BaseGeo` class. The method can also take keyword arguments as input, which are transmitted to the new object. 

# Notes
The `copy` method for the `Collection` was only returning a shallow copy. Since we have changed its philosophy, the `Collection` inherits from `BaseGeo` and also its new `copy` method which now returns a deep copy of the object.

# Example
```python
import magpylib as magpy

col = magpy.Collection(
    magpy.magnet.Cuboid(magnetization=(1,0,1), dimension=(8, 4 ,6), position=(0,0,0)),
    magpy.magnet.Cylinder(magnetization=(0,1,0), dimension=(8, 5), position=(-15,0,0)),
    style_name='Collection_01'
)
col2 = col.copy(position=(0,0,10), style=dict(color='red'), style_color='orange')
magpy.show(col, col2, style_magnetization_show=False, backend='plotly')
```


