### PR TITLE
`style.name` ➡️  `style.label`

### DIFF
--- a/docs/examples/plot_07_custom_source.md
+++ b/docs/examples/plot_07_custom_source.md
@@ -130,8 +130,8 @@ interp_cube = magpy.misc.CustomSource(field_B_lambda=field_B_lambda)
 ```{code-cell} ipython3
 matplotlib_trace = {
     'type':'plot',
-    'xs': np.array([-1, -1,  1,  1, -1, -1, -1, -1, -1,  1,  1,  1,  1, 1,  1, -1])* 0.5 * dim[0], 
-    'ys': np.array([-1,  1,  1, -1, -1, -1,  1,  1,  1,  1,  1,  1, -1, -1, -1, -1])* 0.5 * dim[0], 
+    'xs': np.array([-1, -1,  1,  1, -1, -1, -1, -1, -1,  1,  1,  1,  1, 1,  1, -1])* 0.5 * dim[0],
+    'ys': np.array([-1,  1,  1, -1, -1, -1,  1,  1,  1,  1,  1,  1, -1, -1, -1, -1])* 0.5 * dim[0],
     'zs': np.array([-1, -1, -1, -1, -1,  1,  1, -1,  1,  1, -1,  1,  1, -1,  1,  1])* 0.5 * dim[0],
     'ls': '-',
 }
@@ -149,17 +149,17 @@ plotly_trace = {
 # define user defined 3d representation for each plotting backend
 interp_cube.style.model3d.showdefault = False # hide default 3D-model
 interp_cube.style.model3d.add_trace(
-    backend='matplotlib', 
-    trace=matplotlib_trace, 
+    backend='matplotlib',
+    trace=matplotlib_trace,
     show=True,
     coordsargs={'x':'xs', 'y':'ys', 'z':'zs'}
 )
 interp_cube.style.model3d.add_trace(
-    backend='plotly', 
+    backend='plotly',
     trace=plotly_trace,
     show=True
 )
-interp_cube.style.name = 'Interpolated cuboid field'
+interp_cube.style.label = 'Interpolated cuboid field'
 ```
 
 ## Testing the accuracy of the interpolation

--- a/magpylib/_src/display/display_matplotlib.py
+++ b/magpylib/_src/display/display_matplotlib.py
@@ -434,12 +434,12 @@ def display_matplotlib(
                     draw_markers(
                         np.array([obj.position]), ax, obj_color, symbol="*", size=10
                     )
-                    name = (
-                        obj.style.name
-                        if obj.style.name is not None
+                    label = (
+                        obj.style.label
+                        if obj.style.label is not None
                         else str(type(obj).__name__)
                     )
-                    ax.text(*obj.position, name, horizontalalignment="center")
+                    ax.text(*obj.position, label, horizontalalignment="center")
                     points += [obj.position]
                 if faces is not None:
                     faced_objects_color += [obj_color]

--- a/magpylib/_src/display/plotly/plotly_display.py
+++ b/magpylib/_src/display/plotly/plotly_display.py
@@ -423,7 +423,7 @@ def _update_mag_mesh(
 
 def get_name_and_suffix(default_name, default_suffix, style):
     """provides legend entry based on name and suffix"""
-    name = default_name if style.name is None else style.name
+    name = default_name if style.label is None else style.label
     if style.description.show and style.description.text is None:
         name_suffix = default_suffix
     elif not style.description.show:
@@ -606,16 +606,16 @@ def get_plotly_traces(
         trace = merge_traces(*path_traces)
         for ind, traces_extra in enumerate(path_traces_extra.values()):
             extra_model3d_trace = merge_traces(*traces_extra)
-            name = (
-                input_obj.style.name
-                if input_obj.style.name is not None
+            label = (
+                input_obj.style.label
+                if input_obj.style.label is not None
                 else str(type(input_obj).__name__)
             )
             extra_model3d_trace.update(
                 {
                     "legendgroup": legendgroup,
                     "showlegend": showlegend and ind == 0 and not trace,
-                    "name": name,
+                    "name": label,
                 }
             )
             traces.append(extra_model3d_trace)
@@ -709,7 +709,7 @@ def draw_frame(objs, color_sequence, zoom, autosize=None, **kwargs) -> Tuple:
                     if getattr(subobj, "children", None) is not None:
                         first_shown = any(m3.show for m3 in obj.style.model3d.data)
                     showlegend = True
-                    legendtext = getattr(getattr(obj, "style", None), "name", None)
+                    legendtext = getattr(getattr(obj, "style", None), "label", None)
                     legendtext = f"{obj!r}" if legendtext is None else legendtext
                 else:
                     legendtext = None
@@ -1108,8 +1108,8 @@ def display_plotly(
 
     if obj_list:
         style = getattr(obj_list[0], "style", None)
-        name = getattr(style, "name", None)
-        title = name if len(obj_list) == 1 else None
+        label = getattr(style, "label", None)
+        title = label if len(obj_list) == 1 else None
     else:
         title = "No objects to be displayed"
 

--- a/magpylib/_src/obj_classes/class_BaseDisplayRepr.py
+++ b/magpylib/_src/obj_classes/class_BaseDisplayRepr.py
@@ -23,6 +23,6 @@ class BaseDisplayRepr:
     def __repr__(self) -> str:
         name = getattr(self, "name", None)
         if name is None and hasattr(self, "style"):
-            name = getattr(getattr(self, "style"), "name", None)
-        name_str = "" if name is None else f", name={name!r}"
+            name = getattr(getattr(self, "style"), "label", None)
+        name_str = "" if name is None else f", label={name!r}"
         return f"{type(self).__name__}(id={id(self)!r}{name_str})"

--- a/magpylib/_src/obj_classes/class_BaseGeo.py
+++ b/magpylib/_src/obj_classes/class_BaseGeo.py
@@ -322,13 +322,13 @@ class BaseGeo(BaseTransform):
         """
         # pylint: disable=import-outside-toplevel
         from copy import deepcopy
-        name = self.style.name
-        if name is None:
-            name = f"{type(self).__name__}_01"
+        label = self.style.label
+        if label is None:
+            label = f"{type(self).__name__}_01"
         else:
-            name = add_iteration_suffix(name)
+            label = add_iteration_suffix(label)
         obj_copy = deepcopy(self)
-        obj_copy.style.name = name
+        obj_copy.style.label = label
         style_kwargs = {}
         for k,v in kwargs.items():
             if k.startswith('style'):

--- a/magpylib/_src/style.py
+++ b/magpylib/_src/style.py
@@ -76,7 +76,7 @@ class BaseStyle(MagicProperties):
 
     Properties
     ----------
-    label : str, default=None
+    label: str, default=None
         label of the class instance, can be any string.
 
     description: dict or Description, default=None
@@ -656,7 +656,7 @@ class MagnetStyle(BaseStyle, MagnetProperties):
 
     Properties
     ----------
-    label : str, default=None
+    label: str, default=None
         label of the class instance, can be any string.
 
     description: dict or Description, default=None
@@ -846,7 +846,7 @@ class SensorStyle(BaseStyle, SensorProperties):
 
     Properties
     ----------
-    label : str, default=None
+    label: str, default=None
         label of the class instance, can be any string.
 
     description: dict or Description, default=None
@@ -983,7 +983,7 @@ class CurrentStyle(BaseStyle, CurrentProperties):
 
     Properties
     ----------
-    label : str, default=None
+    label: str, default=None
         label of the class instance, can be any string.
 
     description: dict or Description, default=None
@@ -1219,7 +1219,7 @@ class DipoleStyle(BaseStyle, DipoleProperties):
 
     Properties
     ----------
-    label : str, default=None
+    label: str, default=None
         label of the class instance, can be any string.
 
     description: dict or Description, default=None

--- a/magpylib/_src/style.py
+++ b/magpylib/_src/style.py
@@ -74,7 +74,7 @@ class BaseStyle(MagicProperties):
     """
     Base class for display styling options of `BaseGeo` objects
 
-    Properties
+    Parameters
     ----------
     label: str, default=None
         label of the class instance, can be any string.
@@ -185,7 +185,7 @@ class Description(MagicProperties):
     """
     Defines properties for a description object
 
-    Properties
+    Parameters
     ----------
     text: str, default=None
         Object description text
@@ -228,7 +228,7 @@ class Model3d(MagicProperties):
     """
     Defines properties for the 3d model representation of the magpylib objects
 
-    Properties
+    Parameters
     ----------
     showdefault: bool, default=True
         Shows/hides default 3D-model
@@ -320,7 +320,7 @@ class Trace3d(MagicProperties):
     to the main object to be displayed and moved automatically with it. This feature also allows
     the user to replace the original 3d representation of the object
 
-    Properties
+    Parameters
     ----------
     show : bool, default=None
         shows/hides model3d object based on provided trace:
@@ -450,7 +450,7 @@ class Magnetization(MagicProperties):
     """
     Defines magnetization styling properties
 
-    Properties
+    Parameters
     ----------
     show : bool, default=None
         if `True` shows magnetization direction based on active plotting backend
@@ -510,7 +510,7 @@ class MagnetizationColor(MagicProperties):
 
     Note: This feature is only relevant for the plotly backend.
 
-    Properties
+    Parameters
     ----------
     north: str, default=None
         defines the color of the magnetic north pole
@@ -615,7 +615,7 @@ class MagnetProperties:
     """
     Defines the specific styling properties of objects of the `magnet` family
 
-    Properties
+    Parameters
     ----------
     magnetization: dict or Magnetization, default=None
         Magnetization styling with `'show'`, `'size'`, `'color'` properties
@@ -641,7 +641,7 @@ class Magnet(MagicProperties, MagnetProperties):
     """
     Defines the specific styling properties of objects of the `magnet` family
 
-    Properties
+    Parameters
     ----------
     magnetization: dict or Magnetization, default=None
 
@@ -654,7 +654,7 @@ class Magnet(MagicProperties, MagnetProperties):
 class MagnetStyle(BaseStyle, MagnetProperties):
     """Defines the styling properties of objects of the `magnet` family with base properties
 
-    Properties
+    Parameters
     ----------
     label: str, default=None
         label of the class instance, can be any string.
@@ -777,7 +777,7 @@ class SensorProperties:
     """
     Defines the specific styling properties of objects of the `sensor` family
 
-    Properties
+    Parameters
     ----------
     size: float, default=None
         positive float for relative sensor to canvas size
@@ -825,7 +825,7 @@ class Sensor(MagicProperties, SensorProperties):
     """
     Defines the specific styling properties of objects of the `sensor` family
 
-    Properties
+    Parameters
     ----------
     size: float, default=None
         positive float for relative sensor to canvas size
@@ -844,7 +844,7 @@ class Sensor(MagicProperties, SensorProperties):
 class SensorStyle(BaseStyle, SensorProperties):
     """Defines the styling properties of objects of the `sensor` family with base properties
 
-    Properties
+    Parameters
     ----------
     label: str, default=None
         label of the class instance, can be any string.
@@ -886,7 +886,7 @@ class Pixel(MagicProperties):
     """
     Defines the styling properties of sensor pixels
 
-    Properties
+    Parameters
     ----------
     size: float, default=None
         defines the relative pixel size:
@@ -948,7 +948,7 @@ class CurrentProperties:
     """
     Defines the specific styling properties of objects of the `current` family
 
-    Properties
+    Parameters
     ----------
     arrow: dict or Arrow, default=None
         Arrow class or dict with `'show'`, `'size'` properties/keys
@@ -968,7 +968,7 @@ class Current(MagicProperties, CurrentProperties):
     """
     Defines the specific styling properties of objects of the `current` family
 
-    Properties
+    Parameters
     ----------
     arrow: dict or Arrow, default=None
         Arrow class or dict with 'show', 'size' properties/keys
@@ -981,7 +981,7 @@ class Current(MagicProperties, CurrentProperties):
 class CurrentStyle(BaseStyle, CurrentProperties):
     """Defines the styling properties of objects of the `current` family and base properties
 
-    Properties
+    Parameters
     ----------
     label: str, default=None
         label of the class instance, can be any string.
@@ -1017,7 +1017,7 @@ class Arrow(MagicProperties):
     """
     Defines the styling properties of current arrows
 
-    Properties
+    Parameters
     ----------
     show: bool, default=None
         if `True` current direction is shown with an arrow
@@ -1076,7 +1076,7 @@ class Marker(MagicProperties):
     """
     Defines the styling properties of plot markers
 
-    Properties
+    Parameters
     ----------
     size: float, default=None
         marker size
@@ -1131,7 +1131,7 @@ class Markers(BaseStyle):
     """
     Defines the styling properties of the markers trace
 
-    Properties
+    Parameters
     ----------
     marker: dict, Markers, default=None
         Markers class with 'color', 'symbol', 'size' properties, or dictionary with equivalent
@@ -1155,7 +1155,7 @@ class DipoleProperties:
     """
     Defines the specific styling properties of the objects of the `dipole` family
 
-    Properties
+    Parameters
     ----------
     size: float, default=None
         positive float for relative dipole to size to canvas size
@@ -1200,7 +1200,7 @@ class Dipole(MagicProperties, DipoleProperties):
     """
     Defines the specific styling properties of the objects of the `dipole` family
 
-    Properties
+    Parameters
     ----------
     size: float, default=None
         positive float for relative dipole to size to canvas size
@@ -1217,7 +1217,7 @@ class Dipole(MagicProperties, DipoleProperties):
 class DipoleStyle(BaseStyle, DipoleProperties):
     """Defines the styling properties of the objects of the `dipole` family and base properties
 
-    Properties
+    Parameters
     ----------
     label: str, default=None
         label of the class instance, can be any string.
@@ -1257,7 +1257,7 @@ class Path(MagicProperties):
     """
     Defines the styling properties of an object's path
 
-    Properties
+    Parameters
     ----------
     marker: dict, Markers, default=None
         Markers class with 'color', 'symbol', 'size' properties, or dictionary with equivalent
@@ -1371,7 +1371,7 @@ class Line(MagicProperties):
     """
     Defines Line styling properties
 
-    Properties
+    Parameters
     ----------
     style: str, default=None
         Can be one of:
@@ -1431,7 +1431,7 @@ class DisplayStyle(MagicProperties):
     Base class containing styling properties for all object families. The properties of the
     sub-classes get set to hard coded defaults at class instantiation
 
-    Properties
+    Parameters
     ----------
     base: dict, Base, default=None
         base properties common to all families

--- a/magpylib/_src/style.py
+++ b/magpylib/_src/style.py
@@ -76,8 +76,8 @@ class BaseStyle(MagicProperties):
 
     Properties
     ----------
-    name : str, default=None
-        name of the class instance, can be any string.
+    label : str, default=None
+        label of the class instance, can be any string.
 
     description: dict or Description, default=None
         object description properties
@@ -101,7 +101,7 @@ class BaseStyle(MagicProperties):
 
     def __init__(
         self,
-        name=None,
+        label=None,
         description=None,
         color=None,
         opacity=None,
@@ -110,7 +110,7 @@ class BaseStyle(MagicProperties):
         **kwargs,
     ):
         super().__init__(
-            name=name,
+            label=label,
             description=description,
             color=color,
             opacity=opacity,
@@ -120,13 +120,13 @@ class BaseStyle(MagicProperties):
         )
 
     @property
-    def name(self):
-        """name of the class instance, can be any string"""
-        return self._name
+    def label(self):
+        """label of the class instance, can be any string"""
+        return self._label
 
-    @name.setter
-    def name(self, val):
-        self._name = val if val is None else str(val)
+    @label.setter
+    def label(self, val):
+        self._label = val if val is None else str(val)
 
     @property
     def description(self):
@@ -656,8 +656,8 @@ class MagnetStyle(BaseStyle, MagnetProperties):
 
     Properties
     ----------
-    name : str, default=None
-        name of the class instance, can be any string.
+    label : str, default=None
+        label of the class instance, can be any string.
 
     description: dict or Description, default=None
         object description properties
@@ -846,8 +846,8 @@ class SensorStyle(BaseStyle, SensorProperties):
 
     Properties
     ----------
-    name : str, default=None
-        name of the class instance, can be any string.
+    label : str, default=None
+        label of the class instance, can be any string.
 
     description: dict or Description, default=None
         object description properties
@@ -983,8 +983,8 @@ class CurrentStyle(BaseStyle, CurrentProperties):
 
     Properties
     ----------
-    name : str, default=None
-        name of the class instance, can be any string.
+    label : str, default=None
+        label of the class instance, can be any string.
 
     description: dict or Description, default=None
         object description properties
@@ -1219,8 +1219,8 @@ class DipoleStyle(BaseStyle, DipoleProperties):
 
     Properties
     ----------
-    name : str, default=None
-        name of the class instance, can be any string.
+    label : str, default=None
+        label of the class instance, can be any string.
 
     description: dict or Description, default=None
         object description properties

--- a/tests/test_Coumpound_setters.py
+++ b/tests/test_Coumpound_setters.py
@@ -13,7 +13,7 @@ from magpylib._src.display.plotly.plotly_base_traces import make_BasePrism
 magpy.defaults.display.backend = "plotly"
 
 
-def make_wheel(Ncubes=6, height=10, diameter=36, path_len=5, name=None):
+def make_wheel(Ncubes=6, height=10, diameter=36, path_len=5, label=None):
     """creates a basic Collection Compound object with a rotary arrangement of cuboid magnets"""
     cs_lambda = lambda: magpy.magnet.Cuboid(
         (1, 0, 0), dimension=[height] * 3, position=(diameter / 2, 0, 0)
@@ -33,7 +33,7 @@ def make_wheel(Ncubes=6, height=10, diameter=36, path_len=5, name=None):
         np.linspace(90, 360, path_len), axis="z", start=0, anchor=(80, 0, 0)
     )
     c.move(np.linspace((0, 0, 0), (0, 0, 200), path_len), start=0)
-    c.style.name = name
+    c.style.label = label
 
     trace = make_BasePrism(
         base_vertices=Ncubes, diameter=diameter + height * 2, height=height * 0.5
@@ -47,13 +47,13 @@ def create_compound_set(show=False, **kwargs):
     """creates a styled Collection Compound object with a rotary arrangement of cuboid magnets.
     A copy is created to show the difference when applying position and/or orientation setters over
     kwargs."""
-    c1 = make_wheel(name="Magnetic Wheel after")
+    c1 = make_wheel(label="Magnetic Wheel after")
     c1.set_children_styles(
         path_show=False,
         magnetization_color_north="magenta",
         magnetization_color_south="cyan",
     )
-    c2 = make_wheel(name="Magnetic Wheel before")
+    c2 = make_wheel(label="Magnetic Wheel before")
     c2.style.model3d.data[0].trace["color"] = "red"
     c2.style.model3d.data[0].trace["opacity"] = 0.1
     c2.set_children_styles(path_show=False, opacity=0.1)

--- a/tests/test_obj_BaseGeo.py
+++ b/tests/test_obj_BaseGeo.py
@@ -339,11 +339,11 @@ def test_style():
 
 def test_kwargs():
     """test kwargs inputs, only relevant for styles"""
-    bg = BaseGeo((0, 0, 0), None, style=dict(name="name_01"), style_name="name_02")
-    assert bg.style.name == "name_02"
+    bg = BaseGeo((0, 0, 0), None, style=dict(label="label_01"), style_label="label_02")
+    assert bg.style.label == "label_02"
 
     with pytest.raises(TypeError):
-        bg = BaseGeo((0, 0, 0), None, styl_name="name_02")
+        bg = BaseGeo((0, 0, 0), None, styl_label="label_02")
 
 
 def test_bad_sum():
@@ -355,7 +355,7 @@ def test_bad_sum():
 
 def test_copy():
     """test copying object"""
-    bg1 = BaseGeo((0, 0, 0), None, style_name='name1')
+    bg1 = BaseGeo((0, 0, 0), None, style_label='label1')
     bg2 = BaseGeo((1,2,3), None)
     bg1c = bg1.copy()
     bg2c = bg2.copy(position=(10, 0, 0), style=dict(color='red'), style_color='orange')
@@ -364,9 +364,9 @@ def test_copy():
     np.testing.assert_allclose(bg1.position, (0, 0, 0))
     np.testing.assert_allclose(bg2.position, (1 ,2, 3))
 
-    # check if name suffix iterated correctly
-    assert bg1c.style.name == "name2"
-    assert bg2c.style.name == "BaseGeo_01"
+    # check if label suffix iterated correctly
+    assert bg1c.style.label == "label2"
+    assert bg2c.style.label == "BaseGeo_01"
 
     # check if style is passed correctly
     assert bg2c.style.color == "orange"

--- a/tests/test_obj_Cuboid.py
+++ b/tests/test_obj_Cuboid.py
@@ -84,9 +84,9 @@ def test_repr_cuboid():
     """ test __repr__
     """
     pm1 = Cuboid((1,2,3),(1,2,3))
-    pm1.style.name = 'cuboid_01'
+    pm1.style.label = 'cuboid_01'
     assert pm1.__repr__()[:6] == 'Cuboid', 'Cuboid repr failed'
-    assert "name='cuboid_01'" in pm1.__repr__(), 'Cuboid repr failed'
+    assert "label='cuboid_01'" in pm1.__repr__(), 'Cuboid repr failed'
 
 
 def test_cuboid_object_vs_lib():


### PR DESCRIPTION
# Related Issues
#397

# Notes
if we want to implement #397, the `name` attribute is already reserved in the `param` library. So we change it beforehand to `label` to avoid api change in the future because of this incompatibility. Anyway we also agreed with @OrtnerMichael, that the term `label` makes more sense.

