### PR TITLE
Improve CylinderSegment magnetization matplotlib display

### DIFF
--- a/magpylib/_src/display/display_matplotlib.py
+++ b/magpylib/_src/display/display_matplotlib.py
@@ -295,7 +295,8 @@ def draw_model3d_extra(obj, style, show_path, ax, color):
     ]
     path_traces_extra = {}
     points = []
-    for orient, pos in zip(*get_rot_pos_from_path(obj, show_path)):
+    rots, poss, _ = get_rot_pos_from_path(obj, show_path)
+    for orient, pos in zip(rots, poss):
         for extr in extra_model3d_traces:
             obj_extra_trace = extr.trace() if callable(extr.trace) else extr.trace
             if extr.show:

--- a/magpylib/_src/display/display_matplotlib.py
+++ b/magpylib/_src/display/display_matplotlib.py
@@ -37,7 +37,7 @@ def draw_directs_faced(faced_objects, colors, ax, show_path, size_direction):
     for col, obj in zip(colors, faced_objects):
 
         # add src attributes position and orientation depending on show_path
-        rots, poss = get_rot_pos_from_path(obj, show_path)
+        rots, poss, inds = get_rot_pos_from_path(obj, show_path)
 
         # vector length, color and magnetization
         if obj._object_type in ("Cuboid", "Cylinder"):
@@ -50,22 +50,11 @@ def draw_directs_faced(faced_objects, colors, ax, show_path, size_direction):
 
         # collect all draw positions and directions
         draw_pos, draw_direc = [], []
-        for rot, pos in zip(rots, poss):
-            if (
-                obj._object_type == "CylinderSegment"
-            ):  # change cylinder_tile draw_pos to geo center
-                odim = obj.dimension
-                r1, r2, _, phi1, phi2 = odim
-                phi_mid = (phi1 + phi2) / 2 * np.pi / 180
-                r_mid = (r2 + r1) / 2
-                if (phi2-phi1)<=180:
-                    shift = r_mid * np.array([np.cos(phi_mid), np.sin(phi_mid), 0])
-                    shift = rot.apply(shift)
-                else:
-                    shift = 0
-                draw_pos += [pos + shift]
-            else:
-                draw_pos += [pos]
+        for rot, pos, ind in zip(rots, poss, inds):
+            if obj._object_type == "CylinderSegment":
+                # change cylinder_tile draw_pos to barycenter
+                pos = obj._barycenter[ind]
+            draw_pos += [pos]
             direc = mag / (np.linalg.norm(mag) + 1e-6)
             draw_direc += [rot.apply(direc)]
         draw_pos = np.array(draw_pos)
@@ -142,7 +131,7 @@ def draw_pixel(sensors, ax, col, pixel_col, pixel_size, pixel_symb, show_path):
     # collect sensor and pixel positions in global CS
     pos_sens, pos_pixel = [], []
     for sens in sensors:
-        rots, poss = get_rot_pos_from_path(sens, show_path)
+        rots, poss, _ = get_rot_pos_from_path(sens, show_path)
 
         pos_pixel_flat = np.reshape(sens.pixel, (-1, 3))
 
@@ -180,7 +169,7 @@ def draw_sensors(sensors, ax, sys_size, show_path, size, arrows_style):
     # collect plot data
     possis, exs, eys, ezs = [], [], [], []
     for sens in sensors:
-        rots, poss = get_rot_pos_from_path(sens, show_path)
+        rots, poss, _ = get_rot_pos_from_path(sens, show_path)
 
         for rot, pos in zip(rots, poss):
             possis += [pos]
@@ -219,7 +208,7 @@ def draw_dipoles(dipoles, ax, sys_size, show_path, size, color, pivot):
     # collect plot data
     possis, moms = [], []
     for dip in dipoles:
-        rots, poss = get_rot_pos_from_path(dip, show_path)
+        rots, poss, _ = get_rot_pos_from_path(dip, show_path)
 
         mom = dip.moment / np.linalg.norm(dip.moment)
 
@@ -257,7 +246,7 @@ def draw_circular(circulars, show_path, col, size, width, ax):
     for circ in circulars:
 
         # add src attributes position and orientation depending on show_path
-        rots, poss = get_rot_pos_from_path(circ, show_path)
+        rots, poss, _ = get_rot_pos_from_path(circ, show_path)
 
         # init orientation line positions
         vertices = draw_arrowed_circle(circ.current, circ.diameter, size, discret).T
@@ -281,7 +270,7 @@ def draw_line(lines, show_path, col, size, width, ax) -> list:
     for line in lines:
 
         # add src attributes position and orientation depending on show_path
-        rots, poss = get_rot_pos_from_path(line, show_path)
+        rots, poss, _ = get_rot_pos_from_path(line, show_path)
 
         # init orientation line positions
         if size != 0:

--- a/magpylib/_src/display/display_matplotlib.py
+++ b/magpylib/_src/display/display_matplotlib.py
@@ -58,8 +58,11 @@ def draw_directs_faced(faced_objects, colors, ax, show_path, size_direction):
                 r1, r2, _, phi1, phi2 = odim
                 phi_mid = (phi1 + phi2) / 2 * np.pi / 180
                 r_mid = (r2 + r1) / 2
-                shift = r_mid * np.array([np.cos(phi_mid), np.sin(phi_mid), 0])
-                shift = rot.apply(shift)
+                if (phi2-phi1)<=180:
+                    shift = r_mid * np.array([np.cos(phi_mid), np.sin(phi_mid), 0])
+                    shift = rot.apply(shift)
+                else:
+                    shift = 0
                 draw_pos += [pos + shift]
             else:
                 draw_pos += [pos]

--- a/magpylib/_src/display/display_utility.py
+++ b/magpylib/_src/display/display_utility.py
@@ -174,7 +174,7 @@ def get_rot_pos_from_path(obj, show_path=None):
         inds = np.array([path_len - 1])
     rots = orient[inds]
     poss = pos[inds]
-    return rots, poss
+    return rots, poss, inds
 
 
 def faces_cuboid(src, show_path):
@@ -200,7 +200,7 @@ def faces_cuboid(src, show_path):
     )
     vert0 = vert0 - src.dimension / 2
 
-    rots, poss = get_rot_pos_from_path(src, show_path)
+    rots, poss, _ = get_rot_pos_from_path(src, show_path)
 
     faces = []
     for rot, pos in zip(rots, poss):
@@ -253,7 +253,7 @@ def faces_cylinder(src, show_path):
     ]
 
     # add src attributes position and orientation depending on show_path
-    rots, poss = get_rot_pos_from_path(src, show_path)
+    rots, poss, _ = get_rot_pos_from_path(src, show_path)
 
     # all faces (incl. along path) adding pos and rot
     all_faces = []
@@ -334,7 +334,7 @@ def faces_cylinder_segment(src, show_path):
     ]
 
     # add src attributes position and orientation depending on show_path
-    rots, poss = get_rot_pos_from_path(src, show_path)
+    rots, poss, _ = get_rot_pos_from_path(src, show_path)
 
     # all faces (incl. along path) adding pos and rot
     all_faces = []
@@ -388,7 +388,7 @@ def faces_sphere(src, show_path):
     ]
 
     # add src attributes position and orientation depending on show_path
-    rots, poss = get_rot_pos_from_path(src, show_path)
+    rots, poss, _ = get_rot_pos_from_path(src, show_path)
 
     # all faces (incl. along path) adding pos and rot
     all_faces = []

--- a/magpylib/_src/display/plotly/plotly_display.py
+++ b/magpylib/_src/display/plotly/plotly_display.py
@@ -567,7 +567,8 @@ def get_plotly_traces(
         extra_model3d_traces = [
             t for t in extra_model3d_traces if t.backend == "plotly"
         ]
-        for orient, pos in zip(*get_rot_pos_from_path(input_obj, style.path.frames)):
+        rots, poss, _ = get_rot_pos_from_path(input_obj, style.path.frames)
+        for orient, pos in zip(rots, poss):
             if style.model3d.showdefault and make_func is not None:
                 path_traces.append(
                     make_func(position=pos, orientation=orient, **kwargs)


### PR DESCRIPTION
This PR addresses a small display weirdness of CylinderSegment magnetization arrow . When the segment angle (phi1 - phi2) is large the arrow starts at a off-center position. With this PR, off-center arrow start is now using the new barycenter property of the Cylinder Segment. 

**EDIT: do not merge before checking #484**

```python
import magpylib as magpy
import numpy as np

sources = []
for k,sign in enumerate([-1,1]):
    for j,mag in enumerate([(1,0,0),(0,1,0),(0,0,1)]):
        for i, phi in enumerate((90,180,270, 350)):
            src = magpy.magnet.CylinderSegment(
                magnetization=np.array(mag)*sign, 
                dimension=(1,2,1,0,phi),
            position=(-6*i,7*j,15*k))
            sources.append(src)
    
magpy.show(sources, style_opacity=0.1)
```
## Before

<img width="380" alt="image" src="https://user-images.githubusercontent.com/29252289/156077364-71299168-6239-489a-95e0-f56ac9f6f32d.png">


## After
![image](https://user-images.githubusercontent.com/29252289/156610541-55eb5199-7618-451e-9d5e-2dc327e02214.png)

@OrtnerMichael please have a look ;)
