### PR TITLE
colorize sensor coordinate arrow tails

### DIFF
--- a/magpylib/_src/display/plotly/plotly_sensor_mesh.py
+++ b/magpylib/_src/display/plotly/plotly_sensor_mesh.py
@@ -152,4 +152,3 @@ def get_sensor_mesh(
                 t.extend(trace[k][i[0]:i[1]])
         trace[k] = np.array(t)
     return trace
-

--- a/magpylib/_src/display/plotly/plotly_sensor_mesh.py
+++ b/magpylib/_src/display/plotly/plotly_sensor_mesh.py
@@ -9,6 +9,7 @@ def get_sensor_mesh(
     y_show=True,
     z_show=True,
     center_show=True,
+    colorize_tails=True,
 ):
     """
     returns a plotly mesh3d dictionary of a x,y,z arrows oriented in space accordingly
@@ -124,13 +125,24 @@ def get_sensor_mesh(
                     2.97695041e-01, -2.96093315e-01, -6.52671903e-02,  6.32795095e-02,
                     -1.29736937e-03,  2.30370149e-01, -2.22999811e-01,  8.99043754e-02,
                     -7.91054145e-02,  1.98500464e-16]),
-        'facecolor': np.concatenate([
-            [center_color]*12,
-            [x_color]*56,
-            [z_color]*56,
-            [y_color]*56
-        ]),
     }
+    x_color_tail = x_color
+    y_color_tail = y_color
+    z_color_tail = z_color
+    if colorize_tails:
+        x_color_tail = center_color
+        y_color_tail = center_color
+        z_color_tail = center_color
+    N, N2 = 56, 18
+    trace['facecolor'] = np.concatenate([
+            [center_color]*12,
+            [x_color_tail]*(N2),
+            [x_color]*(N-N2),
+            [y_color_tail]*(N2),
+            [y_color]*(N-N2),
+            [z_color_tail]*(N2),
+            [z_color]*(N-N2)
+        ])
     indices = ((0,12), (12,68), (68,124), (124,180))
     show = (center_show, x_show, z_show, y_show)
     for k in ('i','j','k','facecolor'):
@@ -140,3 +152,4 @@ def get_sensor_mesh(
                 t.extend(trace[k][i[0]:i[1]])
         trace[k] = np.array(t)
     return trace
+


### PR DESCRIPTION
# Problem

When they have no pixels, multiple sensors cannot be simply distinguished from each other. This PR solves this issue by colorizing the tail of the coordinate arrows separately.

# Notes
This fix is plotly only and does not include a matplotlib equivalent (yet @OrtnerMichael ?). 
Should this be a specific style option to turn on/off (`style.arrow.colorizetails` ) ?

```python
import numpy as np
import magpylib as magpy

t = np.linspace(-0.1,0.1,5)
pixel  = [[x,y,z] for x in t for y in t for z in t]
s0 = magpy.Sensor(position=(2,0,0), style_label='Sensor1', style_size=4)
s0.style.pixel.size = 0.5
sensors = [s0.copy(position=(i,j,-2*k), pixel=p) for i in range(2) for j in range(2) for k,p in enumerate(((0,0,0), pixel))]
magpy.show(sensors, backend='plotly', renderer='browser')
```

## Before

![image](https://user-images.githubusercontent.com/29252289/156403991-8b080c1f-5759-4def-b0bd-124ad2689e36.png)

## After

![image](https://user-images.githubusercontent.com/29252289/156403844-9c19c819-253a-4ac4-98ad-20b648540ec4.png)
