### PR TITLE
Fix pixe squeeze

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 - feature-*
 
 pool:
-  vmImage: 'windows-2022'
+  vmImage: 'windows-latest'
 strategy:
   matrix:
     Python37:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 - feature-*
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-2022'
 strategy:
   matrix:
     Python37:

--- a/magpylib/_src/__init__.py
+++ b/magpylib/_src/__init__.py
@@ -1,10 +1,1 @@
 """_src"""
-
-
-# __all__ = ['display', 'fields', 'math_utility', 'obj_classes','config']
-
-# # create interface to outside of package
-# from magpylib._src import display
-# from magpylib._src import fields
-# from magpylib._src import obj_classes
-# from magpylib._src import config

--- a/magpylib/_src/fields/field_wrap_BH_level2.py
+++ b/magpylib/_src/fields/field_wrap_BH_level2.py
@@ -209,7 +209,9 @@ def getBH_level2(sources, observers, **kwargs) -> np.ndarray:
     #   transform input into an ordered list of sensors (pos_vec->pixel)
     #   check if all pixel shapes are similar.
     sensors = check_format_input_observers(observers)
-    pix_shape = sensors[0]._pixel.shape
+    pix_shape = sensors[0].pixel.shape
+    if pix_shape == (3,):
+        pix_shape = (1,3)
 
     # check which sensors have unit roation
     #   so that they dont have to be rotated back later (performance issue)
@@ -256,7 +258,7 @@ def getBH_level2(sources, observers, **kwargs) -> np.ndarray:
     # combine information form all sensors to generate pos_obs with-------------
     #   shape (m * concat all sens flat pixel, 3)
     #   allows sensors with different pixel shapes <- relevant?
-    poso =[[r.apply(sens._pixel.reshape(-1,3)) + p
+    poso =[[r.apply(sens.pixel.reshape(-1,3)) + p
             for r,p in zip(sens._orientation, sens._position)]
            for sens in sensors]
     poso = np.concatenate(poso,axis=1).reshape(-1,3)

--- a/magpylib/_src/obj_classes/class_Sensor.py
+++ b/magpylib/_src/obj_classes/class_Sensor.py
@@ -2,6 +2,7 @@
 DOCSTRINGS V4 READY
 """
 
+import numpy as np
 from magpylib._src.obj_classes.class_BaseGeo import BaseGeo
 from magpylib._src.obj_classes.class_BaseDisplayRepr import BaseDisplayRepr
 from magpylib._src.utility import format_star_input
@@ -92,7 +93,7 @@ class Sensor(BaseGeo, BaseDisplayRepr):
     @property
     def pixel(self):
         """ Sensor pixel attribute getter and setter."""
-        return self._pixel
+        return np.squeeze(self._pixel)
 
     @pixel.setter
     def pixel(self, pix):
@@ -105,7 +106,7 @@ class Sensor(BaseGeo, BaseDisplayRepr):
             shape_m1=3,
             sig_name='pixel',
             sig_type='array_like (list, tuple, ndarray) with shape (n1, n2, ..., 3)',
-            squeeze=True)
+            extend_dim_to2=True)
 
 
     def getB(self, *sources, sumup=False, squeeze=True):

--- a/magpylib/_src/obj_classes/class_Sensor.py
+++ b/magpylib/_src/obj_classes/class_Sensor.py
@@ -2,7 +2,6 @@
 DOCSTRINGS V4 READY
 """
 
-import numpy as np
 from magpylib._src.obj_classes.class_BaseGeo import BaseGeo
 from magpylib._src.obj_classes.class_BaseDisplayRepr import BaseDisplayRepr
 from magpylib._src.utility import format_star_input
@@ -93,7 +92,7 @@ class Sensor(BaseGeo, BaseDisplayRepr):
     @property
     def pixel(self):
         """ Sensor pixel attribute getter and setter."""
-        return np.squeeze(self._pixel)
+        return self._pixel
 
     @pixel.setter
     def pixel(self, pix):
@@ -106,7 +105,7 @@ class Sensor(BaseGeo, BaseDisplayRepr):
             shape_m1=3,
             sig_name='pixel',
             sig_type='array_like (list, tuple, ndarray) with shape (n1, n2, ..., 3)',
-            extend_dim_to2=True)
+        )
 
 
     def getB(self, *sources, sumup=False, squeeze=True):

--- a/magpylib/_src/utility.py
+++ b/magpylib/_src/utility.py
@@ -1,11 +1,11 @@
 """ some utility functions"""
-import numbers
+#import numbers
 from math import log10
 from typing import Sequence
 import numpy as np
 from magpylib._src.exceptions import MagpylibBadUserInput
-from magpylib import _src
-from magpylib._src.input_checks import check_format_input_vector
+#from magpylib import _src
+#from magpylib._src.input_checks import check_format_input_vector
 
 LIBRARY_SOURCES = (
     "Cuboid",
@@ -149,53 +149,53 @@ def format_src_inputs(sources) -> list:
     return list(sources), src_list
 
 
-def format_obs_inputs(observers) -> list:
-    """
-    checks if observer input is one of the following:
-        - case1: bare Sensor
-        - case2: ndarray (can only be possis)
-        - case3: Collection with sensors
+# def format_obs_inputs(observers) -> list:
+#     """
+#     checks if observer input is one of the following:
+#         - case1: bare Sensor
+#         - case2: ndarray (can only be possis)
+#         - case3: Collection with sensors
 
-    returns an ordered 1D list of sensors
+#     returns an ordered 1D list of sensors
 
-    ### Info:
-    - raises an error if sources format is bad
-    """
-    # pylint: disable=too-many-branches
-    # import type, avoid circular imports
-    Sensor = _src.obj_classes.Sensor
+#     ### Info:
+#     - raises an error if sources format is bad
+#     """
+#     # pylint: disable=too-many-branches
+#     # import type, avoid circular imports
+#     Sensor = _src.obj_classes.Sensor
 
-    if not isinstance(observers, (list, tuple, np.ndarray)):
-        observers = (observers,)
-    elif len(observers) == 0:
-        raise MagpylibBadUserInput(wrong_obj_msg(allow="observers"))
-    elif isinstance(observers[0], numbers.Number):
-        observers = (observers,)
+#     if not isinstance(observers, (list, tuple, np.ndarray)):
+#         observers = (observers,)
+#     elif len(observers) == 0:
+#         raise MagpylibBadUserInput(wrong_obj_msg(allow="observers"))
+#     elif isinstance(observers[0], numbers.Number):
+#         observers = (observers,)
 
-    sensors = []
-    for obs in observers:
-        # pylint: disable=protected-access
-        # case 1: sensor
-        if isinstance(obs, Sensor):
-            sensors.append(obs)
+#     sensors = []
+#     for obs in observers:
+#         # pylint: disable=protected-access
+#         # case 1: sensor
+#         if isinstance(obs, Sensor):
+#             sensors.append(obs)
 
-        # case 2: ndarray of positions
-        elif isinstance(obs, (list, tuple, np.ndarray)):
-            check_format_input_vector(
-                obs,
-                dims=range(1,20),
-                shape_m1=3,
-                sig_name='observer position',
-                sig_type='array_like (list, tuple, ndarray) with shape (n1, n2, ..., 3)')
-            sensors.append(Sensor(pixel=obs))
-        elif getattr(obs, "_object_type", "") == "Collection":
-            if not obs.sensors:
-                raise MagpylibBadUserInput(wrong_obj_msg(obs, allow="observers"))
-            sensors.extend(obs.sensors)
-        else:
-            raise MagpylibBadUserInput(wrong_obj_msg(obs, allow="observers"))
+#         # case 2: ndarray of positions
+#         elif isinstance(obs, (list, tuple, np.ndarray)):
+#             check_format_input_vector(
+#                 obs,
+#                 dims=range(1,20),
+#                 shape_m1=3,
+#                 sig_name='observer position',
+#                 sig_type='array_like (list, tuple, ndarray) with shape (n1, n2, ..., 3)')
+#             sensors.append(Sensor(pixel=obs))
+#         elif getattr(obs, "_object_type", "") == "Collection":
+#             if not obs.sensors:
+#                 raise MagpylibBadUserInput(wrong_obj_msg(obs, allow="observers"))
+#             sensors.extend(obs.sensors)
+#         else:
+#             raise MagpylibBadUserInput(wrong_obj_msg(obs, allow="observers"))
 
-    return sensors
+#     return sensors
 
 
 def check_static_sensor_orient(sensors):

--- a/magpylib/_src/utility.py
+++ b/magpylib/_src/utility.py
@@ -147,55 +147,6 @@ def format_src_inputs(sources) -> list:
     return list(sources), src_list
 
 
-# def format_obs_inputs(observers) -> list:
-#     """
-#     checks if observer input is one of the following:
-#         - case1: bare Sensor
-#         - case2: ndarray (can only be possis)
-#         - case3: Collection with sensors
-
-#     returns an ordered 1D list of sensors
-
-#     ### Info:
-#     - raises an error if sources format is bad
-#     """
-#     # pylint: disable=too-many-branches
-#     # import type, avoid circular imports
-#     Sensor = _src.obj_classes.Sensor
-
-#     if not isinstance(observers, (list, tuple, np.ndarray)):
-#         observers = (observers,)
-#     elif len(observers) == 0:
-#         raise MagpylibBadUserInput(wrong_obj_msg(allow="observers"))
-#     elif isinstance(observers[0], numbers.Number):
-#         observers = (observers,)
-
-#     sensors = []
-#     for obs in observers:
-#         # pylint: disable=protected-access
-#         # case 1: sensor
-#         if isinstance(obs, Sensor):
-#             sensors.append(obs)
-
-#         # case 2: ndarray of positions
-#         elif isinstance(obs, (list, tuple, np.ndarray)):
-#             check_format_input_vector(
-#                 obs,
-#                 dims=range(1,20),
-#                 shape_m1=3,
-#                 sig_name='observer position',
-#                 sig_type='array_like (list, tuple, ndarray) with shape (n1, n2, ..., 3)')
-#             sensors.append(Sensor(pixel=obs))
-#         elif getattr(obs, "_object_type", "") == "Collection":
-#             if not obs.sensors:
-#                 raise MagpylibBadUserInput(wrong_obj_msg(obs, allow="observers"))
-#             sensors.extend(obs.sensors)
-#         else:
-#             raise MagpylibBadUserInput(wrong_obj_msg(obs, allow="observers"))
-
-#     return sensors
-
-
 def check_static_sensor_orient(sensors):
     """test which sensors have a static orientation"""
     # pylint: disable=protected-access

--- a/magpylib/_src/utility.py
+++ b/magpylib/_src/utility.py
@@ -4,8 +4,6 @@ from math import log10
 from typing import Sequence
 import numpy as np
 from magpylib._src.exceptions import MagpylibBadUserInput
-#from magpylib import _src
-#from magpylib._src.input_checks import check_format_input_vector
 
 LIBRARY_SOURCES = (
     "Cuboid",
@@ -40,12 +38,12 @@ ALLOWED_OBSERVER_MSG = """Observers must be either
 - array_like positions of shape (N1, N2, ..., 3)
 - Sensor object
 - Collection with at least one Sensor
-- 1D list thereof"""
+- 1D list of the above"""
 
 ALLOWED_SENSORS_MSG = """Sensors must be either
 - Sensor object
 - Collection with at least one Sensor
-- 1D list thereof"""
+- 1D list of the above"""
 
 
 def wrong_obj_msg(*objs, allow="sources"):
@@ -254,11 +252,6 @@ def test_path_format(inp):
     if not result:
         msg = "Bad path format (rot-pos with different lengths)"
         raise MagpylibBadUserInput(msg)
-
-
-def all_same(lst: list) -> bool:
-    """test if all list entries are the same"""
-    return lst[1:] == lst[:-1]
 
 
 def filter_objects(obj_list, allow="sources+sensors", warn=True):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,11 +5,10 @@ import magpylib as magpy
 from magpylib._src.fields.field_wrap_BH_level1 import getBH_level1
 from magpylib._src.fields.field_wrap_BH_level2 import getBH_level2
 from magpylib._src.fields.field_wrap_BH_level2_dict import getBH_dict_level2
-from magpylib._src.exceptions import (MagpylibInternalError, MagpylibBadUserInput,
-    MagpylibBadInputShape)
-from magpylib._src.utility import format_obj_input, format_src_inputs, format_obs_inputs
+from magpylib._src.exceptions import (MagpylibInternalError, MagpylibBadUserInput,)
+from magpylib._src.utility import format_obj_input, format_src_inputs
 from magpylib._src.utility import test_path_format as tpf
-
+from magpylib._src.input_checks import check_format_input_observers
 
 def getBHv_unknown_source_type():
     """ unknown source type """
@@ -168,7 +167,7 @@ def utility_format_obs_inputs():
     sens1 = magpy.Sensor()
     sens2 = magpy.Sensor()
     possis = [1,2,3]
-    format_obs_inputs([sens1,sens2,possis,'whatever'])
+    check_format_input_observers([sens1,sens2,possis,'whatever'])
 
 
 def utility_test_path_format():

--- a/tests/test_getBH_level2.py
+++ b/tests/test_getBH_level2.py
@@ -240,6 +240,7 @@ def test_sensor_rotation3():
 def test_object_tiling():
     """ test if object tiling works when input paths are of various lengths
     """
+    # pylint: disable=no-member
     src1 = magpy.current.Loop(current=1, diameter=1)
     src1.rotate_from_angax(np.linspace(1,31,31), 'x', anchor=(0,1,0), start=-1)
 

--- a/tests/test_input_checks.py
+++ b/tests/test_input_checks.py
@@ -59,7 +59,7 @@ def test_input_objects_pixel_good():
         ]
     for good in goods:
         sens = magpy.Sensor(pixel=good)
-        np.testing.assert_allclose(sens.pixel, np.squeeze(np.array(good)))
+        np.testing.assert_allclose(sens.pixel, good)
 
 
 def test_input_objects_pixel_bad():
@@ -578,6 +578,56 @@ def test_input_rotate_axis_bad():
         np.testing.assert_raises(MagpylibBadUserInput, x.rotate_from_angax, 10, bad)
 
 
+def test_input_observer_good():
+    """good observer inputs"""
+    pos_vec1 = (1,2,3)
+    pos_vec2 = [(1,2,3)]*2
+    pos_vec3 = [[(1,2,3)]*2]*3
+    sens1 = magpy.Sensor()
+    sens2 = magpy.Sensor()
+    sens3 = magpy.Sensor(pixel=pos_vec3)
+    coll1 = magpy.Collection(sens1)
+    coll2 = magpy.Collection(sens1, sens2)
+
+    goods = [
+        sens1,
+        coll1, coll2,
+        pos_vec1, pos_vec2, pos_vec3,
+        [sens1, coll1], [sens1, coll2], [sens1, pos_vec1], [sens3, pos_vec3],
+        [pos_vec1, coll1], [pos_vec1, coll2],
+        [sens1, coll1, pos_vec1],
+        [sens1, coll1, sens2, pos_vec1]
+    ]
+
+    src = magpy.misc.Dipole((1,2,3))
+    for good in goods:
+        B = src.getB(good)
+        assert isinstance(B, np.ndarray)
+
+
+def test_input_observer_bad():
+    """bad observer inputs"""
+    pos_vec1 = (1,2,3)
+    pos_vec2 = [(1,2,3)]*2
+    sens1 = magpy.Sensor()
+    coll1 = magpy.Collection(sens1)
+
+    bads = [
+        'a',
+        None,
+        [],
+        ('a','b','c'),
+        [('a','b','c')],
+        magpy.misc.Dipole((1,2,3)),
+        [pos_vec1, pos_vec2],
+        [sens1, pos_vec2],
+        [pos_vec2, coll1],
+        [magpy.Sensor(pixel=(1,2,3)), ('a','b','c')],
+    ]
+    src = magpy.misc.Dipole((1,2,3))
+    for bad in bads:
+        np.testing.assert_raises(MagpylibBadUserInput, src.getB, bad)
+
 ###########################################################
 ###########################################################
 # GET BH
@@ -613,4 +663,10 @@ def test_input_getBH_field_bad():
     for bad in bads:
         moms = np.array([[1,2,3]])
         obs = np.array([[1,2,3]])
-        np.testing.assert_raises(MagpylibBadUserInput, magpy.core.dipole_field, moms, obs, field=bad)
+        np.testing.assert_raises(
+            MagpylibBadUserInput,
+            magpy.core.dipole_field,
+            moms,
+            obs,
+            field=bad,
+        )

--- a/tests/test_obj_Sensor.py
+++ b/tests/test_obj_Sensor.py
@@ -1,6 +1,6 @@
 import numpy as np
 import magpylib as magpy
-
+from magpylib import Sensor
 
 def test_sensor1():
     """ self-consistent test of the sensor class
@@ -71,3 +71,65 @@ def test_repr():
     """
     sens = magpy.Sensor()
     assert sens.__repr__()[:6]== 'Sensor', 'Sensor repr failed'
+
+
+def test_pixel1():
+    """
+    squeeze=False Bfield minimal shape is (1,1,1,1,3)
+    logic: single sensor, scalar path, single source all generate
+    1 for squeeze=False Bshape. Bare pixel should do the same
+    """
+    src = magpy.misc.Dipole((1,2,3))
+
+    # squeeze=False Bshape of nbare pixel must be (1,1,1,1,3)
+    np.testing.assert_allclose(
+        src.getB(Sensor(pixel=(1,2,3)), squeeze=False).shape,
+        (1,1,1,1,3),
+    )
+
+    # squeeze=False Bshape of [(1,2,3)] must then also be (1,1,1,1,3)
+    src = magpy.misc.Dipole((1,2,3))
+    np.testing.assert_allclose(
+        src.getB(Sensor(pixel=[(1,2,3)]), squeeze=False).shape,
+        (1,1,1,1,3),
+    )
+
+    # squeeze=False Bshape of [[(1,2,3)]] must be (1,1,1,1,1,3)
+    np.testing.assert_allclose(
+        src.getB(Sensor(pixel=[[(1,2,3)]]), squeeze=False).shape,
+        (1,1,1,1,1,3),
+    )
+
+
+def test_pixel2():
+    """
+    Sensor(pixel=pos_vec).pixel should always return pos_vec
+    """
+
+    p0 = (1,2,3)
+    p1 = [(1,2,3)]
+    p2 = [[(1,2,3)]]
+
+    # input pos_vec == Sensor(pixel=pos_vec)
+    for pos_vec in [p0,p1,p2]:
+        np.testing.assert_allclose(
+            Sensor(pixel=pos_vec).pixel,
+            pos_vec,
+        )
+
+
+def test_pixel3():
+    """
+    There should be complete equivalence between pos_vec and
+    Sensor(pixel=pos_vec) inputs
+    """
+    src = magpy.misc.Dipole((1,2,3))
+
+    p0 = (1,2,3)
+    p1 = [(1,2,3)]
+    p2 = [[(1,2,3)]]
+    for pos_vec in [p0,p1,p2]:
+        np.testing.assert_allclose(
+            src.getB(Sensor(pixel=pos_vec), squeeze=False),
+            src.getB(pos_vec, squeeze=False)
+        )


### PR DESCRIPTION
**notes**
The origin of the original problem was that the input `[(1,2,3)]` was interpreted as a list with one position vector `(1,2,3)`, rather than just one bare position vector `((1,2,3),)`.

**changes**

- improved/added `test_format_input_observers`
- moved `test_format_input_observers` from utility to input checks
- fixed tests
- added tests
- pylint
- coverage
- simplification of check_format_input_vector
- minor improvements

**getB(squeeze=False) behavior**

1. `getB(squeeze=False)` minimal shape is (1,1,1,1,3)      *<reshape bare input pixel as (1,3) in getBH>*
2. `Sensor(pixel=pos_vec).pixel == np.array(pos_vec)`     *<no squeezing around of sensor pixel input>*
3. Complete equivalence between `getB(pos_vec)` and `getB(Sensor(pixel=pos_vec))` *<new logical equivalent>*


