### PR TITLE
adding _all parameters

### DIFF
--- a/docs/examples/examples_03_collections.md
+++ b/docs/examples/examples_03_collections.md
@@ -137,6 +137,23 @@ and makes it possible to directly reference to a child object by index:
 print(coll[0])
 ```
 
+Collection nesting is powerful to create a self-consistent hierarchical structure, however, it is often in the way of simple construction and children access in nested trees. For this, the `children_all`, `sources_all`, `sensors_all` and `collections_all` read-only parameters, give quick access to all objects in the tree:
+
+```{code-cell} ipython3
+import magpylib as magpy
+
+s1 = magpy.Sensor(style_label='s1')
+s2 = s1.copy()
+s3 = s2.copy()
+
+# this creates anested collection
+coll = s1 + s2 + s3
+coll.describe(format='label')
+
+# _all gives access to the whole tree
+print([s.style.label for s in coll.sensors_all])
+```
+
 How to work with collections in a practical way is demonstrated in the introduction section {ref}`intro-collections`.
 
 How to make complex compound objects is documented in {ref}`examples-compounds`.

--- a/magpylib/_src/obj_classes/class_Collection.py
+++ b/magpylib/_src/obj_classes/class_Collection.py
@@ -134,7 +134,7 @@ class BaseCollection(BaseDisplayRepr):
     # property getters and setters
     @property
     def children(self):
-        """An ordered list of all children in the collection."""
+        """An ordered list of top level child objects."""
         return self._children
 
     @children.setter
@@ -147,8 +147,13 @@ class BaseCollection(BaseDisplayRepr):
         self.add(*children, override_parent=True)
 
     @property
+    def children_all(self):
+        """An ordered list of all child objects in the collection tree."""
+        return check_format_input_obj(self, 'collections+sensors+sources')
+
+    @property
     def sources(self):
-        """An ordered list of all source objects in the collection."""
+        """An ordered list of top level source objects."""
         return self._sources
 
     @sources.setter
@@ -166,8 +171,13 @@ class BaseCollection(BaseDisplayRepr):
         self.add(*src_list, override_parent=True)
 
     @property
+    def sources_all(self):
+        """An ordered list of all source objects in the collection tree."""
+        return check_format_input_obj(self, 'sources')
+
+    @property
     def sensors(self):
-        """An ordered list of all sensor objects in the collection."""
+        """An ordered list of top level sensor objects."""
         return self._sensors
 
     @sensors.setter
@@ -185,8 +195,13 @@ class BaseCollection(BaseDisplayRepr):
         self.add(*sens_list, override_parent=True)
 
     @property
+    def sensors_all(self):
+        """An ordered list of all sensor objects in the collection tree."""
+        return check_format_input_obj(self, 'sensors')
+
+    @property
     def collections(self):
-        """An ordered list of all collection objects in the collection."""
+        """An ordered list of top level collection objects."""
         return self._collections
 
     @collections.setter
@@ -202,6 +217,11 @@ class BaseCollection(BaseDisplayRepr):
         self._children = new_children
         coll_list = format_obj_input(collections, allow="collections")
         self.add(*coll_list, override_parent=True)
+
+    @property
+    def collections_all(self):
+        """An ordered list of all collection objects in the collection tree."""
+        return check_format_input_obj(self, 'collections')
 
     # dunders
     def __iter__(self):

--- a/tests/test_obj_Collection.py
+++ b/tests/test_obj_Collection.py
@@ -405,21 +405,25 @@ def test_collection_describe():
     cc = x + y
     desc = cc.describe(format="label, properties", return_string=True).split("\n")
     test = [
-        "Collection",
-        "│   • position: [0. 0. 0.] mm",
-        "│   • orientation: [0. 0. 0.] degrees",
-        "├── x",
-        "│       • position: [0. 0. 0.] mm",
-        "│       • orientation: [0. 0. 0.] degrees",
-        "│       • dimension: None mm",
-        "│       • magnetization: None mT",
-        "└── y",
-        "        • position: [0. 0. 0.] mm",
-        "        • orientation: [0. 0. 0.] degrees",
-        "        • dimension: None mm",
-        "        • magnetization: None mT",
+    "Collection",
+    "│   • position: [0. 0. 0.] mm",
+    "│   • orientation: [0. 0. 0.] degrees",
+    "│   • children_all: [Cuboid(id=REGEX, label='x'), Cuboid(id=REGEX, label='y')]",
+    "│   • collections_all: []",
+    "│   • sensors_all: []",
+    "│   • sources_all: [Cuboid(id=REGEX, label='x'), Cuboid(id=REGEX, label='y')]",
+    "├── x",
+    "│       • position: [0. 0. 0.] mm",
+    "│       • orientation: [0. 0. 0.] degrees",
+    "│       • dimension: None mm",
+    "│       • magnetization: None mT",
+    "└── y",
+    "        • position: [0. 0. 0.] mm",
+    "        • orientation: [0. 0. 0.] degrees",
+    "        • dimension: None mm",
+    "        • magnetization: None mT",
     ]
-    assert desc == test
+    assert "".join(test)==re.sub('id=*[0-9]*[0-9]', 'id=REGEX', "".join(desc))
 
     desc = cc.describe()
     assert desc is None

--- a/tests/test_obj_Collection_child_parent.py
+++ b/tests/test_obj_Collection_child_parent.py
@@ -313,3 +313,29 @@ def test_collection_nested_getBH():
     H1 = s1.getH(obs)
     H4 = coll.getH(obs)
     np.testing.assert_allclose(4*H1, H4)
+
+
+def test_collection_properties_all():
+    """ test _all properties"""
+    s1 = magpy.magnet.Cuboid()
+    s2 = magpy.magnet.Cylinder()
+    s3 = magpy.current.Loop()
+    s4 = magpy.current.Loop()
+    x1 = magpy.Sensor()
+    x2 = magpy.Sensor()
+    x3 = magpy.Sensor()
+    c1 = magpy.Collection(s2)
+    c3 = magpy.Collection(s4)
+    c2 = magpy.Collection(s3, x3, c3)
+
+    cc = magpy.Collection(s1, x1, c1, x2, c2)
+
+    assert cc.children == [s1, x1, c1, x2, c2]
+    assert cc.sources == [s1]
+    assert cc.sensors == [x1, x2]
+    assert cc.collections == [c1, c2]
+
+    assert cc.children_all == [s1,x1,c1,s2,x2,c2,s3,x3,c3,s4]
+    assert cc.sources_all == [s1,s2,s3,s4]
+    assert cc.sensors_all == [x1,x2,x3]
+    assert cc.collections_all == [c1, c2, c3]


### PR DESCRIPTION
# What

This adds `children_all`, `sources_all`, `sensors_all` and `collections_all` as collection parameters that return all respective objects in the tree. Returns some of the previous collection behavior.

```python
import magpylib as magpy

s1 = magpy.Sensor(style_label='s1')
s2 = s1.copy()
s3 = s2.copy()

coll = s1 + s2 + s3
coll.describe(format='label')
```

Collection    
├── Collection
│   ├── s1    
│   └── s2    
└── s3        

```
print([s.style.label for s in coll.sensors])
```
['s3']

```
print([s.style.label for s in coll.sensors_all])
```
['s1', 's2', 's3']



```