### PR TITLE
Pyvista dependencies

### DIFF
--- a/.binder/apt.txt
+++ b/.binder/apt.txt
@@ -1,0 +1,2 @@
+libgl1-mesa-dev
+xvfb

--- a/.binder/start
+++ b/.binder/start
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -x
+export DISPLAY=:99.0
+export PYVISTA_OFF_SCREEN=true
+export PYVISTA_USE_IPYVTK=true
+which Xvfb
+Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+sleep 3
+set +x
+exec "$@"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,17 +14,6 @@ build:
     # nodejs: "16"
     # rust: "1.55"
     # golang: "1.17"
-  jobs:
-    post_install:
-      - set -x
-      - export DISPLAY=:99.0
-      - export PYVISTA_OFF_SCREEN=true
-      - export PYVISTA_USE_IPYVTK=true
-      - which Xvfb
-      - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-      - sleep 3
-      - set +x
-      - exec "$@"
   apt_packages:
     # for pyvista
     - libgl1-mesa-dev

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,11 +16,15 @@ build:
     # golang: "1.17"
   jobs:
     post_install:
+      - set -x
       - export DISPLAY=:99.0
       - export PYVISTA_OFF_SCREEN=true
       - export PYVISTA_USE_IPYVTK=true
+      - which Xvfb
       - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
       - sleep 3
+      - set +x
+      - exec "$@"
   apt_packages:
     # for pyvista
     - libgl1-mesa-dev

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,8 +15,7 @@ build:
     # rust: "1.55"
     # golang: "1.17"
   jobs:
-    pre_build:
-      - sudo apt-get install xvfb
+    post_install:
       - export DISPLAY=:99.0
       - export PYVISTA_OFF_SCREEN=true
       - export PYVISTA_USE_IPYVTK=true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
     # rust: "1.55"
     # golang: "1.17"
   jobs:
-    post_build:
+    pre_build:
       - sudo apt-get install xvfb
       - export DISPLAY=:99.0
       - export PYVISTA_OFF_SCREEN=true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,33 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+  apt_packages:
+    # for pyvista
+    - libgl1-mesa-dev
+    - xvfb
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,14 @@ build:
     # nodejs: "16"
     # rust: "1.55"
     # golang: "1.17"
+  jobs:
+    post_build:
+      - sudo apt-get install xvfb
+      - export DISPLAY=:99.0
+      - export PYVISTA_OFF_SCREEN=true
+      - export PYVISTA_USE_IPYVTK=true
+      - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+      - sleep 3
   apt_packages:
     # for pyvista
     - libgl1-mesa-dev

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,10 +16,10 @@ import os
 import sys
 
 # This is for pyvista
-os.system('/usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &')
-os.environ['DISPLAY'] = ':99'
-os.environ['PYVISTA_OFF_SCREEN'] = 'true'
-os.environ['PYVISTA_USE_IPYVTK'] = 'true'
+os.system("/usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &")
+os.environ["DISPLAY"] = ":99"
+os.environ["PYVISTA_OFF_SCREEN"] = "true"
+os.environ["PYVISTA_USE_IPYVTK"] = "true"
 
 
 # Location of Sphinx files

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ import os
 import sys
 
 # This is for pyvista
-os.system('/usr/bin/Xvfb :99 -screen 0 1024x768x24 &')
+os.system('/usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &')
 os.environ['DISPLAY'] = ':99'
 
 # Location of Sphinx files

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,11 @@
 import os
 import sys
 
+# This is for pyvista
+os.system('/usr/bin/Xvfb :99 -screen 0 1024x768x24 &')
+os.environ['DISPLAY'] = ':99'
+
+
 # Location of Sphinx files
 sys.path.insert(0, os.path.abspath("./../"))  ##Add the folder one level above
 os.environ[

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,10 @@
 import os
 import sys
 
+# This is for pyvista
+os.system('/usr/bin/Xvfb :99 -screen 0 1024x768x24 &')
+os.environ['DISPLAY'] = ':99'
+
 # Location of Sphinx files
 sys.path.insert(0, os.path.abspath("./../"))  ##Add the folder one level above
 os.environ[

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -272,5 +272,3 @@ mathjax_options = {
 }
 
 myst_update_mathjax = False
-
-execution_timeout = 120

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -272,3 +272,5 @@ mathjax_options = {
 }
 
 myst_update_mathjax = False
+
+execution_timeout = 120

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,9 @@ import sys
 # This is for pyvista
 os.system('/usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &')
 os.environ['DISPLAY'] = ':99'
+os.environ['PYVISTA_OFF_SCREEN'] = 'true'
+os.environ['PYVISTA_USE_IPYVTK'] = 'true'
+
 
 # Location of Sphinx files
 sys.path.insert(0, os.path.abspath("./../"))  ##Add the folder one level above

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,13 +15,6 @@
 import os
 import sys
 
-# This is for pyvista
-os.system('/usr/bin/Xvfb :99 -screen 0 1024x768x24 &')
-os.environ['DISPLAY'] = ':99'
-os.environ['PYVISTA_OFF_SCREEN'] = 'true'
-os.environ['PYVISTA_USE_IPYVTK'] = 'true'
-
-
 # Location of Sphinx files
 sys.path.insert(0, os.path.abspath("./../"))  ##Add the folder one level above
 os.environ[

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,8 @@ import sys
 # This is for pyvista
 os.system('/usr/bin/Xvfb :99 -screen 0 1024x768x24 &')
 os.environ['DISPLAY'] = ':99'
+os.environ['PYVISTA_OFF_SCREEN'] = 'true'
+os.environ['PYVISTA_USE_IPYVTK'] = 'true'
 
 
 # Location of Sphinx files

--- a/docs/examples/examples_30_coil_field_lines.md
+++ b/docs/examples/examples_30_coil_field_lines.md
@@ -6,7 +6,7 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.13.7
 kernelspec:
-  display_name: Python 3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 ---
@@ -19,7 +19,7 @@ In this example we model the **magnetic field of a coil**, and show how to displ
 
 **Model 1:** The coil consists of multiple windings, each of which can be modeled with a circular current loop which is realized by the `Loop` class. The individual windings are combined into a `Collection` which itself behaves like a single magnetic field source.
 
-```{code-cell}
+```{code-cell} ipython3
 import numpy as np
 import magpylib as magpy
 
@@ -37,7 +37,7 @@ coil1.show()
 
 **Model 2:** The coil is in reality more like a spiral, which can be modeled using the `Line` class. However, a good spiral approximation requires many small line segments, which makes the computation slower.
 
-```{code-cell}
+```{code-cell} ipython3
 import numpy as np
 import magpylib as magpy
 
@@ -55,7 +55,7 @@ coil2.show()
 
 Streamplot from Matplotlib is a powerful tool to outline the field lines. However, it must be understood that streamplot shows only a projection of the field onto the observation plane. All field components that point out of the plane become invisible. In out example we choose symmetry planes, where the perpendicular component is negligible.
 
-```{code-cell}
+```{code-cell} ipython3
 import matplotlib.pyplot as plt
 
 fig, [ax1,ax2] = plt.subplots(1, 2, figsize=(13,5))
@@ -120,7 +120,7 @@ plt.show()
 
 The following example shows how to compute and display 3D field lines of `coil1` with Pyvista. To run this example, the user must install Pyvista (`pip install pyvista`). By removing the command `jupyter_backend='static'` in `show`, the 3D figure becomes interactive.
 
-```{raw-cell}
+```{code-cell} ipython3
 import pyvista as pv
 
 grid = pv.UniformGrid(

--- a/docs/examples/examples_30_coil_field_lines.md
+++ b/docs/examples/examples_30_coil_field_lines.md
@@ -114,7 +114,7 @@ plt.tight_layout()
 plt.show()
 ```
 
-## asdfPyvista streamlines
+## Pyvista streamlines
 
 [Pyvista](https://docs.pyvista.org/) is an incredible VTK based tool for 3D plotting and mesh analysis.
 
@@ -169,10 +169,4 @@ for z in np.linspace(-8, 8, 16):
 pl.camera.position=(160, 10, -10)
 pl.set_background("white")
 pl.show(jupyter_backend='static')
-```
-
-# TEST
-
-```{code-cell} ipython3
-print('test')
 ```

--- a/docs/examples/examples_30_coil_field_lines.md
+++ b/docs/examples/examples_30_coil_field_lines.md
@@ -170,3 +170,9 @@ pl.camera.position=(160, 10, -10)
 pl.set_background("white")
 pl.show(jupyter_backend='static')
 ```
+
+# TEST
+
+```{code-cell} ipython3
+print('test')
+```

--- a/docs/examples/examples_30_coil_field_lines.md
+++ b/docs/examples/examples_30_coil_field_lines.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.6
+    jupytext_version: 1.13.7
 kernelspec:
   display_name: Python 3
   language: python
@@ -19,7 +19,7 @@ In this example we model the **magnetic field of a coil**, and show how to displ
 
 **Model 1:** The coil consists of multiple windings, each of which can be modeled with a circular current loop which is realized by the `Loop` class. The individual windings are combined into a `Collection` which itself behaves like a single magnetic field source.
 
-```{code-cell} ipython3
+```{code-cell}
 import numpy as np
 import magpylib as magpy
 
@@ -37,7 +37,7 @@ coil1.show()
 
 **Model 2:** The coil is in reality more like a spiral, which can be modeled using the `Line` class. However, a good spiral approximation requires many small line segments, which makes the computation slower.
 
-```{code-cell} ipython3
+```{code-cell}
 import numpy as np
 import magpylib as magpy
 
@@ -55,7 +55,7 @@ coil2.show()
 
 Streamplot from Matplotlib is a powerful tool to outline the field lines. However, it must be understood that streamplot shows only a projection of the field onto the observation plane. All field components that point out of the plane become invisible. In out example we choose symmetry planes, where the perpendicular component is negligible.
 
-```{code-cell} ipython3
+```{code-cell}
 import matplotlib.pyplot as plt
 
 fig, [ax1,ax2] = plt.subplots(1, 2, figsize=(13,5))
@@ -120,7 +120,7 @@ plt.show()
 
 The following example shows how to compute and display 3D field lines of `coil1` with Pyvista. To run this example, the user must install Pyvista (`pip install pyvista`). By removing the command `jupyter_backend='static'` in `show`, the 3D figure becomes interactive.
 
-```{code-cell} ipython3
+```{raw-cell}
 import pyvista as pv
 
 grid = pv.UniformGrid(

--- a/docs/examples/examples_30_coil_field_lines.md
+++ b/docs/examples/examples_30_coil_field_lines.md
@@ -114,7 +114,7 @@ plt.tight_layout()
 plt.show()
 ```
 
-## Pyvista streamlines
+## asdfPyvista streamlines
 
 [Pyvista](https://docs.pyvista.org/) is an incredible VTK based tool for 3D plotting and mesh analysis.
 


### PR DESCRIPTION
Fixes docs failing to build when Pyvista output are required.

Also allows mybinder.org to be able to render Pyvista outputs.
![image](https://user-images.githubusercontent.com/29252289/163437044-c3e22b2d-f2d8-446a-8467-356a42ce65aa.png)

useful links:

https://github.com/pyvista/pyvista/issues/313

https://docs.pyvista.org/getting-started/installation.html
