### PR TITLE
Fix magnetization coloring with mesh grouping (plotly)

### DIFF
--- a/magpylib/_src/display/plotly/plotly_utility.py
+++ b/magpylib/_src/display/plotly/plotly_utility.py
@@ -77,7 +77,9 @@ def getIntensity(vertices, axis) -> np.ndarray:
     m = np.array(axis)
     intensity = (p[0] - pos[0]) * m[0] + (p[1] - pos[1]) * m[1] + (p[2] - pos[2]) * m[2]
     # normalize to interval [0,1] (necessary for when merging mesh3d traces)
-    intensity = (intensity - np.min(intensity)) / np.ptp(intensity)
+    ptp = np.ptp(intensity)
+    ptp = ptp if ptp != 0 else 1
+    intensity = (intensity - np.min(intensity)) / ptp
     return intensity
 
 

--- a/magpylib/_src/display/plotly/plotly_utility.py
+++ b/magpylib/_src/display/plotly/plotly_utility.py
@@ -74,9 +74,10 @@ def getIntensity(vertices, axis) -> np.ndarray:
     """
     p = np.array(vertices).T
     pos = np.mean(p, axis=1)
-    norm = np.linalg.norm(axis)
-    m = (np.array(axis) / norm) if norm != 0 else (0, 0, 0)
+    m = np.array(axis)
     intensity = (p[0] - pos[0]) * m[0] + (p[1] - pos[1]) * m[1] + (p[2] - pos[2]) * m[2]
+    # normalize to interval [0,1] (necessary for when merging mesh3d traces)
+    intensity = (intensity - np.min(intensity)) / np.ptp(intensity)
     return intensity
 
 


### PR DESCRIPTION
The magnetization coloring was failing when magnets are grouped into a collection and have quite different sizes and magnetization. The intensity calculation for the magnetization color scale was not normalized and when merging traces was leading to a bad magnetization representation with plotly. 

This PR fixes this regression introduced by #524. 

```python
import magpylib as magpy
from magpylib.magnet import Cuboid, Cylinder, Sphere
import plotly.graph_objects as go

cube = Cuboid(magnetization=(0, 0, 1), dimension=(1, 2, 2))
cylinder = Cylinder(magnetization=(0, 100000, 0), dimension=(1, 1), position=(2,0,0))
sphere = Sphere(magnetization=(0, 1, 1), diameter=1, position=(4,0,0))

coll = magpy.Collection(cube, cylinder, sphere)
magpy.show(coll, backend="plotly")
```

# Before
<img width="749" alt="image" src="https://user-images.githubusercontent.com/29252289/166303800-1781f94e-8fbd-4c01-a92e-2f339a054287.png">

# After
<img width="721" alt="image" src="https://user-images.githubusercontent.com/29252289/166304030-1575ebea-51a2-43cc-8059-6f387b82090c.png">

