### PR TITLE
allowing float colors, adding tests, pylint

### DIFF
--- a/magpylib/_src/defaults/defaults_utility.py
+++ b/magpylib/_src/defaults/defaults_utility.py
@@ -243,11 +243,20 @@ def color_validator(color_input, allow_None=True, parent_name=""):
             pass
 
         if isinstance(color_input, (tuple, list)):
+
+            if len(color_input) == 4: # do not allow opacity values for now
+                color_input = color_input[:-1]
             if len(color_input) != 3:
-                msg = "When specifying a color with a tuple, it must have length 3"
-                raise ValueError(msg)
+                raise ValueError(
+                    "Input color must be of shape (3,) or (4,)."
+                    f"Instead received {color_input}"
+                )
+            # transform matplotlib colors scaled from 0-1 to rgb colors
+            if not isinstance(color_input[0], int):
+                color_input = [int(255*c) for c in color_input]
             c = tuple(color_input)
             color_input = f"#{c[0]:02x}{c[1]:02x}{c[2]:02x}"
+
         if isinstance(color_input, str):
             color_input = color_input.replace(" ", "").lower()
             if color_input.startswith("rgb"):

--- a/tests/test_default_utils.py
+++ b/tests/test_default_utils.py
@@ -106,6 +106,8 @@ def test_linearize_dict():
         ("0.5", True, "#7f7f7f"),
         ((127, 127, 127), True, "#7f7f7f"),
         ("rgb(127, 127, 127)", True, "#7f7f7f"),
+        ((0, 0, 0, 0), False, "#000000"),
+        ((.1, .2, .3), False, "#19334c"),
     ]
     + [(shortC, True, longC) for shortC, longC in COLORS_MATPLOTLIB_TO_PLOTLY.items()],
 )
@@ -120,8 +122,8 @@ def test_good_colors(color, allow_None, color_expected):
     [
         (None, False, ValueError),
         (-1, False, ValueError),
-        ((0, 0, 0, 0), False, ValueError),
         ((-1, 0, 0), False, ValueError),
+        ((1, 2), False, ValueError),
         ((0, 0, 260), False, ValueError),
         ((0, "0", 200), False, ValueError),
         ("rgb(a, 0, 260)", False, ValueError),


### PR DESCRIPTION
# Related Issues
#527

# Notes

**Merge this into 4.0.2 branch before 4.0.2 release !**

To consider: Opaqueness is automatically set to 1 when providing a float color. The alpha entry is ignored.

We can now do this:
```
import magpylib as magpy
from matplotlib import pyplot as plt

cmap = plt.cm.get_cmap('jet')

coll = magpy.Collection()
for i in range(10):
    cube = magpy.magnet.Cuboid(
        magnetization=(0,0,1000),
        dimension=(1,1,1),
        position=(i,0,0),
    )
    cube.style.color=cmap(i/10)
    coll.add(cube)

magpy.show(*coll)
```

![image](https://user-images.githubusercontent.com/47384012/166648950-f36847ad-42e4-46b6-9653-240a9be23e1e.png)


