### PR TITLE
Mayavi plotting backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,16 +22,16 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Specific depedencies for pyvista or mayavi
+          command: |
+            apt update
+            apt-get install -y libgl1-mesa-dev xvfb
+      - run:
           name: Install local magpylib
           command: pip install .[dev]
       - run:
           name: Set up testing tools and environment
           command: mkdir test-results && pip install tox && pip install pylint
-      - run:
-          name: Specific depedencies for pyvista
-          command: |
-            apt update
-            apt-get install -y libgl1-mesa-dev xvfb
       - run:
           name: Run pylint test
           command: pylint --rcfile='./.pylintrc' magpylib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,11 @@ jobs:
           name: Set up testing tools and environment
           command: mkdir test-results && pip install tox && pip install pylint
       - run:
+          name: Specific depedencies for pyvista
+          command: |
+            apt update
+            apt-get install -y libgl1-mesa-dev xvfb
+      - run:
           name: Run pylint test
           command: pylint --rcfile='./.pylintrc' magpylib
       - run:

--- a/___temp.py
+++ b/___temp.py
@@ -1,0 +1,49 @@
+import numpy as np
+import plotly.graph_objects as go
+import pytest
+
+import magpylib as magpy
+from magpylib._src.exceptions import MagpylibBadUserInput
+from magpylib.magnet import Cuboid
+from magpylib.magnet import Cylinder
+from magpylib.magnet import CylinderSegment
+from magpylib.magnet import Sphere
+
+magpy.defaults.display.backend = "matplotlib"
+cuboid = Cuboid((1, 2, 3), (1, 2, 3))
+cuboid.move(np.linspace((0.4, 0.4, 0.4), (12.4, 12.4, 12.4), 33), start=-1)
+cuboid.style.model3d.showdefault = False
+cuboid.style.model3d.data = [
+    {
+        "backend": "generic",
+        "constructor": "Scatter3d",
+        "kwargs": {
+            "x": [-1, -1, 1, 1, -1, -1, -1, -1, -1, 1, 1, 1, 1, 1, 1, -1],
+            "y": [-1, 1, 1, -1, -1, -1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1],
+            "z": [-1, -1, -1, -1, -1, 1, 1, -1, 1, 1, -1, 1, 1, -1, 1, 1],
+            "mode": "lines",
+        },
+        "show": True,
+    },
+    {
+        "backend": "generic",
+        "constructor": "Mesh3d",
+        "kwargs": {
+            "i": [7, 0, 0, 0, 4, 4, 2, 6, 4, 0, 3, 7],
+            "j": [0, 7, 1, 2, 6, 7, 1, 2, 5, 5, 2, 2],
+            "k": [3, 4, 2, 3, 5, 6, 5, 5, 0, 1, 7, 6],
+            "x": [-1, -1, 1, 1, -1, -1, 1, 1],
+            "y": [-1, 1, 1, -1, -1, 1, 1, -1],
+            "z": [-1, -1, -1, -1, 1, 1, 1, 1],
+            "facecolor": ["red"] * 12,
+        },
+        "show": True,
+    },
+]
+coll = magpy.Collection(cuboid)
+coll.rotate_from_angax(45, "z")
+magpy.show(
+    coll,
+    animation=False,
+    style=dict(model3d_showdefault=False),
+)

--- a/magpylib/_src/defaults/defaults_utility.py
+++ b/magpylib/_src/defaults/defaults_utility.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from magpylib._src.defaults.defaults_values import DEFAULTS
 
 
-SUPPORTED_PLOTTING_BACKENDS = ("matplotlib", "plotly", "pyvista")
+SUPPORTED_PLOTTING_BACKENDS = ("matplotlib", "plotly", "pyvista", "mayavi")
 
 
 SYMBOLS_MATPLOTLIB_TO_PLOTLY = {

--- a/magpylib/_src/defaults/defaults_utility.py
+++ b/magpylib/_src/defaults/defaults_utility.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from magpylib._src.defaults.defaults_values import DEFAULTS
 
 
-SUPPORTED_PLOTTING_BACKENDS = ("matplotlib", "plotly")
+SUPPORTED_PLOTTING_BACKENDS = ("matplotlib", "plotly", "pyvista")
 
 
 SYMBOLS_MATPLOTLIB_TO_PLOTLY = {

--- a/magpylib/_src/display/backend_mayavi.py
+++ b/magpylib/_src/display/backend_mayavi.py
@@ -1,0 +1,131 @@
+import warnings
+
+import numpy as np
+from matplotlib.colors import colorConverter
+from mayavi import mlab
+
+from magpylib._src.display.traces_generic import get_frames
+from magpylib._src.display.traces_utility import subdivide_mesh_by_facecolor
+
+
+# from magpylib._src.utility import format_obj_input
+
+
+def generic_trace_to_mayavi(trace):
+    """Transform a generic trace into a mayavi trace"""
+    traces_mvi = []
+    if trace["type"] == "mesh3d":
+        subtraces = [trace]
+        if trace.get("facecolor", None) is not None:
+            subtraces = subdivide_mesh_by_facecolor(trace)
+        for subtrace in subtraces:
+            x, y, z = np.array([subtrace[k] for k in "xyz"], dtype=float)
+            triangles = np.array([subtrace[k] for k in "ijk"]).T
+            opacity = trace.get("opacity", 1)
+            color = subtrace.get("color", None)
+            color = (0.0, 0.0, 0.0, opacity) if color is None else color
+            color = colorConverter.to_rgb(color)
+            trace_mvi = {
+                "constructor": "triangular_mesh",
+                "mlab_source_names": {"x": x, "y": y, "z": z, "triangles": triangles},
+                "args": (x, y, z, triangles),
+                "kwargs": {
+                    # "scalars": subtrace.get("intensity", None),
+                    # "alpha": subtrace.get("opacity", None),
+                    "color": color,
+                    "opacity": opacity,
+                },
+            }
+            traces_mvi.append(trace_mvi)
+    elif trace["type"] == "scatter3d":
+        x, y, z = np.array([trace[k] for k in "xyz"], dtype=float)
+        opacity = trace.get("opacity", 1)
+        color = trace.get("line", {}).get("color", trace.get("line_color", None))
+        color = (0.0, 0.0, 0.0, opacity) if color is None else color
+        color = colorConverter.to_rgb(color)
+        trace_mvi = {
+            "constructor": "plot3d",
+            "mlab_source_names": {"x": x, "y": y, "z": z},
+            "args": (x, y, z),
+            "kwargs": {
+                "color": color,
+                "opacity": opacity,
+            },
+        }
+        traces_mvi.append(trace_mvi)
+    else:
+        raise ValueError(
+            f"Trace type {trace['type']!r} cannot be transformed into mayavi trace"
+        )
+    return traces_mvi
+
+
+def display_mayavi(
+    *obj_list,
+    zoom=1,
+    canvas=None,
+    animation=False,
+    colorsequence=None,
+    **kwargs,
+):
+
+    """Display objects and paths graphically using the mayavi library."""
+
+    # flat_obj_list = format_obj_input(obj_list)
+
+    show_canvas = True
+    if canvas == "hold":
+        show_canvas = False
+    elif canvas is not None:
+        msg = (
+            "The mayavi backend does not support a specific backend. You can specify "
+            "`canvas='hold'` if you want to hold `on mlab.show()`"
+        )
+        warnings.warn(msg)
+
+    data = get_frames(
+        objs=obj_list,
+        colorsequence=colorsequence,
+        zoom=zoom,
+        animation=animation,
+        extra_backend="pyvista",
+        mag_arrows=True,
+        **kwargs,
+    )
+    frames = data["frames"]
+    for fr in frames:
+        new_data = []
+        for tr in fr["data"]:
+            new_data.extend(generic_trace_to_mayavi(tr))
+        fr["data"] = new_data
+
+    mayvi_traces = []
+
+    def draw_frame(frame_ind):
+        for trace_ind, tr1 in enumerate(frames[frame_ind]["data"]):
+            if frame_ind == 0:
+                constructor = tr1["constructor"]
+                args = tr1["args"]
+                kwargs = tr1["kwargs"]
+                tr = getattr(mlab, constructor)(*args, **kwargs)
+                mayvi_traces.append(tr)
+            else:
+                mlab_source = getattr(mayvi_traces[trace_ind], "mlab_source")
+                mlab_source.trait_set(**tr1["mlab_source_names"])
+
+    draw_frame(0)
+
+    if animation:
+
+        @mlab.animate(delay=data["frame_duration"])
+        def anim():
+            while 1:
+                for frame_ind, _ in enumerate(frames):
+                    if frame_ind > 0:
+                        draw_frame(frame_ind)
+                    yield
+
+        anim()
+
+    if show_canvas:
+        mlab.show()

--- a/magpylib/_src/display/backend_pyvista.py
+++ b/magpylib/_src/display/backend_pyvista.py
@@ -1,0 +1,149 @@
+import warnings
+from functools import lru_cache
+
+import numpy as np
+
+try:
+    import pyvista as pv
+except ImportError as missing_module:  # pragma: no cover
+    raise ModuleNotFoundError(
+        """In order to use the pyvista plotting backend, you need to install pyvista via pip or
+        conda, see https://docs.pyvista.org/getting-started/installation.html"""
+    ) from missing_module
+
+from pyvista.plotting.colors import Color  # pylint: disable=import-error
+from matplotlib.colors import LinearSegmentedColormap
+from magpylib._src.display.traces_generic import get_frames
+
+# from magpylib._src.utility import format_obj_input
+
+
+@lru_cache(maxsize=32)
+def colormap_from_colorscale(colorscale, name="plotly_to_mpl", N=256, gamma=1.0):
+    """Create matplotlib colormap from plotly colorscale"""
+
+    cs_rgb = [(v[0], Color(v[1]).float_rgb) for v in colorscale]
+    cdict = {
+        rgb_col: [
+            (
+                c[0],
+                *[c[1][rgb_ind]] * 2,
+            )
+            for c in cs_rgb
+        ]
+        for rgb_ind, rgb_col in enumerate(("red", "green", "blue"))
+    }
+    return LinearSegmentedColormap(name, cdict, N, gamma)
+
+
+def generic_trace_to_pyvista(trace):
+    """Transform a generic trace into a pyvista trace"""
+    traces_pv = []
+    if trace["type"] == "mesh3d":
+        vertices = np.array([trace[k] for k in "xyz"], dtype=float).T
+        faces = np.array([trace[k] for k in "ijk"]).T.flatten()
+        faces = np.insert(faces, range(0, len(faces), 3), 3)
+        colorscale = trace.get("colorscale", None)
+        mesh = pv.PolyData(vertices, faces)
+        facecolor = trace.get("facecolor", None)
+        trace_pv = {
+            "mesh": mesh,
+            "opacity": trace.get("opacity", None),
+            "color": trace.get("color", None),
+            "scalars": trace.get("intensity", None),
+        }
+        if facecolor is not None:
+            # pylint: disable=unsupported-assignment-operation
+            mesh.cell_data["colors"] = [
+                Color(c, default_color=(0, 0, 0)).int_rgb for c in facecolor
+            ]
+            trace_pv.update(
+                {
+                    "scalars": "colors",
+                    "rgb": True,
+                    "preference": "cell",
+                }
+            )
+        traces_pv.append(trace_pv)
+        if colorscale is not None:
+            if colorscale is not None:
+                # ipygany does not support custom colorsequences
+                if pv.global_theme.jupyter_backend == "ipygany":
+                    trace_pv["cmap"] = "PiYG"
+                else:
+                    trace_pv["cmap"] = colormap_from_colorscale(colorscale)
+    elif trace["type"] == "scatter3d":
+        points = np.array([trace[k] for k in "xyz"], dtype=float).T
+        line = trace.get("line", {})
+        line_color = line.get("color", trace.get("line_color", None))
+        line_width = line.get("width", trace.get("line_width", None))
+        trace_pv_line = {
+            "mesh": pv.lines_from_points(points),
+            "opacity": trace.get("opacity", None),
+            "color": line_color,
+            "line_width": line_width,
+        }
+        traces_pv.append(trace_pv_line)
+        marker = trace.get("marker", {})
+        marker_color = marker.get("color", trace.get("marker_color", None))
+        # marker_symbol = marker.get("symbol", trace.get("marker_symbol", None))
+        marker_size = marker.get("size", trace.get("marker_size", None))
+        trace_pv_marker = {
+            "mesh": pv.PolyData(points),
+            "opacity": trace.get("opacity", None),
+            "color": marker_color,
+            "point_size": 1 if marker_size is None else marker_size,
+        }
+        traces_pv.append(trace_pv_marker)
+    else:
+        raise ValueError(
+            f"Trace type {trace['type']!r} cannot be transformed into pyvista trace"
+        )
+    return traces_pv
+
+
+def display_pyvista(
+    *obj_list,
+    zoom=1,
+    canvas=None,
+    animation=False,
+    colorsequence=None,
+    **kwargs,
+):
+
+    """Display objects and paths graphically using the pyvista library."""
+
+    if animation is not False:
+        msg = "The pyvista backend does not support animation at the moment.\n"
+        msg += "Use `backend=plotly` instead."
+        warnings.warn(msg)
+        # animation = False
+
+    # flat_obj_list = format_obj_input(obj_list)
+
+    show_canvas = False
+    if canvas is None:
+        show_canvas = True
+        canvas = pv.Plotter()
+    data = get_frames(
+        objs=obj_list,
+        colorsequence=colorsequence,
+        zoom=zoom,
+        animation=animation,
+        extra_backend="pyvista",
+        **kwargs,
+    )
+
+    frame = data["frames"][0]  # select first, since no animation supported
+
+    for tr0 in frame["data"]:
+        for tr1 in generic_trace_to_pyvista(tr0):
+            canvas.add_mesh(**tr1)
+
+    # apply_fig_ranges(canvas, zoom=zoom)
+    try:
+        canvas.remove_scalar_bar()
+    except IndexError:
+        pass
+    if show_canvas:
+        canvas.show()

--- a/magpylib/_src/display/display.py
+++ b/magpylib/_src/display/display.py
@@ -58,6 +58,7 @@ def show(
         If True, the function call returns the figure object.
         - with matplotlib: `matplotlib.figure.Figure`.
         - with plotly: `plotly.graph_objects.Figure` or `plotly.graph_objects.FigureWidget`.
+        - with pyvista: `pyvista.Plotter`.
 
     Returns
     -------

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setuptools.setup(
             "jupyterlab>=3.2",
             "sphinx==4.4.0",
             "pandas",
+            "pyvista",
         ]
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setuptools.setup(
             "sphinx==4.4.0",
             "pandas",
             "pyvista",
+            "mayavi",
         ]
     },
     classifiers=[


### PR DESCRIPTION
- ⚠️ Do not merge before #548
# Related Issues
#539 


This PR implements a new [mayavi](https://docs.enthought.com/mayavi/mayavi/) using the new plotting logic from #539.

# Feature parity checks
| Checked | Feature type | Possible?
| --- | --- | --- |
| <ul><li>[x] </li></ul> | animation | :heavy_check_mark: | 
| <ul><li>[ ] </li></ul> | animation time | | 
| <ul><li>[ ] </li></ul> | animation fps | | 
| <ul><li>[x] </li></ul> | animation slider | :x: | 
| <ul><li>[x] </li></ul> | triangular mesh 3d |:heavy_check_mark:   | 
| <ul><li>[x] </li></ul> | line/scatter 3d | :heavy_check_mark:  | 
| <ul><li>[ ] </li></ul> | line style | | 
| <ul><li>[ ] </li></ul> | line width | | 
| <ul><li>[ ] </li></ul> | line color | | 
| <ul><li>[ ] </li></ul> | marker | | 
| <ul><li>[ ] </li></ul> | marker size | | 
| <ul><li>[ ] </li></ul> | marker symbol | | 
| <ul><li>[ ] </li></ul> | marker color | | 
| <ul><li>[ ] </li></ul> | marker numbering | | 
| <ul><li>[ ] </li></ul> | zoom level  | | 
| <ul><li>[ ] </li></ul> | colorscale | | 
| <ul><li>[ ] </li></ul> | custom color scale | | 
| <ul><li>[ ] </li></ul> | custom color scale for  individual objects | | 

# Tasks
- [x] changelog
- [ ] tests
- [ ] docstrings
- [ ] docs
