### PR TITLE
Graphics-style docs fix

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -506,5 +506,5 @@ preferred-modules=
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/docs/examples/examples_12_styles.md
+++ b/docs/examples/examples_12_styles.md
@@ -67,13 +67,15 @@ magpy.show(cube, cylinder, sphere, backend="plotly")
 
 user_defined_style = {
     'show': True,
+    "size": 0.5,
     'color': {
-        'transition': 1,
+        'transition': 0,
         'mode': 'tricolor',
         'middle': 'white',
         'north': 'magenta',
         'south': 'turquoise',
     },
+    "mode": "arrow+color",
 }
 magpy.defaults.display.style.magnet.magnetization = user_defined_style
 

--- a/magpylib/_src/display/backend_matplotlib.py
+++ b/magpylib/_src/display/backend_matplotlib.py
@@ -174,6 +174,7 @@ def display_matplotlib(
         draw_frame(ind)
         return [ax]
 
+    anim = None
     if len(frames) == 1:
         draw_frame(0)
     else:

--- a/magpylib/_src/display/backend_plotly.py
+++ b/magpylib/_src/display/backend_plotly.py
@@ -39,7 +39,7 @@ def apply_fig_ranges(fig, ranges):
     """
     fig.update_scenes(
         **{
-            f"{k}axis": dict(range=ranges[i], autorange=False, title=f"{k} [mm]")
+            f"{k}axis": {"range": ranges[i], "autorange": False, "title": f"{k} [mm]"}
             for i, k in enumerate("xyz")
         },
         aspectratio={k: 1 for k in "xyz"},

--- a/magpylib/_src/display/traces_base.py
+++ b/magpylib/_src/display/traces_base.py
@@ -24,7 +24,13 @@ validate_pivot = partial(base_validator, "pivot")
 def get_model(trace, *, backend, show, scale, kwargs):
     """Returns model3d dict depending on backend"""
 
-    model = dict(constructor="Mesh3d", kwargs=trace, args=(), show=show, scale=scale)
+    model = {
+        "constructor": "Mesh3d",
+        "kwargs": trace,
+        "args": (),
+        "show": show,
+        "scale": scale,
+    }
     if backend == "matplotlib":
         x, y, z, i, j, k = (trace[k] for k in "xyzijk")
         triangles = np.array([i, j, k]).T
@@ -85,14 +91,14 @@ def make_Cuboid(
         a 3D-model.
     """
     dimension = np.array(dimension, dtype=float)
-    trace = dict(
-        i=np.array([7, 0, 0, 0, 4, 4, 2, 6, 4, 0, 3, 7]),
-        j=np.array([0, 7, 1, 2, 6, 7, 1, 2, 5, 5, 2, 2]),
-        k=np.array([3, 4, 2, 3, 5, 6, 5, 5, 0, 1, 7, 6]),
-        x=np.array([-1, -1, 1, 1, -1, -1, 1, 1]) * 0.5 * dimension[0],
-        y=np.array([-1, 1, 1, -1, -1, 1, 1, -1]) * 0.5 * dimension[1],
-        z=np.array([-1, -1, -1, -1, 1, 1, 1, 1]) * 0.5 * dimension[2],
-    )
+    trace = {
+        "i": np.array([7, 0, 0, 0, 4, 4, 2, 6, 4, 0, 3, 7]),
+        "j": np.array([0, 7, 1, 2, 6, 7, 1, 2, 5, 5, 2, 2]),
+        "k": np.array([3, 4, 2, 3, 5, 6, 5, 5, 0, 1, 7, 6]),
+        "x": np.array([-1, -1, 1, 1, -1, -1, 1, 1]) * 0.5 * dimension[0],
+        "y": np.array([-1, 1, 1, -1, -1, 1, 1, -1]) * 0.5 * dimension[1],
+        "z": np.array([-1, -1, -1, -1, 1, 1, 1, 1]) * 0.5 * dimension[2],
+    }
 
     trace = place_and_orient_model3d(trace, orientation=orientation, position=position)
     return get_model(trace, backend=backend, show=show, scale=scale, kwargs=kwargs)
@@ -183,7 +189,7 @@ def make_Prism(
     k = np.concatenate([k1, j2, j3, k4])
 
     x, y, z = c.T
-    trace = dict(x=x, y=y, z=z, i=i, j=j, k=k)
+    trace = {"x": x, "y": y, "z": z, "i": i, "j": j, "k": k}
     trace = place_and_orient_model3d(trace, orientation=orientation, position=position)
     return get_model(trace, backend=backend, show=show, scale=scale, kwargs=kwargs)
 
@@ -246,25 +252,34 @@ def make_Ellipsoid(
     y = np.cos(theta) * np.cos(phi) * dimension[1] * 0.5
     z = np.sin(theta) * dimension[2] * 0.5
 
-    x, y, z = x.flatten()[N - 1 :], y.flatten()[N - 1 :], z.flatten()[N - 1 :]
+    x, y, z = (
+        x.flatten()[N - 1 : -N + 1],
+        y.flatten()[N - 1 : -N + 1],
+        z.flatten()[N - 1 : -N + 1],
+    )
+    N2 = len(x) - 1
 
     i1 = [0] * N
-    j1 = np.array([N] + list(range(1, N)), dtype=int)
-    k1 = np.array(list(range(1, N)) + [N], dtype=int)
+    j1 = np.array([N, *range(1, N)], dtype=int)
+    k1 = np.array([*range(1, N), N], dtype=int)
 
-    i2 = np.concatenate([k1 + i * N for i in range(N - 2)])
-    j2 = np.concatenate([j1 + i * N for i in range(N - 2)])
-    k2 = np.concatenate([j1 + (i + 1) * N for i in range(N - 2)])
+    i2 = np.concatenate([k1 + i * N for i in range(N - 3)])
+    j2 = np.concatenate([j1 + i * N for i in range(N - 3)])
+    k2 = np.concatenate([j1 + (i + 1) * N for i in range(N - 3)])
 
-    i3 = np.concatenate([k1 + i * N for i in range(N - 2)])
-    j3 = np.concatenate([j1 + (i + 1) * N for i in range(N - 2)])
-    k3 = np.concatenate([k1 + (i + 1) * N for i in range(N - 2)])
+    i3 = np.concatenate([k1 + i * N for i in range(N - 3)])
+    j3 = np.concatenate([j1 + (i + 1) * N for i in range(N - 3)])
+    k3 = np.concatenate([k1 + (i + 1) * N for i in range(N - 3)])
 
-    i = np.concatenate([i1, i2, i3])
-    j = np.concatenate([j1, j2, j3])
-    k = np.concatenate([k1, k2, k3])
+    i4 = [N2] * N
+    j4 = k1 + N2 - N - 1
+    k4 = j1 + N2 - N - 1
 
-    trace = dict(x=x, y=y, z=z, i=i, j=j, k=k)
+    i = np.concatenate([i1, i2, i3, i4])
+    j = np.concatenate([j1, j2, j3, j4])
+    k = np.concatenate([k1, k2, k3, k4])
+
+    trace = {"x": x, "y": y, "z": z, "i": i, "j": j, "k": k}
     trace = place_and_orient_model3d(trace, orientation=orientation, position=position)
     return get_model(trace, backend=backend, show=show, scale=scale, kwargs=kwargs)
 
@@ -364,7 +379,7 @@ def make_CylinderSegment(
         k.extend([j5, j5 + N - 1])
     i, j, k = (np.hstack(l) for l in (i, j, k))
 
-    trace = dict(x=x, y=y, z=z, i=i, j=j, k=k)
+    trace = {"x": x, "y": y, "z": z, "i": i, "j": j, "k": k}
     trace = place_and_orient_model3d(trace, orientation=orientation, position=position)
     return get_model(trace, backend=backend, show=show, scale=scale, kwargs=kwargs)
 
@@ -445,7 +460,7 @@ def make_Pyramid(
     j = i + 1
     j[-1] = 0
     k = np.array([N] * N, dtype=int)
-    trace = dict(x=x, y=y, z=z, i=i, j=j, k=k)
+    trace = {"x": x, "y": y, "z": z, "i": i, "j": j, "k": k}
     trace = place_and_orient_model3d(trace, orientation=orientation, position=position)
     return get_model(trace, backend=backend, show=show, scale=scale, kwargs=kwargs)
 
@@ -581,21 +596,14 @@ def make_Tetrahedron(
         a 3D-model.
     """
     x, y, z = np.array(vertices).T
-    trace = dict(
-        i=np.array(
-            [
-                0,
-                0,
-                1,
-                2,
-            ]
-        ),
-        j=np.array([1, 1, 2, 0]),
-        k=np.array([2, 3, 3, 3]),
-        x=x,
-        y=y,
-        z=z,
-    )
+    trace = {
+        "i": np.array([0, 0, 1, 2]),
+        "j": np.array([1, 1, 2, 0]),
+        "k": np.array([2, 3, 3, 3]),
+        "x": x,
+        "y": y,
+        "z": z,
+    }
 
     trace = place_and_orient_model3d(trace, orientation=orientation, position=position)
     return get_model(trace, backend=backend, show=show, scale=scale, kwargs=kwargs)
@@ -658,13 +666,6 @@ def make_TriangularMesh(
         hull = ConvexHull(vertices)
         triangles = hull.simplices
     i, j, k = np.array(triangles).T
-    trace = dict(
-        i=i,
-        j=j,
-        k=k,
-        x=x,
-        y=y,
-        z=z,
-    )
+    trace = {"x": x, "y": y, "z": z, "i": i, "j": j, "k": k}
     trace = place_and_orient_model3d(trace, orientation=orientation, position=position)
     return get_model(trace, backend=backend, show=show, scale=scale, kwargs=kwargs)

--- a/magpylib/_src/display/traces_generic.py
+++ b/magpylib/_src/display/traces_generic.py
@@ -66,15 +66,15 @@ class MagpyMarkers:
         marker_kwargs["marker_color"] = (
             style.marker.color if style.marker.color is not None else color
         )
-        trace = dict(
-            type="scatter3d",
-            x=x,
-            y=y,
-            z=z,
-            mode="markers",
+        trace = {
+            "type": "scatter3d",
+            "x": x,
+            "y": y,
+            "z": z,
+            "mode": "markers",
             **marker_kwargs,
             **kwargs,
-        )
+        }
         default_name = "Marker" if len(x) == 1 else "Markers"
         default_suffix = "" if len(x) == 1 else f" ({len(x)} points)"
         update_trace_name(trace, default_name, default_suffix, style)
@@ -95,16 +95,16 @@ def make_DefaultTrace(
     name.
     """
     style = obj.style if style is None else style
-    trace = dict(
-        type="scatter3d",
-        x=[0.0],
-        y=[0.0],
-        z=[0.0],
-        mode="markers+text",
-        marker_size=10,
-        marker_color=color,
-        marker_symbol="diamond",
-    )
+    trace = {
+        "type": "scatter3d",
+        "x": [0.0],
+        "y": [0.0],
+        "z": [0.0],
+        "mode": "markers+text",
+        "marker_size": 10,
+        "marker_color": color,
+        "marker_symbol": "diamond",
+    }
     update_trace_name(trace, f"{type(obj).__name__}", "", style)
     trace["text"] = trace["name"]
     return place_and_orient_model3d(
@@ -134,15 +134,15 @@ def make_Line(
     else:
         vertices = np.array(vertices).T
     x, y, z = vertices
-    trace = dict(
-        type="scatter3d",
-        x=x,
-        y=y,
-        z=z,
-        mode="lines",
-        line_width=style.arrow.width,
-        line_color=color,
-    )
+    trace = {
+        "type": "scatter3d",
+        "x": x,
+        "y": y,
+        "z": z,
+        "mode": "lines",
+        "line_width": style.arrow.width,
+        "line_color": color,
+    }
     default_suffix = (
         f" ({unit_prefix(current)}A)"
         if current is not None
@@ -173,15 +173,15 @@ def make_Loop(
     arrow_size = style.arrow.size if style.arrow.show else 0
     vertices = draw_arrowed_circle(current, diameter, arrow_size, vertices)
     x, y, z = vertices
-    trace = dict(
-        type="scatter3d",
-        x=x,
-        y=y,
-        z=z,
-        mode="lines",
-        line_width=style.arrow.width,
-        line_color=color,
-    )
+    trace = {
+        "type": "scatter3d",
+        "x": x,
+        "y": y,
+        "z": z,
+        "mode": "lines",
+        "line_width": style.arrow.width,
+        "line_color": color,
+    }
     default_suffix = (
         f" ({unit_prefix(current)}A)"
         if current is not None
@@ -440,7 +440,7 @@ def make_Triangle(
     **kwargs,
 ) -> dict:
     """
-    Creates the plotly mesh3d parameters for a TriangularMesh Magnet in a dictionary based on the
+    Creates the plotly mesh3d parameters for a Trianglular facet in a dictionary based on the
     provided arguments.
     """
     vert = obj.vertices
@@ -465,7 +465,7 @@ def make_Triangle(
     trace = make_BaseTriangularMesh(
         "plotly-dict", vertices=vert, triangles=triangles, color=color
     )
-    update_trace_name(trace, "Triangle", "", style)
+    update_trace_name(trace, obj.__class__.__name__, "", style)
     update_magnet_mesh(
         trace, mag_style=style.magnetization, magnetization=obj.magnetization
     )
@@ -666,19 +666,19 @@ def make_path(input_obj, style, legendgroup, kwargs):
     line["dash"] = line["style"]
     line["color"] = kwargs["color"] if line["color"] is None else line["color"]
     line = {k: v for k, v in line.items() if k != "style"}
-    scatter_path = dict(
-        type="scatter3d",
-        x=x,
-        y=y,
-        z=z,
-        name=f"Path: {input_obj}",
-        showlegend=False,
-        legendgroup=legendgroup,
+    scatter_path = {
+        "type": "scatter3d",
+        "x": x,
+        "y": y,
+        "z": z,
+        "name": f"Path: {input_obj}",
+        "showlegend": False,
+        "legendgroup": legendgroup,
         **{f"marker_{k}": v for k, v in marker.items()},
         **{f"line_{k}": v for k, v in line.items()},
         **txt_kwargs,
-        opacity=kwargs["opacity"],
-    )
+        "opacity": kwargs["opacity"],
+    }
     return scatter_path
 
 
@@ -1013,7 +1013,7 @@ def draw_frame(
             traces_to_resize[obj] = {**params}
             # temporary coordinates to be able to calculate ranges
             x, y, z = obj._position.T
-            traces_out[obj] = [dict(x=x, y=y, z=z)]
+            traces_out[obj] = [{"x": x, "y": y, "z": z}]
         else:
             out_traces = get_generic_traces(
                 obj,
@@ -1103,12 +1103,12 @@ def get_frames(
         if i == 0:  # get the dipoles and sensors autosize from first frame
             autosize = autosize_init
         frames.append(
-            dict(
-                data=traces,
-                name=str(ind + 1),
-                layout=dict(title=title_str),
-                extra_backend_traces=extra_backend_traces,
-            )
+            {
+                "data": traces,
+                "name": str(ind + 1),
+                "layout": {"title": title_str},
+                "extra_backend_traces": extra_backend_traces,
+            }
         )
 
     clean_legendgroups(frames)

--- a/magpylib/_src/display/traces_utility.py
+++ b/magpylib/_src/display/traces_utility.py
@@ -32,7 +32,7 @@ def place_and_orient_model3d(
     new_model_args = list(model_args)
     if model_args:
         if coordsargs is None:  # matplotlib default
-            coordsargs = dict(x="args[0]", y="args[1]", z="args[2]")
+            coordsargs = {"x": "args[0]", "y": "args[1]", "z": "args[2]"}
     vertices = []
     if coordsargs is None:
         coordsargs = {"x": "x", "y": "y", "z": "z"}

--- a/magpylib/_src/obj_classes/class_Collection.py
+++ b/magpylib/_src/obj_classes/class_Collection.py
@@ -674,7 +674,7 @@ class Collection(BaseGeo, BaseCollection):
 
     Parameters
     ----------
-    children: sources, `Sensor` or `Collection objects
+    children: sources, `Sensor` or `Collection` objects
         An ordered list of all children in the collection.
 
     sensors: `Sensor` objects

--- a/magpylib/_src/style.py
+++ b/magpylib/_src/style.py
@@ -570,8 +570,8 @@ class Magnetization(MagicProperties):
         can display both and `auto` is chosen, the priority is given to `color`.
     """
 
-    def __init__(self, show=None, size=None, color=None, **kwargs):
-        super().__init__(show=show, size=size, color=color, **kwargs)
+    def __init__(self, show=None, size=None, color=None, mode=None, **kwargs):
+        super().__init__(show=show, size=size, color=color, mode=mode, **kwargs)
 
     @property
     def show(self):


### PR DESCRIPTION
## Notes
- Fixes an  graphics style example of the documentation
- Also update code base for pylint>=2.16

@OrtnerMichael 
Not sure if it is worth doing an release fix yet. I think it can wait for the 4.3 release. Anyway I'm working on more flexible and robust style defaults

## Before
![image](https://user-images.githubusercontent.com/29252289/216565385-afb0159b-5419-478a-a8bd-d990f474e2f6.png)

## After
![image](https://user-images.githubusercontent.com/29252289/216565811-9fa3d34f-6873-4f15-bce8-7262d99b5911.png)
