### PR TITLE
Defer Style initialization to when it is needed

### DIFF
--- a/magpylib/_src/obj_classes/class_BaseGeo.py
+++ b/magpylib/_src/obj_classes/class_BaseGeo.py
@@ -244,6 +244,7 @@ class BaseGeo(BaseTransform):
         """
         if getattr(self, "_style", None) is None:
             self._style = self._validate_style(self._style_kwargs)
+            self._style_kwargs = {}
         return self._style
 
     @style.setter

--- a/magpylib/_src/obj_classes/class_BaseGeo.py
+++ b/magpylib/_src/obj_classes/class_BaseGeo.py
@@ -72,13 +72,13 @@ class BaseGeo(BaseTransform):
         style=None,
         **kwargs,
     ):
-
+        self._style_kwargs = {}
         self._parent = None
         # set _position and _orientation attributes
         self._init_position_orientation(position, orientation)
 
         if style is not None or kwargs:  # avoid style creation cost if not needed
-            self.style = self._process_style_kwargs(style=style, **kwargs)
+            self._style_kwargs = self._process_style_kwargs(style=style, **kwargs)
 
     @staticmethod
     def _process_style_kwargs(style=None, **kwargs):
@@ -242,8 +242,8 @@ class BaseGeo(BaseTransform):
         Object style in the form of a BaseStyle object. Input must be
         in the form of a style dictionary.
         """
-        if not hasattr(self, "_style") or self._style is None:
-            self._style = self._validate_style(val=None)
+        if getattr(self, "_style", None) is None:
+            self._style = self._validate_style(self._style_kwargs)
         return self._style
 
     @style.setter

--- a/magpylib/_src/obj_classes/class_BaseGeo.py
+++ b/magpylib/_src/obj_classes/class_BaseGeo.py
@@ -342,7 +342,9 @@ class BaseGeo(BaseTransform):
         else:
             obj_copy = deepcopy(self)
 
-        if getattr(self, "_style", None) is not None:
+        if getattr(self, "_style", None) is not None or bool(
+            getattr(self, "_style_kwargs", False)
+        ):
             label = self.style.label
             if label is None:
                 label = f"{type(self).__name__}_01"


### PR DESCRIPTION
# Notes
When working on some routine code where the creation of magpylib objects is very frequent, specifying style attributes cost some significant additional initialization time, so we tend to avoid using them in these cases. However it is quite convenient to be able to give at least a `style.label` to our objects in order to track them more easily later.

This PR partly addresses this issue by deferring the style class tree initialization to when it is really called explicitly (e.g. `obj.style`...). It allows to declare some `style_kwargs` at init level without carrying the time penalty right away. This would be even more relevant if we decide to implement #397.
Here some before/after examples to illustrate the use cases:

![image](https://user-images.githubusercontent.com/29252289/217750802-1a85e528-1c2a-4c94-ac36-feeeef68cf2b.png)
