### PR TITLE
Update pre-commit hooks for python 3.8+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,13 +15,13 @@ repos:
     rev: v3.10.0
     hooks:
       - id: reorder-python-imports
-        args: [--py37-plus]
+        args: [--py38-plus]
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.7.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
 
   - repo: https://github.com/psf/black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to magpylib are documented here.
 - Change pyvista plotting defaults when using `show(backend='pyvista')` to fit better with other libraries. ([#551](https://github.com/magpylib/magpylib/issues/551))
 - Added code of conduct attempting to align with NumFocus standards ([#558](https://github.com/magpylib/magpylib/issues/558))
 - Improved Loop field computation in terms of performance and numerical stability ([#374](https://github.com/magpylib/magpylib/issues/374))
-- Add `magnetization.mode` style to allow showing magnetization direction for any backend [#576](https://github.com/magpylib/magpylib/pull/576))
+- Add `magnetization.mode` style to allow showing magnetization direction for any backend ([#576](https://github.com/magpylib/magpylib/pull/576))
 - Documentation changes:
     - Correct conda install command
     - Integration of Triangle and Tetrahedron

--- a/tests/test_obj_BaseGeo.py
+++ b/tests/test_obj_BaseGeo.py
@@ -518,7 +518,7 @@ def test_describe():
     s = magpy.magnet.TriangularMesh.from_pyvista(
         magnetization=(0, 0, 1000),
         polydata=pv.Text3D("A"),
-        check_selfintersecting='skip',
+        check_selfintersecting="skip",
     )
     desc = s.describe(return_string=True)
     test = (


### PR DESCRIPTION
update hooks:
- reorder-python-imports
- pyupgrade

@OrtnerMichael, don't squash, just merge please