### PR TITLE
Accept discontinuous `current.Line` segments and treat as separate lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to magpylib are documented here.
 
 # Releases
 
-## [4.3.x] 
+## [4.4.0] 
 - include self-intersection check in `TriangularMesh` ([#589](https://github.com/magpylib/magpylib/issues/589)).
+- disconnected line
 
 ## [4.3.0] - 2023-06-25
 - New `TriangularMesh` magnet class added to conveniently work with triangular surface meshes instead of large collections of individual `Triangle` objects. The `TriangularMesh` class performs important checks (closed, connected, oriented) and can directly import pyvista objects and for convex hull bodies. ([#569](https://github.com/magpylib/magpylib/issues/569), [#598](https://github.com/magpylib/magpylib/pull/598)).

--- a/magpylib/_src/fields/field_BH_line.py
+++ b/magpylib/_src/fields/field_BH_line.py
@@ -122,8 +122,12 @@ def current_line_field(
     ntot = len(current)
     field_all = np.zeros((ntot, 3))
 
-    # Check for zero-length segments
-    mask0 = np.all(segment_start == segment_end, axis=1)
+    # Check for zero-length segments (or discontinuous)
+    mask_nan_start = np.isnan(segment_start).all(axis=1)
+    mask_nan_end = np.isnan(segment_end).all(axis=1)
+    mask_equal = np.all(segment_start == segment_end, axis=1)
+    mask0 = mask_equal | mask_nan_start | mask_nan_end
+
     if np.all(mask0):
         return field_all
 

--- a/tests/test_obj_Line.py
+++ b/tests/test_obj_Line.py
@@ -83,3 +83,36 @@ def test_line_position_bug():
     B2 = col.getB(poso)
 
     assert np.allclose(B1, B2)
+
+
+def test_discontinous_line():
+    """test discontinuous line"""
+    line_1 = magpy.current.Line(
+        current=1,
+        vertices=[
+            [0, 0, 0],
+            [0, 0, 1],
+        ],
+    )
+    line_2 = magpy.current.Line(
+        current=1,
+        vertices=[
+            [1, 0, 0],
+            [1, 0, 1],
+        ],
+    )
+    line_12 = magpy.current.Line(
+        current=1,
+        vertices=[
+            [None, None, None],
+            *line_1.vertices.tolist(),
+            [None, None, None],
+            [None, None, None],
+            *line_2.vertices.tolist(),
+            [None, None, None],
+        ],
+    )
+
+    B1 = magpy.getB((line_1, line_2), (0, 0, 0), sumup=True)
+    B2 = line_12.getB((0, 0, 0))
+    np.testing.assert_allclose(B1, B2)


### PR DESCRIPTION
- fixes #604

Accepts discontinuous `current.Line` segments by treating them as multiple lines. Only works if all 3 coordinates `x,y,z` are null.

