### PR TITLE
Fix axis mismatch on show/hide of sensor arrows

### DIFF
--- a/magpylib/_src/display/sensor_mesh.py
+++ b/magpylib/_src/display/sensor_mesh.py
@@ -149,7 +149,7 @@ def get_sensor_mesh(
         ]
     )
     indices = ((0, 12), (12, 68), (68, 124), (124, 180))
-    show = (center_show, x_show, z_show, y_show)
+    show = (center_show, x_show, y_show, z_show)
     for k in ("i", "j", "k", "facecolor"):
         t = []
         for i, s in zip(indices, show):


### PR DESCRIPTION
This fixes the mismatch of showed or hidden sensor axes. More specifically the "y" and"z" where switched when trying to hide one.

I would suggest to do a patch fix release right away when this is merged.  I'd have a workaround for a Left Handed Sensor which needs this fix (see #676)

```python
import magpylib as magpy

sens = []
for i, k in enumerate("xyz"):
    s = magpy.Sensor(
        position=(i, 0, 0),
        style_label=f"Sensor ({k}-axis hidden)",
        style_size=4,
    )
    s.style.arrows.update({f"{k}_show": False})
    sens.append(s)
magpy.show(sens)
```

### Before
<img width="538" alt="image" src="https://github.com/magpylib/magpylib/assets/29252289/a03e09c9-050f-4f36-8536-5b3d12e831d4">

### After
<img width="520" alt="image" src="https://github.com/magpylib/magpylib/assets/29252289/d8854c7c-e8fc-4cad-9dc9-d85d64575601">
