### PR TITLE
Fix Cylinder inside H-field computation

### DIFF
--- a/magpylib/_src/fields/field_BH_cylinder.py
+++ b/magpylib/_src/fields/field_BH_cylinder.py
@@ -386,7 +386,7 @@ def magnet_cylinder_field(
         return np.concatenate(((Bx,), (By,), (Bz,)), axis=0).T
 
     if any(mask_ax):  # ax computes B-field
-        Bz[mask_tv * mask_inside] -= magz[mask_tv * mask_inside]
+        Bz[mask_ax * mask_inside] -= magz[mask_ax * mask_inside]
     return np.concatenate(((Bx,), (By,), (Bz,)), axis=0).T * 10 / 4 / np.pi
 
 

--- a/tests/test_field_cylinder.py
+++ b/tests/test_field_cylinder.py
@@ -461,3 +461,26 @@ def test_cylinder_diametral_small_r():
     ddB = abs(ddB - np.mean(ddB, axis=0))
 
     assert np.all(ddB < 0.001)
+
+
+def test_cyl_vs_cylseg_axial_H_inside_mask():
+    """see https://github.com/magpylib/magpylib/issues/703"""
+    field = "H"
+    obs = np.array([(0.1, 0.2, 0.3)])
+    pols = np.array([(0, 0, 1)])
+    dims = np.array([(1, 1)])
+    dims_cs = np.array([(0,0.5,1,0,360)])
+
+    Bc = magpy.core.magnet_cylinder_field(
+        field=field,
+        observers=obs,
+        dimension=dims,
+        magnetization=pols,
+    )
+    Bcs = magpy.core.magnet_cylinder_segment_field(
+        field=field,
+        observers=obs,
+        dimension=dims_cs,
+        magnetization=pols,
+    )
+    np.testing.assert_allclose(Bc, Bcs)

--- a/tests/test_field_cylinder.py
+++ b/tests/test_field_cylinder.py
@@ -469,7 +469,7 @@ def test_cyl_vs_cylseg_axial_H_inside_mask():
     obs = np.array([(0.1, 0.2, 0.3)])
     pols = np.array([(0, 0, 1)])
     dims = np.array([(1, 1)])
-    dims_cs = np.array([(0,0.5,1,0,360)])
+    dims_cs = np.array([(0, 0.5, 1, 0, 360)])
 
     Bc = magpy.core.magnet_cylinder_field(
         field=field,


### PR DESCRIPTION
- fixes #703

also added a test for it, relying on the cylinder segment result.