### PR TITLE
Fix plotting labeling of deeply nested collections

### DIFF
--- a/magpylib/_src/display/traces_utility.py
+++ b/magpylib/_src/display/traces_utility.py
@@ -282,10 +282,12 @@ def get_flatten_objects_properties_recursive(
         style = get_style(subobj, default_settings, **kwargs)
         if style.label is None:
             style.label = str(type(subobj).__name__)
-        if parent_legendgroup is not None:
-            legendgroup = parent_legendgroup
-        else:
-            legendgroup = f"{subobj}"
+        legendgroup = f"{subobj}" if parent_legendgroup is None else parent_legendgroup
+        label = (
+            get_legend_label(subobj, style=style)
+            if parent_label is None
+            else parent_label
+        )
         if parent_color is not None and style.color is None:
             style.color = parent_color
         elif style.color is None:
@@ -293,11 +295,10 @@ def get_flatten_objects_properties_recursive(
         flat_objs[subobj] = {
             "legendgroup": legendgroup,
             "style": style,
-            "legendtext": parent_label,
+            "legendtext": label,
             "showlegend": parent_showlegend,
         }
         if isCollection:
-            label = get_legend_label(subobj, style=style)
             flat_objs.update(
                 get_flatten_objects_properties_recursive(
                     *subobj.children,


### PR DESCRIPTION
This fixes the wrong labeling of deeply nested collections on `show` call. Label propagation was not working beyond the first level.

```python
import magpylib as magpy
cube = magpy.magnet.Cuboid(style_label="cube")
nested = magpy.Collection(cube, style_label="nested")
root = magpy.Collection(nested, style_label="root")
magpy.show(root)
```

### Before
![image](https://github.com/magpylib/magpylib/assets/29252289/a3b26f80-6850-4008-ad7e-008f07c75dcc)

### After

![image](https://github.com/magpylib/magpylib/assets/29252289/7aded927-ddb8-4fb1-8e41-e85f1952747e)
