### PR TITLE
Fix tests with macos CI backend + adapt to pylint and rtd version

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -70,10 +70,10 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install flit
         run: pip install flit
       - name: Build package

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.10"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/magpylib/_src/display/traces_core.py
+++ b/magpylib/_src/display/traces_core.py
@@ -318,6 +318,7 @@ def make_triangle_orientations(obj, **kwargs) -> Dict[str, Any]:
 
 def get_closest_vertices(faces_subsets, vertices):
     """Get closest pairs of points between disconnected subsets of faces indices"""
+    # pylint: disable=used-before-assignment
     nparts = len(faces_subsets)
     inds_subsets = [np.unique(v) for v in faces_subsets]
     closest_verts_list = []

--- a/magpylib/_src/input_checks.py
+++ b/magpylib/_src/input_checks.py
@@ -545,9 +545,6 @@ def check_format_input_obj(
     if "collections" in allow.split("+"):
         wanted_types += (Collection,)
 
-    if typechecks:
-        all_types = (BaseSource, Sensor, Collection)
-
     obj_list = []
     for obj in inp:
         # add to list if wanted type
@@ -564,7 +561,8 @@ def check_format_input_obj(
             )
 
         # typechecks
-        if typechecks and not isinstance(obj, all_types):
+        # pylint disable possibly-used-before-assignment
+        if typechecks and not isinstance(obj, (BaseSource, Sensor, Collection)):
             raise MagpylibBadUserInput(
                 f"Input objects must be {allow} or a flat list thereof.\n"
                 f"Instead received {type(obj)}."

--- a/magpylib/_src/obj_classes/class_Collection.py
+++ b/magpylib/_src/obj_classes/class_Collection.py
@@ -506,6 +506,7 @@ class BaseCollection(BaseDisplayRepr):
         """
         # pylint: disable=protected-access
         # pylint: disable=too-many-branches
+        # pylint: disable=possibly-used-before-assignment
         current_sources = format_obj_input(self, allow="sources")
         current_sensors = format_obj_input(self, allow="sensors")
 

--- a/magpylib/_src/obj_classes/class_current_Circle.py
+++ b/magpylib/_src/obj_classes/class_current_Circle.py
@@ -63,25 +63,13 @@ class Circle(BaseCurrent):
 
     We rotate the source object, and compute the B-field, this time at a set of observer positions:
 
-    >>> src.rotate_from_angax(45, 'x')
+    >>> src.rotate_from_angax(90, 'x')
     Circle(id=...)
     >>> B = src.getB([(.01,.01,.01), (.02,.02,.02), (.03,.03,.03)])
     >>> print(B)
-    [[-1.63585841e-24 -4.44388287e-05  4.44388287e-05]
-     [-6.55449367e-24 -4.44688604e-05  4.44688604e-05]
-     [-9.85948765e-24 -4.45190261e-05  4.45190261e-05]]
-
-    The same result is obtained when the rotated source moves along a path away from an
-    observer at position (1,1,1). This time we use a `Sensor` object as observer.
-
-    >>> src.move([(-.01,-.01,-.01), (-.02,-.02,-.02)])
-    Circle(id=...)
-    >>> sens = magpy.Sensor(position=(.01,.01,.01))
-    >>> B = src.getB(sens)
-    >>> print(B)
-    [[-1.63585841e-24 -4.44388287e-05  4.44388287e-05]
-     [-6.55449367e-24 -4.44688604e-05  4.44688604e-05]
-     [-9.85948765e-24 -4.45190261e-05  4.45190261e-05]]
+    [[-9.42595544e-09 -6.28318490e-05 -9.42595544e-09]
+     [-3.77179218e-08 -6.28317871e-05 -3.77179218e-08]
+     [-8.49179752e-08 -6.28315185e-05 -8.49179752e-08]]
     """
 
     _field_func = staticmethod(BHJM_circle)

--- a/magpylib/_src/obj_classes/class_current_Polyline.py
+++ b/magpylib/_src/obj_classes/class_current_Polyline.py
@@ -67,25 +67,13 @@ class Polyline(BaseCurrent):
 
     We rotate the source object, and compute the B-field, this time at a set of observer positions:
 
-    >>> src.rotate_from_angax(45, 'x')
+    >>> src.rotate_from_angax(90, 'x')
     Polyline(id=...)
     >>> B = src.getB([(.01,.01,.01), (.02,.02,.02), (.03,.03,.03)])
     >>> print(B)
-    [[-1.04529728e-21  3.50341393e-06 -3.50341393e-06]
-     [-9.28140349e-23  3.62181325e-07 -3.62181325e-07]
-     [-1.72744075e-23  1.03643004e-07 -1.03643004e-07]]
-
-    The same result is obtained when the rotated source moves along a path away from an
-    observer at position (1,1,1). This time we use a `Sensor` object as observer.
-
-    >>> src.move([(-.01,-.01,-.01), (-.02,-.02,-.02)])
-    Polyline(id=...)
-    >>> sens = magpy.Sensor(position=(.01,.01,.01))
-    >>> B = src.getB(sens)
-    >>> print(B)
-    [[-1.04529728e-21  3.50341393e-06 -3.50341393e-06]
-     [-9.28140349e-23  3.62181325e-07 -3.62181325e-07]
-     [-1.72744075e-23  1.03643004e-07 -1.03643004e-07]]
+    [[-3.97177559e-06 -9.63684251e-07 -3.97177559e-06]
+     [-4.90331150e-07 -3.11039072e-08 -4.90331150e-07]
+     [-1.43908549e-07 -4.10438492e-09 -1.43908549e-07]]
     """
 
     # pylint: disable=dangerous-default-value

--- a/tests/test_core_physics_consistency.py
+++ b/tests/test_core_physics_consistency.py
@@ -355,7 +355,9 @@ def test_core_physics_dipole_approximation_magnet_far_field():
         dimension=dim,
         polarization=pol,
     )
-    np.testing.assert_allclose(Bdip, Bcub)
+    # np.testing.assert_allclose(Bdip, Bcub)
+    err = np.linalg.norm(Bdip - Bcub) / np.linalg.norm(Bdip)
+    assert err < 1e-6
 
     dim = np.array([(0.5, 0.5)] * 2)
     vol = 0.25**2 * np.pi * 0.5
@@ -366,7 +368,9 @@ def test_core_physics_dipole_approximation_magnet_far_field():
         dimension=dim,
         polarization=pol,
     )
-    np.testing.assert_allclose(Bdip, Bcyl)
+    # np.testing.assert_allclose(Bdip, Bcyl, rtol=1e-6)
+    err = np.linalg.norm(Bdip - Bcyl) / np.linalg.norm(Bdip)
+    assert err < 1e-6
 
     vert = np.array([[(0, 0, 0), (0, 0, 0.1), (0.1, 0, 0), (0, 0.1, 0)]] * 2)
     vol = 1 / 6 * 1e-3
@@ -377,7 +381,9 @@ def test_core_physics_dipole_approximation_magnet_far_field():
         vertices=vert,
         polarization=pol,
     )
-    np.testing.assert_allclose(Bdip, Btetra, rtol=1e-3)
+    # np.testing.assert_allclose(Bdip, Btetra, rtol=1e-3)
+    err = np.linalg.norm(Bdip - Btetra) / np.linalg.norm(Bdip)
+    assert err < 1e-3
 
     dim = np.array([(0.1, 0.2, 0.1, -25, 25)] * 2)
     vol = 3 * np.pi * (50 / 360) * 1e-3
@@ -388,7 +394,9 @@ def test_core_physics_dipole_approximation_magnet_far_field():
         dimension=dim,
         polarization=pol,
     )
-    np.testing.assert_allclose(Bdip, Bcys, rtol=1e-4)
+    # np.testing.assert_allclose(Bdip, Bcys, rtol=1e-4)
+    err = np.linalg.norm(Bdip - Bcys) / np.linalg.norm(Bdip)
+    assert err < 1e-4
 
 
 # --> Circle

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -74,6 +74,7 @@ bad_inputs = {
 
 def get_bad_test_data():
     """create parametrized bad style test data"""
+    # pylint: disable=possibly-used-before-assignment
     bad_test_data = []
     for k, tup in bad_inputs.items():
         for v in tup:

--- a/tests/test_getBH_level2.py
+++ b/tests/test_getBH_level2.py
@@ -244,24 +244,30 @@ def test_sensor_rotation2():
     B = magpy.getB(src, poss, squeeze=True)
     Btest = x1
     np.testing.assert_allclose(
-        np.around(B, decimals=5),
+        B,
         Btest,
+        rtol=1e-4,
+        atol=1e-5,
         err_msg="FAIL: mag  +  pos",
     )
 
     B = magpy.getB([src], [sens], squeeze=True)
     Btest = np.array([x1, x2, x3])
     np.testing.assert_allclose(
-        np.around(B, decimals=5),
+        B,
         Btest,
+        rtol=1e-4,
+        atol=1e-5,
         err_msg="FAIL: mag  +  sens_rot_path",
     )
 
     B = magpy.getB([src], [sens, poss], squeeze=True)
     Btest = np.array([[x1, x1], [x2, x1], [x3, x1]])
     np.testing.assert_allclose(
-        np.around(B, decimals=5),
+        B,
         Btest,
+        rtol=1e-4,
+        atol=1e-5,
         err_msg="FAIL: mag  +  sens_rot_path, pos",
     )
 
@@ -270,8 +276,10 @@ def test_sensor_rotation2():
         [[[x1, x1], [x2, x1], [x3, x1]], [[x1b, x1b], [x2b, x1b], [x3b, x1b]]]
     )
     np.testing.assert_allclose(
-        np.around(B, decimals=5),
+        B,
         Btest,
+        rtol=1e-4,
+        atol=1e-5,
         err_msg="FAIL: mag,col  +  sens_rot_path, pos",
     )
 

--- a/tests/test_obj_BaseGeo.py
+++ b/tests/test_obj_BaseGeo.py
@@ -74,6 +74,12 @@ def test_BaseGeo_basics():
     poss = np.array(poss)
     rots = np.array(rots)
 
+    # avoid generating different zeros in macos
+    ptest = np.around(ptest, decimals=6)
+    otest = np.around(otest, decimals=6)
+    poss = np.around(poss, decimals=6)
+    rots = np.around(rots, decimals=6)
+
     np.testing.assert_allclose(poss, ptest, err_msg="test_BaseGeo bad position")
     np.testing.assert_allclose(rots, otest, err_msg="test_BaseGeo bad orientation")
 

--- a/tests/test_obj_BaseGeo.py
+++ b/tests/test_obj_BaseGeo.py
@@ -74,14 +74,19 @@ def test_BaseGeo_basics():
     poss = np.array(poss)
     rots = np.array(rots)
 
-    # avoid generating different zeros in macos
-    ptest = np.around(ptest, decimals=6)
-    otest = np.around(otest, decimals=6)
-    poss = np.around(poss, decimals=6)
-    rots = np.around(rots, decimals=6)
-
-    np.testing.assert_allclose(poss, ptest, err_msg="test_BaseGeo bad position")
-    np.testing.assert_allclose(rots, otest, err_msg="test_BaseGeo bad orientation")
+    # avoid generating different zeros in macos CI tests (atol=1e-6)
+    np.testing.assert_allclose(
+        poss,
+        ptest,
+        atol=1e-6,
+        err_msg="test_BaseGeo bad position",
+    )
+    np.testing.assert_allclose(
+        rots,
+        otest,
+        atol=1e-6,
+        err_msg="test_BaseGeo bad orientation",
+    )
 
 
 def test_rotate_vs_rotate_from():


### PR DESCRIPTION
### Notes
This PR addresses some failing tests with the new macos CI backend (similar to numerical stability problems) and some new pylint warnings with new package version. Also sets the minimum version python to 3.10 in github workflows and RTD.

PS: When this is merged, #772  PR will only address the original display fix ;)

