### PR TITLE
Fix python version as string in actions/setup-python@v4 for pypi Publishing

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install flit
         run: pip install flit
       - name: Build package


### PR DESCRIPTION
The release process was failing because of a wrong version number of python version.

In the publish job, the python version number must be a string and not a number. For versions ending with `0` like `3.10` are interpreted as `3.1` hence the change to `"3.10"`.

@OrtnerMichael I already released the package from this branch, so no need to make a new one once this is merged!
