### PR TITLE
Fix pyvista plotting ranges and zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased] - YYYY-MM-DD
 - Added `units_length` input to the `show` function to allow displaying axes with different length units. This parameter can be set individually for each subplot. ([#786](https://github.com/magpylib/magpylib/pull/786))
 - Small documentation and Readme improvement. Change naming from "explicit expression" to "analytical expression" as described in ([#794](https://github.com/magpylib/magpylib/issues/794)).
+- Fix Pvyvista plot bounds on animation. Also enables `zoom` feature which was not working until now. ([#798](https://github.com/magpylib/magpylib/pull/798))
 
 ## [5.0.4] - 2024-06-18
 - Add support for Numpy 2.0 ([#795](https://github.com/magpylib/magpylib/pull/789))

--- a/magpylib/_src/display/backend_pyvista.py
+++ b/magpylib/_src/display/backend_pyvista.py
@@ -279,6 +279,13 @@ def display_pyvista(
                 -1, 3
             )
             canvas.add_mesh(pv.PolyData(pts), opacity=0)
+            try:
+                canvas.remove_scalar_bar()
+            except IndexError:
+                # try to remove scalar bar, if none, pass
+                # needs to happen in the loop otherwise they cummulate
+                # while the max of 10 is reached and throws a ValueError
+                pass
 
         for rowcol, count in count_with_labels.items():
             if 0 < count <= legend_maxitems:
@@ -289,11 +296,6 @@ def display_pyvista(
         # match other backends plotter properties
         canvas.set_background("gray", top="white")
         canvas.camera.azimuth = -90
-        try:
-            canvas.remove_scalar_bar()
-        except IndexError:
-            # try to remove scalar bar, if none, pass
-            pass
 
     def run_animation(filename, embed=True):
         # embed=True, embeds the animation into the notebook page and is necessary when using

--- a/magpylib/_src/display/backend_pyvista.py
+++ b/magpylib/_src/display/backend_pyvista.py
@@ -266,7 +266,8 @@ def display_pyvista(
                 canvas.subplot(row, col)
                 if subplot_specs[row, col]["type"] == "scene":
                     getattr(canvas, f"add_{typ}")(**tr1)
-                    canvas.show_axes()
+                    if callable(canvas.show_axes):
+                        canvas.show_axes()
                 else:
                     if charts.get((row, col), None) is None:
                         charts_max_ind += 1

--- a/magpylib/_src/display/backend_pyvista.py
+++ b/magpylib/_src/display/backend_pyvista.py
@@ -273,6 +273,11 @@ def display_pyvista(
                         charts[(row, col)] = pv.Chart2D()
                         canvas.add_chart(charts[(row, col)])
                     getattr(charts[(row, col)], typ)(**tr1)
+            # in pyvista there is no way to set the bouds so we add corners with
+            # a transparent scatter plot to set the ranges and zoom correctly
+            pts  = np.array(np.meshgrid(*data["ranges"][row+1,col+1])).T.reshape(-1, 3)
+            canvas.add_mesh(pv.PolyData(pts), opacity=0)
+
         for rowcol, count in count_with_labels.items():
             if 0 < count <= legend_maxitems:
                 row, col = rowcol

--- a/magpylib/_src/display/backend_pyvista.py
+++ b/magpylib/_src/display/backend_pyvista.py
@@ -275,9 +275,8 @@ def display_pyvista(
                     getattr(charts[(row, col)], typ)(**tr1)
             # in pyvista there is no way to set the bouds so we add corners with
             # a transparent scatter plot to set the ranges and zoom correctly
-            pts = np.array(np.meshgrid(*data["ranges"][row + 1, col + 1])).T.reshape(
-                -1, 3
-            )
+            ranges = data["ranges"][row + 1, col + 1]
+            pts = np.array(np.meshgrid(*ranges)).T.reshape(-1, 3)
             canvas.add_mesh(pv.PolyData(pts), opacity=0)
             try:
                 canvas.remove_scalar_bar()
@@ -287,15 +286,14 @@ def display_pyvista(
                 # while the max of 10 is reached and throws a ValueError
                 pass
 
-        for rowcol, count in count_with_labels.items():
+        for (row, col), count in count_with_labels.items():
+            canvas.subplot(row, col)
+            # match other backends plotter properties
+            canvas.camera.azimuth = -90
+            canvas.set_background("gray", top="white")
             if 0 < count <= legend_maxitems:
-                row, col = rowcol
-                canvas.subplot(row, col)
                 if subplot_specs[row, col]["type"] == "scene":
                     canvas.add_legend(bcolor=None)
-        # match other backends plotter properties
-        canvas.set_background("gray", top="white")
-        canvas.camera.azimuth = -90
 
     def run_animation(filename, embed=True):
         # embed=True, embeds the animation into the notebook page and is necessary when using


### PR DESCRIPTION
### Related Issues
- #766 


This fixes the plot bounds in pyvista. This was especially visible on animations where the plot ranges were not fixed.
In pyvista there is no known way of setting the bounds manually and setting the camera position by an special algorithm is not practical at all. The solution in this case is to add a transparent scatter plot, that sets the ranges correctly.

This correction also enables the zoom feature which was absent until now!

### Ranges
```python
import magpylib as magpy
import numpy as np

cylseg = magpy.magnet.CylinderSegment(
    dimension=(3, 4, 1, 0, 45),
    polarization=(0, 0, 1),
)

angles = np.linspace(0, 360, 10, endpoint=False)
cylseg.rotate_from_angax(angles, axis="z")

magpy.show(
    {"objects": cylseg, "col": 1},
    backend="pyvista",
    style_legend_show=False,
    animation=True,
    animation_duration=2,
    animation_output="test.gif",
)
```

Before |  After
:------:|:------:
![test](https://github.com/magpylib/magpylib/assets/29252289/1c5217bc-c86e-424f-805d-f7b2b9eea8cf) | ![test](https://github.com/magpylib/magpylib/assets/29252289/d130481f-dc68-46f9-9304-aa1bbbef85d2)

### Zoom levels
```python
import magpylib as magpy
import numpy as np

cylseg = magpy.magnet.CylinderSegment(
    dimension=(3, 4, 1, 0, 45),
    polarization=(0, 0, 1),
)

magpy.show(
    *[{"objects": cylseg, "col": i+1,  "zoom":i} for i in range(4)],
    backend="pyvista",
    style_legend_show=False,
)
```

Before (also a camera issue) |  After
:------:|:------:
<img width="923" alt="image" src="https://github.com/magpylib/magpylib/assets/29252289/afa64808-9fd2-4d93-baf2-1090d71170e8"> | <img width="921" alt="image" src="https://github.com/magpylib/magpylib/assets/29252289/43f44ec0-1350-4b9e-92e4-ce03027a7a60">

