### PR TITLE
Move optional-dependencies to dependency groups

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,7 +33,7 @@ You can set up a development environment by running:
 ```bash
 python3 -m venv .venv
 source ./.venv/bin/activate
-pip install -v -e .[dev]
+pip install --group dev -e .
 ```
 
 If you have the
@@ -42,7 +42,7 @@ can instead do:
 
 ```bash
 py -m venv .venv
-py -m install -v -e .[dev]
+py -m install --group dev -e .
 ```
 
 # Pre-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
 
-      - name: Install dependencies with uv
-        run: uv pip install .[test]
-
       - name: Test package
         run: >-
           uv run pytest -ra --cov --cov-report=xml --cov-report=term

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,6 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv venv
-    - uv pip install .[docs]
+    - uv sync --no-dev --no-default-groups --group docs
     - .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D
       language=en docs $READTHEDOCS_OUTPUT/html

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,7 +31,7 @@ def pylint(session: nox.Session) -> None:
     """
     # This needs to be installed into the package environment, and is slower
     # than a pre-commit check
-    session.install("-e.[test]", "pylint>=3.2")
+    session.install("--group", "dev", "-e", ".", "pylint>=3.2")
     session.run("pylint", "magpylib", *session.posargs)
 
 
@@ -40,7 +40,7 @@ def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.
     """
-    session.install("-e.[test]")
+    session.install("--group", "dev", "-e", ".")
     session.run("pytest", *session.posargs)
 
 
@@ -58,7 +58,7 @@ def docs(session: nox.Session) -> None:
     args, posargs = parser.parse_known_args(session.posargs)
     serve = args.builder == "html" and session.interactive
 
-    session.install("-e.[docs]", "sphinx-autobuild")
+    session.install("--group", "dev", "-e", ".", "sphinx-autobuild")
 
     shared_args = (
         "-n",  # nitpicky mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,11 @@ dependencies = [
     "plotly>=5.16",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
   "pytest >=6",
   "pytest-cov >=3",
+  {include-group = "test"}
 ]
 docs = [
     "pydata-sphinx-theme",
@@ -95,11 +96,6 @@ installer = "uv"
 features = ["test"]
 scripts.test = "pytest {args}"
 
-
-[tool.uv]
-dev-dependencies = [
-  "magpylib[test]",
-]
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,37 +41,33 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-  "pytest >=6",
-  "pytest-cov >=3",
-  {include-group = "test"}
+  { include-group = "test" }
 ]
+
 docs = [
-    "pydata-sphinx-theme",
-    "sphinx>=7.0,<8.0",
-    "sphinx-design",
-    "sphinx-thebe",
-    "sphinx-favicon",
-    "sphinx-gallery",
-    "sphinx-copybutton",
-    "myst-nb",
-    "pandas",
-    "numpy-stl",
-    "pyvista",
-    "magpylib-material-response",
-    "magpylib-force",
+  "pydata-sphinx-theme",
+  "sphinx>=7.0,<8.0",
+  "sphinx-design",
+  "sphinx-thebe",
+  "sphinx-favicon",
+  "sphinx-gallery",
+  "sphinx-copybutton",
+  "myst-nb",
+  "pandas",
+  "numpy-stl",
+  "pyvista",
+  "magpylib-material-response",
+  "magpylib-force",
 ]
 test = [
-    "tox>=4.11",
-    "pytest >=6",
-    "pytest-cov >=3",
-    "pytest>=7.4",
-    "coverage",
-    "pandas",
-    "pyvista",
-    "ipywidgets", # for plotly FigureWidget
-    "imageio[tifffile, ffmpeg]",
-    "jupyterlab",
-    "anywidget",
+  "pytest>=7.4",
+  "pytest-cov>=3",
+  "pandas",
+  "pyvista",
+  "ipywidgets",  # for plotly FigureWidget
+  "imageio[tifffile,ffmpeg]",
+  "jupyterlab",
+  "anywidget",
 ]
 binder = [
     "jupytext",


### PR DESCRIPTION
Optional dependencies are user facing while dev groups are meant to be for developers.
Additionally, the tool.uv.dev-dependencies option is now a legacy option, per https://docs.astral.sh/uv/concepts/projects/dependencies/#legacy-dev-dependencies 