### PR TITLE
testfix - inf_dipole

### DIFF
--- a/tests/test_input_checks.py
+++ b/tests/test_input_checks.py
@@ -720,8 +720,8 @@ def test_input_rotate_axis_bad(axis):
 @pytest.mark.parametrize(
     "observers",
     [
-        magpy.Sensor(),
-        magpy.Collection(magpy.Sensor()),
+        magpy.Sensor(position=(1, 1, 1)),
+        magpy.Collection(magpy.Sensor(position=(1, 1, 1))),
         magpy.Collection(magpy.Sensor(), magpy.Sensor()),
         (1, 2, 3),
         [(1, 2, 3)] * 2,
@@ -740,6 +740,7 @@ def test_input_observers_good(observers):
     """good observers input"""
     src = magpy.misc.Dipole(moment=(1, 2, 3))
     B = src.getB(observers)
+    print(B)
     assert isinstance(B, np.ndarray)
 
 


### PR DESCRIPTION
This fixes the tests. There is a new `Rotation` class inconsistency.
```python
import numpy as np
from scipy.spatial.transform import Rotation as R

# THIS THORWS A RUNTIME_WARNING 
vec = np.array([np.inf]*3)
R.from_rotvec((0,0,0)).apply(vec)
print(vec)
# [inf inf inf]

# THIS THORWS NO WARNING
vec = np.array([[np.inf]*3]*2)
R.from_rotvec([(0,0,0)]*2).apply(vec)
print(vec)
#[[inf inf inf]
# [inf inf inf]]
```

forwarding this to scipy also.