### PR TITLE
100% Success on running unit tests, added 2d Ellipsoids

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
     "scipy>=1.8",
     "matplotlib>=3.6",
     "plotly>=5.16",
+    "anywidget",
+    "pandas"
 ]
 
 [dependency-groups]

--- a/src/magpylib/_src/display/traces_core.py
+++ b/src/magpylib/_src/display/traces_core.py
@@ -6,6 +6,7 @@
 # pylint: disable=too-many-nested-blocks
 # pylint: disable=cyclic-import
 
+import numbers
 import warnings
 from itertools import combinations, cycle
 from typing import Any
@@ -127,8 +128,24 @@ def make_Circle(obj, base=72, **kwargs) -> dict[str, Any] | list[dict[str, Any]]
                 x, y, z = vertices.T
             else:
                 t = np.linspace(0, 2 * np.pi, base)
-                x = np.cos(t) * obj.diameter / 2
-                y = np.sin(t) * obj.diameter / 2
+                x = (
+                    np.cos(t)
+                    * (
+                        obj.diameter[0]
+                        if not isinstance(obj.diameter, numbers.Number)
+                        else obj.diameter
+                    )
+                    / 2
+                )
+                y = (
+                    np.sin(t)
+                    * (
+                        obj.diameter[1]
+                        if not isinstance(obj.diameter, numbers.Number)
+                        else obj.diameter
+                    )
+                    / 2
+                )
                 z = np.zeros(x.shape)
             trace = {
                 "type": "scatter3d",

--- a/src/magpylib/_src/display/traces_utility.py
+++ b/src/magpylib/_src/display/traces_utility.py
@@ -3,6 +3,7 @@
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-positional-arguments
 
+import numbers
 from collections import defaultdict
 from functools import lru_cache
 from itertools import chain, cycle
@@ -217,6 +218,11 @@ def draw_arrow_from_vertices(
 
 def draw_arrow_on_circle(sign, diameter, arrow_size, scaled=True, angle_pos_deg=0):
     """draws an oriented circle with an arrow"""
+    if not isinstance(diameter, numbers.Number):
+        diameter = diameter[
+            0
+        ]  # always pick such that the arrow is on the right of the centroid
+
     hy = 0.2 * arrow_size if scaled else arrow_size / diameter * 2
     hx = 0.6 * hy
     hy *= np.sign(sign)

--- a/src/magpylib/_src/input_checks.py
+++ b/src/magpylib/_src/input_checks.py
@@ -577,6 +577,38 @@ def check_format_input_obj(
     return obj_list
 
 
+def check_format_scalar_or_vector(
+    inp,
+    dims=(1,),
+    shape_m1="any",
+    sig_name=None,
+    sig_type=None,
+    length=None,
+    allow_None=False,
+    forbid_negative0=False,
+):
+    """checks rotate anchor input and return in formatted form
+    - input must be array_like or None or 0
+    """
+    if isinstance(inp, numbers.Number):
+        return check_format_input_scalar(
+            inp,
+            sig_name=sig_name,
+            sig_type=sig_type,
+            allow_None=allow_None,
+            forbid_negative=forbid_negative0,
+        )
+    return check_format_input_vector(
+        inp,
+        dims=dims,
+        shape_m1=shape_m1,
+        sig_name=sig_name,
+        sig_type=sig_type,  # "`None` or  or array_like (list, tuple, ndarray) with shape (3,)",
+        length=length,
+        allow_None=allow_None,
+    )
+
+
 ############################################################################################
 ############################################################################################
 # SHOW AND GETB CHECKS

--- a/src/magpylib/_src/obj_classes/class_current_Circle.py
+++ b/src/magpylib/_src/obj_classes/class_current_Circle.py
@@ -6,7 +6,7 @@ from typing import ClassVar
 from magpylib._src.display.traces_core import make_Circle
 from magpylib._src.exceptions import MagpylibDeprecationWarning
 from magpylib._src.fields.field_BH_circle import BHJM_circle
-from magpylib._src.input_checks import check_format_input_scalar
+from magpylib._src.input_checks import check_format_scalar_or_vector
 from magpylib._src.obj_classes.class_BaseExcitations import BaseCurrent
 from magpylib._src.utility import unit_prefix
 
@@ -33,7 +33,7 @@ class Circle(BaseCurrent):
         a unit-rotation. For m>1, the `position` and `orientation` attributes
         together represent an object path.
 
-    diameter: float, default=`None`
+    diameter: array_like, shape (2,), or float, default=`None`
         Diameter of the loop in units of m.
 
     current: float, default=`None`
@@ -86,7 +86,11 @@ class Circle(BaseCurrent):
         **kwargs,
     ):
         # instance attributes
-        self.diameter = diameter
+        self.diameter = check_format_scalar_or_vector(
+            diameter, allow_None=True, length=2
+        )
+        if str(self.diameter) != "None":
+            self.diameter = abs(self.diameter)
 
         # init inheritance
         super().__init__(position, orientation, current, style, **kwargs)
@@ -100,13 +104,15 @@ class Circle(BaseCurrent):
     @diameter.setter
     def diameter(self, dia):
         """Set Circle loop diameter, float, meter."""
-        self._diameter = check_format_input_scalar(
+        self._diameter = check_format_scalar_or_vector(
             dia,
             sig_name="diameter",
-            sig_type="`None` or a positive number (int, float)",
+            sig_type="`None`, a scalar (int, float), or a array_like (list, tuple, ndarray) of shape (1,) and length 2",
+            length=2,
             allow_None=True,
-            forbid_negative=True,
         )
+        if str(self._diameter) != "None":
+            self._diameter = abs(self._diameter)
 
     @property
     def _default_style_description(self):

--- a/tests/test_display_matplotlib.py
+++ b/tests/test_display_matplotlib.py
@@ -134,6 +134,13 @@ def test_Circle_display():
     src.rotate_from_angax([5] * 35, "x", anchor=(1, 2, 3))
     src.show(canvas=ax, style_path_frames=3, return_fig=True)
 
+    # Test Ellipsoid support
+    src2 = magpy.current.Circle(current=1, diameter=(1, 2))
+    src2.show(canvas=ax, return_fig=True)
+
+    src2.rotate_from_angax([5] * 35, "x", anchor=(1, 2, 3))
+    src2.show(canvas=ax, style_path_frames=3, return_fig=True)
+
 
 def test_Triangle_display():
     """testing display for Triangle source built from vertices"""

--- a/tests/test_display_plotly.py
+++ b/tests/test_display_plotly.py
@@ -105,6 +105,15 @@ def test_Circle_display():
     x = src.show(canvas=fig, style_path_frames=3)
     assert x is None, "display test fail"
 
+    # Test New Ellipsoid support
+    src2 = magpy.current.Circle(current=1, diameter=(1, 2))
+    x = src2.show(canvas=fig)
+    assert x is None, "display test fail"
+
+    src2.rotate_from_angax([5] * 35, "x", anchor=(1, 2, 3))
+    x = src2.show(canvas=fig, style_path_frames=3)
+    assert x is None, "display test fail"
+
 
 def test_Triangle_display():
     """testing display for Triangle source"""

--- a/tests/test_input_checks.py
+++ b/tests/test_input_checks.py
@@ -193,6 +193,9 @@ def test_input_objects_current_bad(current):
         1.2,
         np.array([1, 2, 3])[1],
         True,
+        (1, 2),
+        -1,
+        -1.24,
     ],
 )
 def test_input_objects_diameter_good(diameter):
@@ -202,19 +205,22 @@ def test_input_objects_diameter_good(diameter):
     if diameter is None:
         assert src.diameter is None
     else:
+        if (
+            str(diameter) != "None"
+            and str(diameter) != "True"
+            and str(diameter) != "False"
+        ):
+            diameter = abs(np.array(diameter))
         np.testing.assert_allclose(src.diameter, diameter)
 
 
 @pytest.mark.parametrize(
     "diameter",
     [
-        (1, 2),
         [(1, 2, 3, 4)] * 2,
         "x",
         ["x", "y", "z"],
         {"woot": 15},
-        -1,
-        -1.123,
     ],
 )
 def test_input_objects_diameter_bad(diameter):


### PR DESCRIPTION
Added (as mentioned in the title), the ability to draw 2d ellipsoids, and 'expanded' the framework to allow for the calculation of their magnetic field. The underlying mathematical model allows for the representation for circles with multiple radii, so I expanded the present definition of 'current.Circle' to include the ability to do so. This functionality may be better suited for a new, separate object named (to the effect of) 'current.Ellipse', where there may be some hierarchical relation between the two.

This modification means that 'current.Circle' may now take array_types (and now negatives as bonus) as a 'diameter' parameter

Unfortunately, (and against my best efforts), Nox was unable to run due to a dependency conflict with the present development package (version "0.1.dev1901+gb7e0628") and 'magpylib-material-response' (required version ">=5.0"). I am not familiar with Nox, and despite googling, I have found no solution (as of yet). I have, however, manually run the pytests and have (as mentioned) a 100% pass rate. I have attempted to maintain the "spirit" of the repository in naming conventions, style, and structure.