### PR TITLE
add func to interface

### DIFF
--- a/src/magpylib/__init__.py
+++ b/src/magpylib/__init__.py
@@ -2,7 +2,7 @@
 
 from scipy.constants import mu_0
 
-from magpylib import core, current, graphics, magnet, misc, func
+from magpylib import core, current, func, graphics, magnet, misc
 from magpylib._src.defaults.defaults_classes import default_settings as defaults
 from magpylib._src.defaults.defaults_utility import SUPPORTED_PLOTTING_BACKENDS
 from magpylib._src.display.display import show, show_context
@@ -20,6 +20,7 @@ __all__ = [
     "core",
     "current",
     "defaults",
+    "func",
     "getB",
     "getFT",
     "getH",
@@ -31,5 +32,4 @@ __all__ = [
     "mu_0",
     "show",
     "show_context",
-    "func",
 ]


### PR DESCRIPTION
The functional interface is missing from the interface :) ... adding `func` to `__init__`.