### PR TITLE
Complete elliptic integral (cel) errtol

### DIFF
--- a/src/magpylib/_src/fields/special_cel.py
+++ b/src/magpylib/_src/fields/special_cel.py
@@ -6,7 +6,6 @@ import math as m
 
 import numpy as np
 
-
 _errtol = 1e-8
 # def _errtol(x) = np.sqrt(np.finfo(x.dtype)))
 

--- a/src/magpylib/_src/fields/special_cel.py
+++ b/src/magpylib/_src/fields/special_cel.py
@@ -7,6 +7,10 @@ import math as m
 import numpy as np
 
 
+_errtol = 1e-8
+# def _errtol(x) = np.sqrt(np.finfo(x.dtype)))
+
+
 def _cel0(kc, p, c, s):
     """
     Complete elliptic integral algorithm after
@@ -16,7 +20,6 @@ def _cel0(kc, p, c, s):
     if kc == 0:
         msg = "FAIL cel: kc==0 not allowed."
         raise RuntimeError(msg)
-    errtol = 0.000001
     if p > 0:
         p = np.sqrt(p)
         s = s / p
@@ -38,7 +41,7 @@ def _cel0(kc, p, c, s):
         p += g
         g = mu
         mu += nu
-        if abs(g - nu) <= g * errtol:
+        if abs(g - nu) <= g * _errtol:
             break
         nu = 2 * np.sqrt(munu)
         munu = mu * nu
@@ -52,7 +55,6 @@ def _celv(kc, p, c, s):
 
     # if kc == 0:
     #    return NaN
-    errtol = 0.000001
     n = len(kc)
 
     pp = p.copy()
@@ -92,7 +94,7 @@ def _celv(kc, p, c, s):
         pp[mask] += g[mask]
         g[mask] = mu[mask]
         mu[mask] += nu[mask]
-        mask[mask] = np.abs(g[mask] - nu[mask]) > g[mask] * errtol
+        mask[mask] = np.abs(g[mask] - nu[mask]) > g[mask] * _errtol
         if not np.any(mask[mask]):
             break
         nu[mask] = 2 * np.sqrt(munu[mask])
@@ -149,7 +151,7 @@ def _cel_iter0(qc, p, g, cc, ss, em, kk):
     """
     Iterative part of Bulirsch cel algorithm
     """
-    while m.fabs(g - qc) >= qc * 1e-8:
+    while m.fabs(g - qc) >= g * _errtol:
         qc = 2 * m.sqrt(kk)
         kk = qc * em
         f = cc
@@ -166,7 +168,7 @@ def _cel_iterv(qc, p, g, cc, ss, em, kk):
     """
     Iterative part of Bulirsch cel algorithm
     """
-    while np.any(np.fabs(g - qc) >= qc * 1e-8):
+    while np.any(np.fabs(g - qc) >= g * _errtol):
         qc = 2 * np.sqrt(kk)
         kk = qc * em
         f = cc


### PR DESCRIPTION
The implementations of the cel algorithm (for complete elliptic integrals) in special_cel.py have an errtol (error tolerance) that determines the number of iterations that these routines perform, resulting in a relative accuracy of the result of 10^-D (i.e., D digits) for an errtol = 10^(-D/2), according to the paper by Bulirsch. The value of errtol is hardcoded, and different in magpylib's `cel` vs. `cel_iter` implementations: 10^-6 in the former (as in the Bulirsch and Derby papers, and their analog in M. Ortner's article) vs.  10^-8 in cel_iter (and celx and celxx in M. Ortner's article). This PR attempts to harmonize these by introducing a common `_errtol = 1e-8`, which would seem appropriate (approximately equal to the square root of machine epsilon for a float64).
This improves the convergence of `cel()`, as shown in this graph:
<img width="584" height="432" alt="image" src="https://github.com/user-attachments/assets/f359586b-926c-40be-8034-27a480b45675" />
Going from right to left, the steps correspond to the increasing number of iterations and concomitant improvement in convergence of `cel()` using either the standard float64 or more precise quad datatype; it agrees with Bulirsch expectations for the relative accuracy.
Going from 10^-6 to 10^-8 gives you 2 extra digits accuracy at the cost of an extra iteration, apparently.
For definiteness: the graph is generated as follows:
```
import numpy_quaddtype as npq
import magpylib as magpy
import matplotlib
import matplotlib.pyplot as plt

e = np.linspace(-16, -1, 50)
kc = 0.9
rslt = []
qrslt = []
for ee in e:
    magpy._src.fields.special_cel._errtol = 10**ee
    c = magpy._src.fields.special_cel._cel0(kc, 1., 1., 0.)
    rslt.append(c)
    cq = magpy._src.fields.special_cel._cel0(np.array(kc, dtype=npq.QuadPrecDType()), 1., 1., 0.)
    qrslt.append(cq)
plt.figure()
plt.semilogy(e, np.abs(np.array(rslt)-qrslt[0]))
plt.semilogy(e, np.abs(np.array(qrslt)-qrslt[0]))
plt.xlabel('errtol')
plt.ylabel('abs(cel(errtol)-cel(1e-16))')
plt.legend(['double, i.e., float64', 'quad'])
```
The proposed PR also changes the convergence criterion in cel_iter0/v to match that in the Ortner article and Bulirsch paper (it was subtly different, somehow).

As an alternative to `_errtol = 1e-8`, we could set _errtol to `np.sqrt(np.finfo(x.dtype))`, and get rid of the hard-coded constant completely.
Please advise.
