### PR TITLE
Improve cel_iter_*

### DIFF
--- a/src/magpylib/_src/fields/special_cel.py
+++ b/src/magpylib/_src/fields/special_cel.py
@@ -1,7 +1,5 @@
 """Special functions cel."""
 
-# pylint: disable=too-many-positional-arguments
-
 import math as m
 
 import numpy as np
@@ -138,47 +136,30 @@ def _cel(kc: np.ndarray, p: np.ndarray, c: np.ndarray, s: np.ndarray) -> np.ndar
     return _cel_vector(kc, p, c, s)
 
 
-def _cel_iter_scalar(qc, p, g, cc, ss, em, kk):
+# pylint: disable=too-many-positional-arguments
+
+
+def _cel_iter_scalarvector(qc, p, g, cc, ss, em, kk, xp=m, any=lambda b: b):
     """
-    Iterative part of the scalar Bulirsch cel algorithm.
-    This routine continues the iteration from an already prepared state.
-    """
-
-    while abs(g - qc) > g * _CEL_ERRORTOL:
-        qc = 2 * m.sqrt(kk)
-        kk = em * qc
-
-        g = kk / p
-        cc, ss = cc + ss / p, 2 * (ss + cc * g)
-        p = p + g
-
-        g = em
-        em = em + qc
-
-    return (m.pi / 2) * (ss + cc * em) / (em * (em + p))
-
-
-def _cel_iter_vector(qc, p, g, cc, ss, em, kk):
-    """
-    Vectorized iterative part of the Bulirsch cel algorithm.
+    Iterative part of the Bulirsch cel algorithm.
     This routine continues the iteration from an already prepared state.
 
+    Handles scalar (xp=m) or vectorized (xp=np, any=np.any) inputs.
     Does not modify input arrays in-place.
     """
 
-    while np.any(np.abs(g - qc) > g * _CEL_ERRORTOL):
-        qc = 2 * np.sqrt(kk)
+    while any(abs(g - qc) > g * _CEL_ERRORTOL):
+        qc = 2 * xp.sqrt(kk)
         kk = em * qc
 
         g = kk / p
         cc, ss = cc + ss / p, 2 * (ss + cc * g)
-
         p = p + g
 
         g = em
         em = em + qc
 
-    return (np.pi / 2) * (ss + cc * em) / (em * (em + p))
+    return (xp.pi / 2) * (ss + cc * em) / (em * (em + p))
 
 
 def _cel_iter(
@@ -191,18 +172,15 @@ def _cel_iter(
     kk: np.ndarray,
 ) -> np.ndarray:
     """
-    Iterative part of bulirsch cel algorithm where the first iteration was already performed.
-    This function improves computation of current loop only and is separated from the
+    Iterative part of Bulirsch cel algorithm where the first iteration was already performed.
+    This function improves computation of current loop only and is separate from the _cel
     implementation above.
     """
 
     if qc.size < _CEL_SCALAR_THRESHOLD:
-        out = np.empty(qc.size, dtype=float)
-        for i in range(qc.size):
-            out[i] = _cel_iter_scalar(qc[i], p[i], g[i], cc[i], ss[i], em[i], kk[i])
-        return out
-
-    return _cel_iter_vector(qc, p, g, cc, ss, em, kk)
+        return np.array([_cel_iter_scalarvector(*args)
+                         for args in zip(qc, p, g, cc, ss, em, kk, strict=False)])  # fmt: skip
+    return _cel_iter_scalarvector(qc, p, g, cc, ss, em, kk, xp=np, any=np.any)
 
 
 # import math as m

--- a/src/magpylib/_src/fields/special_cel.py
+++ b/src/magpylib/_src/fields/special_cel.py
@@ -139,7 +139,7 @@ def _cel(kc: np.ndarray, p: np.ndarray, c: np.ndarray, s: np.ndarray) -> np.ndar
 # pylint: disable=too-many-positional-arguments
 
 
-def _cel_iter_scalarvector(qc, p, g, cc, ss, em, kk, xp=m, any=lambda b: b):
+def _cel_iter_scalarvector(qc, p, g, cc, ss, em, kk, xp=m, any_=lambda b: b):
     """
     Iterative part of the Bulirsch cel algorithm.
     This routine continues the iteration from an already prepared state.
@@ -148,7 +148,7 @@ def _cel_iter_scalarvector(qc, p, g, cc, ss, em, kk, xp=m, any=lambda b: b):
     Does not modify input arrays in-place.
     """
 
-    while any(abs(g - qc) > g * _CEL_ERRORTOL):
+    while any_(abs(g - qc) > g * _CEL_ERRORTOL):
         qc = 2 * xp.sqrt(kk)
         kk = em * qc
 
@@ -180,7 +180,7 @@ def _cel_iter(
     if qc.size < _CEL_SCALAR_THRESHOLD:
         return np.array([_cel_iter_scalarvector(*args)
                          for args in zip(qc, p, g, cc, ss, em, kk, strict=False)])  # fmt: skip
-    return _cel_iter_scalarvector(qc, p, g, cc, ss, em, kk, xp=np, any=np.any)
+    return _cel_iter_scalarvector(qc, p, g, cc, ss, em, kk, xp=np, any_=np.any)
 
 
 # import math as m


### PR DESCRIPTION
A closer look at `cel_iter_...()`, after the revision in #955, suggests two minor improvements/simplifications:

- The definitions for `cel_iter_scalar()` and `cel_iter_vector()` appear almost identical - the only differences are the `m` vs. `np` libraries, and a call to `np.any()`. It does not take much to parametrize this, so we don't have to repeat ourselves.
- In `cel_iter()`: replacing the for loop (with its pre-allocation and indexing) by a list comprehension is faster; it is how it was done in `cel()` before; and it avoids having to commit to `dtype=float`.

Here is a comparison of timings before and after these changes, for both scalar (`_CEL_SCALAR_THRESHOLD` large) and vector (`_CEL_SCALAR_THRESHOLD = 0`) style `magpy.core.current_circle_Hfield()`:

<img width="578" height="437" alt="image" src="https://github.com/user-attachments/assets/aeb30ae0-341d-499b-8fdd-c16db21e61cd" />

The plot shows that merging the scalar and vector function did not adversely affect the timings, so it is a nice cleanup.
(It also suggests slightly increasing `_CEL_SCALAR_THRESHOLD = 15`, as it was in `_cel()` before...)

For definiteness, the script that generates the plot is attached here: [cel_iter_improvements.ipynb](https://github.com/user-attachments/files/28079487/cel_iter_improvements.ipynb)
