### PR TITLE
_cel() suggestions

### DIFF
--- a/src/magpylib/_src/fields/special_cel.py
+++ b/src/magpylib/_src/fields/special_cel.py
@@ -135,6 +135,7 @@ def _cel(kc: np.ndarray, p: np.ndarray, c: np.ndarray, s: np.ndarray) -> np.ndar
 
 # pylint: disable=too-many-positional-arguments
 
+
 def _cel_iter_scalarvector(qc, p, g, cc, ss, em, kk, xp=m, any_=lambda b: b):
     """
     Iterative part of the Bulirsch cel algorithm.

--- a/src/magpylib/_src/fields/special_cel.py
+++ b/src/magpylib/_src/fields/special_cel.py
@@ -10,12 +10,14 @@ _CEL_ERRORTOL = 1e-8
 
 def _cel_scalar(kc, p, c, s):
     """
-    scalar version of bulirsch cel algorithm
-    caller ensures that kc != 0
+    Scalar version of Bulirsch cel algorithm
     """
+    if kc == 0:
+        return np.nan
+
     if p > 0:
         p = m.sqrt(p)
-        s /= p
+        s = s / p
     else:
         f = kc * kc
         q = 1 - f
@@ -50,34 +52,33 @@ def _cel_scalar(kc, p, c, s):
 
 def _cel_vector(kc, p, c, s):
     """
-    vectorized version of Bulirsch cel algorithm.
+    Vectorized version of Bulirsch cel algorithm.
     """
 
     n = len(kc)
 
-    pp = p.copy()
-    cc = c.copy()
-    ss = s.copy()
+    p = p.copy()
+    c = c.copy()
+    s = s.copy()
 
-    mask = pp <= 0
+    mask = p <= 0
     pos = ~mask
 
-    pp[pos] = np.sqrt(pp[pos])
-    ss[pos] /= pp[pos]
+    p[pos] = np.sqrt(p[pos])
+    s[pos] /= p[pos]
 
     if np.any(mask):
         f = kc[mask] * kc[mask]
         q = 1 - f
-        g = 1 - pp[mask]
-        f -= pp[mask]
-        q *= ss[mask] - cc[mask] * pp[mask]
+        g = 1 - p[mask]
+        f -= p[mask]
+        q *= s[mask] - c[mask] * p[mask]
 
-        pp[mask] = np.sqrt(f / g)
-        cc[mask] = (cc[mask] - ss[mask]) / g
-        ss[mask] = -q / (g * g * pp[mask]) + cc[mask] * pp[mask]
+        p[mask] = np.sqrt(f / g)
+        c[mask] = (c[mask] - s[mask]) / g
+        s[mask] = -q / (g * g * p[mask]) + c[mask] * p[mask]
 
     em = np.ones(n)
-
     kc_zero = kc == 0
 
     qc = np.abs(kc)
@@ -86,10 +87,9 @@ def _cel_vector(kc, p, c, s):
     kk = qc.copy()
 
     while True:
-        g = kk / pp
-
-        cc, ss = cc + ss / pp, 2 * (ss + cc * g)
-        pp += g
+        g = kk / p
+        c, s = c + s / p, 2 * (s + c * g)
+        p += g
 
         g = em.copy()
         em += qc
@@ -100,7 +100,7 @@ def _cel_vector(kc, p, c, s):
         qc = 2 * np.sqrt(kk)
         kk = em * qc
 
-    result = (np.pi / 2) * (ss + cc * em) / (em * (em + pp))
+    result = (np.pi / 2) * (s + c * em) / (em * (em + p))
     result[kc_zero] = np.nan
 
     return result
@@ -109,11 +109,11 @@ def _cel_vector(kc, p, c, s):
 def _cel(kc: np.ndarray, p: np.ndarray, c: np.ndarray, s: np.ndarray) -> np.ndarray:
     """
     Complete elliptic integral
-                     π/2
-                      ⌠  c cos²𝜗 + s sin²𝜗         d𝜗
-    cel(kc, p, c, s) = |  ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
-                      ⌡   cos²𝜗 + p sin²𝜗   √(cos²𝜗 + kc² sin²𝜗)
-                      0
+                      π/2
+                       ⌠  c cos²𝜗 + s sin²𝜗          d𝜗
+    cel(kc, p, c, s) = |  ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+                       ⌡   cos²𝜗 + p sin²𝜗   √(cos²𝜗 + kc² sin²𝜗)
+                       0
     Combines vectorized and non-vectorized implementations for improved performance.
 
     See also:
@@ -128,16 +128,12 @@ def _cel(kc: np.ndarray, p: np.ndarray, c: np.ndarray, s: np.ndarray) -> np.ndar
     """
 
     if kc.size < _CEL_SCALAR_THRESHOLD:
-        out = np.empty(kc.size, dtype=float)
-        for i in range(kc.size):
-            out[i] = np.nan if kc[i] == 0 else _cel_scalar(kc[i], p[i], c[i], s[i])
-        return out
-
+        return np.array([_cel_scalar(*args)
+                         for args in zip(kc, p, c, s, strict=False)])  # fmt: skip
     return _cel_vector(kc, p, c, s)
 
 
 # pylint: disable=too-many-positional-arguments
-
 
 def _cel_iter_scalarvector(qc, p, g, cc, ss, em, kk, xp=m, any_=lambda b: b):
     """


### PR DESCRIPTION
A few minor suggestions:

- In `_cel_scalar()`: avoid in-place update `s /= p`, keep `s = s / p` instead, since we don't want to modify `s` in caller: 
An in-place update could in principle modify a variable in a function's caller, as in:
  ```python
  def f(x):
      x /= 2
      return x
  
  x = np.array(1)
  print(f(x))
  print(x)
  ``` 
  (for instance, when `x` is a numpy array). 
  That's why in `_cel_vector()`, the in-place update `ss /= p` is preceded by `ss = s.copy()`.

  Admittedly this is not immediately an issue, since `np.isscalar(s) -> True`, `_cel_scalar` is intended for scalars.
  But to me, this is a little too close for comfort.
  And it turns out it is for no benefit: `s=s/p` is actually slightly faster than `s/=p` in the situation at hand:

  ```python
  import numpy as np
  import timeit

  display(timeit.repeat('s /= p', setup='s = np.float64(0.1); p = np.float64(1)', number=100000000, globals=globals()))
  display(timeit.repeat('s = s / p', setup='s = np.float64(0.1); p = np.float64(1)', number=100000000, globals=globals()))
  [3.8989724999992177,
   3.931931999977678,
   3.937487700022757,
   4.007137299980968,
   4.009531599935144]
  [3.860392199945636,
   3.8086202000267804,
   3.8343616999918595,
   3.8326475999783725,
   3.8462840999709442]
  ```
- `_cel_vector()`: `pp -> p, cc -> c, ss -> s`
We don't need reference to the original function arguments after copying,
we can shadow the original arguments `p, c, s` on purpose: `c = c.copy()`, etc.
and we stay closer to the original Bulirsch formulation and to `_cel_scalar()`, by using just `p, c, s` instead of introducing additional `pp, cc, ss`.
- Change the alignment of the formula lines in the `_cel()` docstring, so the parts of the integral sign line up
- `_cel()`: Use a list comprehension instead of a for loop with indexing: faster, and it avoids committing to `dtype=float` in the initialization of result 
(and it was like that before)
- `_cel_scalar()` stated: 'Caller ensures that kc != 0' (i.e., `_cel()` would take care of it):
  I'd suggest to include this in `_cel_scalar()`, since 
  1) `_cel_vector()` deals with the `kc==0` case internally too, it is consistent; 
  2) in `_cel()` it clutters up the list comprehension, while in `_cel_scalar()` it fits naturally at the beginning;
  3) it simplifies the `_cel_scalar` docstring (no 'Caller ensures that...')
