### PR TITLE
🎨 Declarative typed-property tree for styles and defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [Unreleased]
+
+- Rewrote the style and defaults internals as a declarative typed-property tree,
+  replacing `MagicProperties`
+  ([#967](https://github.com/magpylib/magpylib/pull/967)). Style _usage_ is
+  unchanged — nested attribute access, magic underscore kwargs, dict assignment
+  and `None`-defers-to-defaults all behave as before — but `show()` is about 3x
+  faster on typical scenes and `get_style()` about 50x faster per object.
+- Added a public introspection contract on every style and defaults node, so
+  third-party tools can build GUIs on top: `schema()` (JSON Schema),
+  `get(path)`/`set(path, value)` (dotted paths), `observe(callback)` (change
+  events), and `is_set`/`set_values()`/`merged()` (set-vs-inherited resolution).
+- **Breaking:** invalid style and defaults values now raise `ValueError` instead
+  of `AssertionError`. The old checks were `assert` statements and silently
+  vanished under `python -O`.
+- **Breaking:** number-valued style properties no longer accept booleans (`bool`
+  is an `int` subclass, so the old checks let `size=True` through).
+- **Breaking:** assigning `None` to an always-set property such as
+  `style.model3d.showdefault` now resets it to its default instead of raising.
+- **Breaking:** `as_dict()` no longer includes the deprecated
+  `magnetization.size` key. It remains readable and writable as an attribute.
+- `magpy.defaults.display.backend` and `style.model3d.data[].backend` now accept
+  any backend present in the display registry, resolved per call instead of
+  frozen at import. `magpylib.SUPPORTED_PLOTTING_BACKENDS` is unchanged and
+  still lists the built-in backends.
+- Fixed `color_validator` raising `TypeError: unhashable type` on the documented
+  list and array color forms.
+
 ## [5.2.3] 2026-05-15
 
 - Fixed `getFT` modifying the root logger at import time via

--- a/src/magpylib/_src/defaults/defaults_classes.py
+++ b/src/magpylib/_src/defaults/defaults_classes.py
@@ -1,8 +1,8 @@
 """Library default settings classes, declared as a typed-property tree."""
 
 from magpylib._src.defaults.defaults_utility import (
-    SUPPORTED_PLOTTING_BACKENDS,
     get_defaults_dict,
+    get_registered_backends,
 )
 from magpylib._src.defaults.property_tree import (
     Boolean,
@@ -75,8 +75,9 @@ class Display(PropertyNode):
     ----------
     backend: str, default=None
         Plotting backend to be used by default, if not explicitly set in the
-        `display` function (e.g. 'matplotlib', 'plotly'). Supported backends
-        are defined in magpylib.SUPPORTED_PLOTTING_BACKENDS.
+        `display` function (e.g. 'matplotlib', 'plotly'). The built-in
+        backends are listed in magpylib.SUPPORTED_PLOTTING_BACKENDS; any
+        backend registered at runtime is accepted as well.
     colorsequence: iterable, default=None
         An iterable of color values used to cycle through for every object
         displayed. A color may be specified by a hex string, an rgb string,
@@ -92,7 +93,8 @@ class Display(PropertyNode):
     """
 
     backend = Choice(
-        *SUPPORTED_PLOTTING_BACKENDS, "auto", doc="Default plotting backend."
+        lambda: (*get_registered_backends(), "auto"),
+        doc="Default plotting backend.",
     )
     colorsequence = ColorSequence(
         doc="Colors cycled through for every object displayed."

--- a/src/magpylib/_src/defaults/defaults_classes.py
+++ b/src/magpylib/_src/defaults/defaults_classes.py
@@ -1,273 +1,129 @@
+"""Library default settings classes, declared as a typed-property tree."""
+
 from magpylib._src.defaults.defaults_utility import (
     SUPPORTED_PLOTTING_BACKENDS,
-    MagicProperties,
-    color_validator,
     get_defaults_dict,
-    validate_property_class,
+)
+from magpylib._src.defaults.property_tree import (
+    Boolean,
+    Choice,
+    ColorSequence,
+    Integer,
+    Nested,
+    Number,
+    Property,
+    PropertyNode,
 )
 from magpylib._src.style import DisplayStyle
 
 
-class DefaultSettings(MagicProperties):
+class AnimationOutput(Property):
+    """A string ending with 'mp4' or 'gif', coerced via str()."""
+
+    def validate(self, obj, value):
+        value = str(value)
+        if not value.endswith(("mp4", "gif")):
+            self._fail(obj, value, "either 'mp4' or 'gif'")
+        return value
+
+
+class Animation(PropertyNode):
+    """Defines the animation properties used by the `plotly` plotting backend
+    when `animation=True` in the `show` function.
+
+    Parameters
+    ----------
+    fps: int, default=None
+        Target number of frames to be displayed per second.
+    maxfps: int, default=None
+        Maximum number of frames to be displayed per second before downsampling
+        kicks in.
+    maxframes: int, default=None
+        Maximum total number of frames to be displayed before downsampling
+        kicks in.
+    time: int, default=None
+        Default animation time.
+    slider: bool, default=None
+        If True, an interactive slider will be displayed and stay in sync with
+        the animation, will be hidden otherwise.
+    output: str, default=None
+        The path where to store the animation. Must end with `.mp4` or `.gif`.
+        If only the suffix is used, the file is only stored in a temporary
+        folder and deleted after the animation is done.
+    """
+
+    fps = Integer(
+        exclusive_minimum=0, doc="Target number of frames displayed per second."
+    )
+    maxfps = Integer(
+        exclusive_minimum=0,
+        doc="Maximum number of frames per second before downsampling kicks in.",
+    )
+    maxframes = Integer(
+        exclusive_minimum=0,
+        doc="Maximum total number of frames before downsampling kicks in.",
+    )
+    time = Integer(exclusive_minimum=0, doc="Default animation time.")
+    slider = Boolean(doc="Show/hide interactive animation slider.")
+    output = AnimationOutput(doc="Animation output type ('mp4' or 'gif').")
+
+
+class Display(PropertyNode):
+    """Defines the properties for the plotting features.
+
+    Parameters
+    ----------
+    backend: str, default=None
+        Plotting backend to be used by default, if not explicitly set in the
+        `display` function (e.g. 'matplotlib', 'plotly'). Supported backends
+        are defined in magpylib.SUPPORTED_PLOTTING_BACKENDS.
+    colorsequence: iterable, default=None
+        An iterable of color values used to cycle through for every object
+        displayed. A color may be specified by a hex string, an rgb string,
+        or a named CSS color.
+    animation: dict or `Animation` object, default=None
+        Animation properties used by the `plotly` plotting backend when
+        `animation=True` in the `show` function.
+    autosizefactor: float, default=None
+        Defines at which scale objects like sensors and dipoles are displayed.
+        Specifically `object_size` = `canvas_size` / `AUTOSIZE_FACTOR`.
+    style: dict or `DisplayStyle` object, default=None
+        Display styling properties for all object families.
+    """
+
+    backend = Choice(
+        *SUPPORTED_PLOTTING_BACKENDS, "auto", doc="Default plotting backend."
+    )
+    colorsequence = ColorSequence(
+        doc="Colors cycled through for every object displayed."
+    )
+    animation = Nested(Animation, doc="Animation properties (plotly backend).")
+    autosizefactor = Number(
+        exclusive_minimum=0, doc="Display scale of autosized objects."
+    )
+    style = Nested(DisplayStyle, doc="Display styling properties for all families.")
+
+
+class DefaultSettings(PropertyNode):
     """Library default settings.
 
     Parameters
     ----------
-    display: dict or Display
-        `Display` class containing display settings. ('backend', 'animation', 'colorsequence' ...)`
+    display: dict or `Display` object
+        `Display` class containing display settings
+        ('backend', 'animation', 'colorsequence', ...).
     """
 
-    def __init__(
-        self,
-        display=None,
-        **kwargs,
-    ):
-        super().__init__(
-            display=display,
-            **kwargs,
-        )
+    display = Nested(Display, doc="Display settings.")
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.reset()
 
     def reset(self):
-        """Resets all nested properties to their hard coded default values"""
+        """Resets all nested properties to their hard coded default values."""
         self.update(get_defaults_dict(), _match_properties=False)
         return self
-
-    @property
-    def display(self):
-        """`Display` class containing display settings.
-        ('backend', 'animation', 'colorsequence')`"""
-        return self._display
-
-    @display.setter
-    def display(self, val):
-        self._display = validate_property_class(val, "display", Display, self)
-
-
-class Display(MagicProperties):
-    """
-    Defines the properties for the plotting features.
-
-    Properties
-    ----------
-    backend: str, default='matplotlib'
-        Defines the plotting backend to be used by default, if not explicitly set in the `display`
-        function (e.g. 'matplotlib', 'plotly').
-        Supported backends are defined in magpylib.SUPPORTED_PLOTTING_BACKENDS
-
-    colorsequence: iterable, default=
-            ['#2E91E5', '#E15F99', '#1CA71C', '#FB0D0D', '#DA16FF', '#222A2A',
-            '#B68100', '#750D86', '#EB663B', '#511CFB', '#00A08B', '#FB00D1',
-            '#FC0080', '#B2828D', '#6C7C32', '#778AAE', '#862A16', '#A777F1',
-            '#620042', '#1616A7', '#DA60CA', '#6C4516', '#0D2A63', '#AF0038']
-        An iterable of color values used to cycle through for every object displayed.
-        A color may be specified by
-      - a hex string (e.g. '#ff0000')
-      - an rgb/rgba string (e.g. 'rgb(255, 0, 0)')
-      - an hsl/hsla string (e.g. 'hsl(0, 100%, 50%)')
-      - an hsv/hsva string (e.g. 'hsv(0, 100%, 100%)')
-      - a named CSS color
-
-    animation: dict or Animation
-        Defines the animation properties used by the `plotly` plotting backend when `animation=True`
-        in the `show` function.
-
-    autosizefactor: int, default=10
-        Defines at which scale objects like sensors and dipoles are displayed.
-        Specifically `object_size` = `canvas_size` / `AUTOSIZE_FACTOR`.
-
-    styles: dict or DisplayStyle
-        Base class containing display styling properties for all object families.
-    """
-
-    @property
-    def backend(self):
-        """plotting backend to be used by default, if not explicitly set in the `display`
-        function (e.g. 'matplotlib', 'plotly').
-        Supported backends are defined in magpylib.SUPPORTED_PLOTTING_BACKENDS"""
-        return self._backend
-
-    @backend.setter
-    def backend(self, val):
-        backends = [*SUPPORTED_PLOTTING_BACKENDS, "auto"]
-        assert val is None or val in backends, (
-            f"Input backend of {type(self).__name__} must be one of "
-            f"{backends}; instead received {val!r}."
-        )
-        self._backend = val
-
-    @property
-    def colorsequence(self):
-        """An iterable of color values used to cycle through for every object displayed.
-          A color may be specified by
-        - a hex string (e.g. '#ff0000')
-        - an rgb/rgba string (e.g. 'rgb(255, 0, 0)')
-        - an hsl/hsla string (e.g. 'hsl(0, 100%, 50%)')
-        - an hsv/hsva string (e.g. 'hsv(0, 100%, 100%)')
-        - a named CSS color"""
-        return self._colorsequence
-
-    @colorsequence.setter
-    def colorsequence(self, val):
-        if val is not None:
-            name = type(self).__name__
-            try:
-                val = tuple(
-                    color_validator(c, allow_None=False, parent_name=f"{name}")
-                    for c in val
-                )
-            except TypeError as err:
-                msg = (
-                    f"The colorsequence property of {name} must be an "
-                    f"iterable of colors; instead received {val!r}."
-                )
-                raise ValueError(msg) from err
-
-        self._colorsequence = val
-
-    @property
-    def animation(self):
-        """Animation properties used by the ``plotly`` plotting backend when ``animation=True``
-        in the ``show()`` function."""
-        return self._animation
-
-    @animation.setter
-    def animation(self, val):
-        self._animation = validate_property_class(val, "animation", Animation, self)
-
-    @property
-    def autosizefactor(self):
-        """Defines at which scale objects like sensors and dipoles are displayed.
-        Specifically `object_size` = `canvas_size` / `AUTOSIZE_FACTOR`."""
-        return self._autosizefactor
-
-    @autosizefactor.setter
-    def autosizefactor(self, val):
-        assert val is None or (isinstance(val, int | float) and val > 0), (
-            f"Input autosizefactor of {type(self).__name__} must be a strictly positive"
-            f" number; instead received {val!r}."
-        )
-        self._autosizefactor = val
-
-    @property
-    def style(self):
-        """Base class containing display styling properties for all object families."""
-        return self._style
-
-    @style.setter
-    def style(self, val):
-        self._style = validate_property_class(val, "style", DisplayStyle, self)
-
-
-class Animation(MagicProperties):
-    """
-    Defines the animation properties used by the `plotly` plotting backend when `animation=True`
-    in the `display` function.
-
-    Properties
-    ----------
-    fps: str, default=30
-        Target number of frames to be displayed per second.
-
-    maxfps: str, default=50
-        Maximum number of frames to be displayed per second before downsampling kicks in.
-
-    maxframes: int, default=200
-        Maximum total number of frames to be displayed before downsampling kicks in.
-
-    time: float, default=5
-        Default animation time.
-
-    slider: bool, default = True
-        If True, an interactive slider will be displayed and stay in sync with the animation, will
-        be hidden otherwise.
-
-    output: str, default = None
-        The path where to store the animation. Must end with `.mp4` or `.gif`. If only the suffix
-        is used, the file is only store in a temporary folder and deleted after the animation is
-        done.
-    """
-
-    @property
-    def maxfps(self):
-        """Maximum number of frames to be displayed per second before downsampling kicks in."""
-        return self._maxfps
-
-    @maxfps.setter
-    def maxfps(self, val):
-        assert val is None or (isinstance(val, int) and val > 0), (
-            f"Input maxfps of {type(self).__name__} must be a strictly positive"
-            f" integer; instead received {val!r}."
-        )
-        self._maxfps = val
-
-    @property
-    def fps(self):
-        """Target number of frames to be displayed per second."""
-        return self._fps
-
-    @fps.setter
-    def fps(self, val):
-        assert val is None or (isinstance(val, int) and val > 0), (
-            f"Input fps of {type(self).__name__} must be a strictly positive"
-            f" integer; instead received {val!r}."
-        )
-        self._fps = val
-
-    @property
-    def maxframes(self):
-        """Maximum total number of frames to be displayed before downsampling kicks in."""
-        return self._maxframes
-
-    @maxframes.setter
-    def maxframes(self, val):
-        assert val is None or (isinstance(val, int) and val > 0), (
-            f"Input maxframes of {type(self).__name__} must be a strictly positive"
-            f" integer; instead received {val!r}."
-        )
-        self._maxframes = val
-
-    @property
-    def time(self):
-        """Default animation time."""
-        return self._time
-
-    @time.setter
-    def time(self, val):
-        assert val is None or (isinstance(val, int) and val > 0), (
-            f"Input time of {type(self).__name__} must be a strictly positive"
-            f" integer; instead received {val!r}."
-        )
-        self._time = val
-
-    @property
-    def slider(self):
-        """show/hide slider"""
-        return self._slider
-
-    @slider.setter
-    def slider(self, val):
-        assert val is None or isinstance(val, bool), (
-            f"Input slider of {type(self).__name__} must be a either True or False"
-            f"; instead received {val!r}."
-        )
-        self._slider = val
-
-    @property
-    def output(self):
-        """Animation output type"""
-        return self._output
-
-    @output.setter
-    def output(self, val):
-        if val is not None:
-            val = str(val)
-            valid = val.endswith(("mp4", "gif"))
-            assert val is None or valid, (
-                f"Input output of {type(self).__name__} must be a either 'mp4' or 'gif' "
-                f"; instead received {val!r}."
-            )
-        self._output = val
 
 
 default_settings = DefaultSettings()

--- a/src/magpylib/_src/defaults/defaults_utility.py
+++ b/src/magpylib/_src/defaults/defaults_utility.py
@@ -3,6 +3,7 @@
 # pylint: disable=too-many-branches
 
 import re
+import sys
 from copy import deepcopy
 from functools import lru_cache
 
@@ -12,6 +13,25 @@ from matplotlib.colors import CSS4_COLORS as mcolors
 from magpylib._src.defaults.defaults_values import DEFAULTS
 
 SUPPORTED_PLOTTING_BACKENDS = ("matplotlib", "plotly", "pyvista")
+
+
+def get_registered_backends():
+    """Return the names of the display backends registered so far.
+
+    Unlike `SUPPORTED_PLOTTING_BACKENDS`, which lists the built-in backends
+    only, this reflects backends registered at runtime through
+    `RegisteredBackend`.
+
+    The registry module is looked up rather than imported: it imports the
+    defaults tree, so importing it from here would be circular while this
+    module is still initializing. That is not a limitation -- registering a
+    backend requires importing the registry, so while it is absent the
+    registered set is exactly the built-in one.
+    """
+    module = sys.modules.get("magpylib._src.display.display")
+    if module is None:
+        return SUPPORTED_PLOTTING_BACKENDS
+    return tuple(module.RegisteredBackend.backends)
 
 
 ALLOWED_SYMBOLS = (".", "+", "D", "d", "s", "x", "o")

--- a/src/magpylib/_src/defaults/defaults_utility.py
+++ b/src/magpylib/_src/defaults/defaults_utility.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=too-many-branches
 
-import collections.abc
 import re
 from copy import deepcopy
 from functools import lru_cache
@@ -82,48 +81,6 @@ def get_defaults_dict(arg=None) -> dict:
         for v in arg.split("."):
             dict_ = dict_[v]
     return dict_
-
-
-def update_nested_dict(d, u, same_keys_only=False, replace_None_only=False) -> dict:
-    """updates recursively dictionary 'd' from  dictionary 'u'
-
-    Parameters
-    ----------
-    d : dict
-       dictionary to be updated
-    u : dict
-        dictionary to update with
-    same_keys_only : bool, optional
-        if ``True``, only key found in d get updated and no new items are created,
-        by default False
-    replace_None_only : bool, optional
-        if ``True``, only key/value pair from d where ``value=None`` get updated from u,
-        by default False
-
-    Returns
-    -------
-    dict
-        updated dictionary
-    """
-    if not isinstance(d, collections.abc.Mapping):
-        if d is None or not replace_None_only:
-            d = u.copy()
-        return d
-    new_dict = deepcopy(d)
-    for k, v in u.items():
-        if k in new_dict or not same_keys_only:
-            if isinstance(v, collections.abc.Mapping):
-                new_dict[k] = update_nested_dict(
-                    new_dict.get(k, {}),
-                    v,
-                    same_keys_only=same_keys_only,
-                    replace_None_only=replace_None_only,
-                )
-            elif (new_dict.get(k, None) is None or not replace_None_only) and (
-                not same_keys_only or k in new_dict
-            ):
-                new_dict[k] = v
-    return new_dict
 
 
 def magic_to_dict(kwargs, separator="_") -> dict:
@@ -300,22 +257,6 @@ def _color_validator_cached(color_input, allow_None=True, parent_name=""):
     return color_new
 
 
-def validate_property_class(val, name, class_, parent):
-    """validator for sub property"""
-    if isinstance(val, dict):
-        val = class_(**val)
-    elif val is None:
-        val = class_()
-    if not isinstance(val, class_):
-        msg = (
-            f"The {name} property of {type(parent).__name__} must be an instance "
-            f"of {class_} or a dictionary with equivalent key/value pairs; "
-            f"instead received {val!r}."
-        )
-        raise TypeError(msg)
-    return val
-
-
 @lru_cache(maxsize=1)
 def _valid_style_keys():
     """generally available style keys, derived from the hardcoded defaults"""
@@ -337,123 +278,3 @@ def validate_style_keys(style_kwargs):
         )
         raise ValueError(msg)
     return style_kwargs
-
-
-class MagicProperties:
-    (
-        """
-    Base Class to represent only the property attributes defined at initialization, after which the
-    class is frozen. This prevents user to create any attributes that are not defined as properties.
-
-    Raises
-    ------
-    AttributeError
-        raises AttributeError if the object is not a property
-    """
-        """"""
-    )
-
-    __isfrozen = False
-
-    def __init__(self, **kwargs):
-        input_dict = dict.fromkeys(self._property_names_generator())
-        if kwargs:
-            magic_kwargs = magic_to_dict(kwargs)
-            diff = set(magic_kwargs.keys()).difference(set(input_dict.keys()))
-            for attr in diff:
-                msg = (
-                    f"{type(self).__name__} has no property {attr}. "
-                    f"Available properties: {list(self._property_names_generator())}."
-                )
-                raise AttributeError(msg)
-            input_dict.update(magic_kwargs)
-        for k, v in input_dict.items():
-            setattr(self, k, v)
-        self._freeze()
-
-    def __setattr__(self, key, value):
-        if self.__isfrozen and not hasattr(self, key):
-            msg = (
-                f"{type(self).__name__} has no property {key}. "
-                f"Available properties: {list(self._property_names_generator())}."
-            )
-            raise AttributeError(msg)
-        object.__setattr__(self, key, value)
-
-    def _freeze(self):
-        self.__isfrozen = True
-
-    def _property_names_generator(self):
-        """returns a generator with class properties only"""
-        return (
-            attr
-            for attr in dir(self)
-            if isinstance(getattr(type(self), attr, None), property)
-        )
-
-    def __repr__(self):
-        params = self._property_names_generator()
-        dict_str = ", ".join(f"{k}={getattr(self, k)!r}" for k in params)
-        return f"{type(self).__name__}({dict_str})"
-
-    def as_dict(self, flatten=False, separator="."):
-        """Returns recursively a nested dictionary with all properties objects of the class
-
-        Parameters
-        ----------
-        flatten: bool
-            If ``True``, the nested dictionary gets flatten out with provided separator for the
-            dictionary keys
-        separator: str
-            the separator to be used when flattening the dictionary. Only applies if
-            ``flatten=True``
-        """
-        params = self._property_names_generator()
-        dict_ = {}
-        for k in params:
-            val = getattr(self, k)
-            if hasattr(val, "as_dict"):
-                dict_[k] = val.as_dict()
-            else:
-                dict_[k] = val
-        if flatten:
-            dict_ = linearize_dict(dict_, separator=separator)
-        return dict_
-
-    def update(
-        self, arg=None, _match_properties=True, _replace_None_only=False, **kwargs
-    ):
-        """
-        Updates the class properties with provided arguments, supports magic underscore notation
-
-        Parameters
-        ----------
-        _match_properties: bool
-            If ``True``, checks if provided properties over keyword arguments are matching the current
-            object properties. An error is raised if a non-matching property is found.
-            If ``False``, the ``update`` method does not raise any error when an argument is not
-            matching a property.
-        _replace_None_only:
-            updates matching properties that are equal to ``None`` (not already been set)
-
-
-        Returns
-        -------
-        self
-        """
-        arg = {} if arg is None else arg.copy()
-        arg = magic_to_dict({**arg, **kwargs})
-        current_dict = self.as_dict()
-        new_dict = update_nested_dict(
-            current_dict,
-            arg,
-            same_keys_only=not _match_properties,
-            replace_None_only=_replace_None_only,
-        )
-        for k, v in new_dict.items():
-            setattr(self, k, v)
-        return self
-
-    def copy(self):
-        """returns a copy of the current class instance"""
-        return deepcopy(self)

--- a/src/magpylib/_src/defaults/defaults_utility.py
+++ b/src/magpylib/_src/defaults/defaults_utility.py
@@ -7,6 +7,7 @@ import re
 from copy import deepcopy
 from functools import lru_cache
 
+import numpy as np
 from matplotlib.colors import CSS4_COLORS as mcolors
 
 from magpylib._src.defaults.defaults_values import DEFAULTS
@@ -206,7 +207,6 @@ def linearize_dict(kwargs, separator=".") -> dict:
     return dict_
 
 
-@lru_cache(maxsize=1000)
 def color_validator(color_input, allow_None=True, parent_name=""):
     """validates color inputs based on chosen `backend', allows `None` by default.
 
@@ -229,6 +229,16 @@ def color_validator(color_input, allow_None=True, parent_name=""):
     ValueError
         raises ValueError inf validation fails
     """
+    if isinstance(color_input, list | np.ndarray):
+        color_input = tuple(np.asarray(color_input).tolist())
+    try:
+        return _color_validator_cached(color_input, allow_None, parent_name)
+    except TypeError:  # unhashable input (e.g. nested list) cannot use the cache
+        return _color_validator_cached.__wrapped__(color_input, allow_None, parent_name)
+
+
+@lru_cache(maxsize=1000)
+def _color_validator_cached(color_input, allow_None=True, parent_name=""):
     if allow_None and color_input is None:
         return color_input
 

--- a/src/magpylib/_src/defaults/defaults_utility.py
+++ b/src/magpylib/_src/defaults/defaults_utility.py
@@ -316,11 +316,17 @@ def validate_property_class(val, name, class_, parent):
     return val
 
 
+@lru_cache(maxsize=1)
+def _valid_style_keys():
+    """generally available style keys, derived from the hardcoded defaults"""
+    styles_by_family = DEFAULTS["display"]["style"]
+    return frozenset(key for v in styles_by_family.values() for key in v)
+
+
 def validate_style_keys(style_kwargs):
     """validates style kwargs based on key up to first underscore.
     checks in the defaults structures the generally available style keys"""
-    styles_by_family = get_defaults_dict("display.style")
-    valid_keys = {key for v in styles_by_family.values() for key in v}
+    valid_keys = _valid_style_keys()
     level0_style_keys = {k.split("_")[0]: k for k in style_kwargs}
     kwargs_diff = set(level0_style_keys).difference(valid_keys)
     invalid_keys = {level0_style_keys[k] for k in kwargs_diff}

--- a/src/magpylib/_src/defaults/property_tree.py
+++ b/src/magpylib/_src/defaults/property_tree.py
@@ -407,6 +407,8 @@ class PropertyNode:
                 setattr(self, key, value)
         return self
 
+    _IMMUTABLE_TYPES = (str, int, float, bool, type(None))
+
     def copy(self):
         """Return a detached, unobserved deep copy."""
         new = type(self).__new__(type(self))
@@ -418,6 +420,8 @@ class PropertyNode:
                 object.__setattr__(child, "_parent", new)
                 object.__setattr__(child, "_name", key)
                 new.__dict__[key] = child
+            elif isinstance(value, self._IMMUTABLE_TYPES):
+                new.__dict__[key] = value
             else:
                 new.__dict__[key] = deepcopy(value)
         return new

--- a/src/magpylib/_src/defaults/property_tree.py
+++ b/src/magpylib/_src/defaults/property_tree.py
@@ -410,10 +410,9 @@ class PropertyNode:
     def copy(self):
         """Return a detached, unobserved deep copy."""
         new = type(self).__new__(type(self))
-        for key in self.__dict__:
+        for key, value in self.__dict__.items():
             if key not in self._fields:
                 continue
-            value = self.__dict__[key]
             if isinstance(value, PropertyNode):
                 child = value.copy()
                 object.__setattr__(child, "_parent", new)
@@ -489,14 +488,14 @@ class PropertyNode:
         """Register ``callback(path, value)`` to fire on any change in this
         subtree; ``path`` is the dotted path of the changed property relative
         to this node."""
-        if not self._observers:
-            object.__setattr__(self, "_observers", [])
-        self._observers.append(callback)
+        object.__setattr__(self, "_observers", (*self._observers, callback))
         self._mark_observed()
 
     def unobserve(self, callback):
         """Unregister a previously registered callback."""
-        self._observers.remove(callback)
+        observers = list(self._observers)
+        observers.remove(callback)
+        object.__setattr__(self, "_observers", tuple(observers))
 
     def _mark_observed(self):
         object.__setattr__(self, "_observed", True)

--- a/src/magpylib/_src/defaults/property_tree.py
+++ b/src/magpylib/_src/defaults/property_tree.py
@@ -108,10 +108,13 @@ class Number(Property):
     json_type = "number"
     _types = (int, float)
 
-    def __init__(self, default=None, doc="", minimum=None, maximum=None):
+    def __init__(
+        self, default=None, doc="", minimum=None, maximum=None, exclusive_minimum=None
+    ):
         super().__init__(default, doc)
         self.minimum = minimum
         self.maximum = maximum
+        self.exclusive_minimum = exclusive_minimum
 
     def validate(self, obj, value):
         if (
@@ -119,9 +122,13 @@ class Number(Property):
             or isinstance(value, bool)
             or (self.minimum is not None and value < self.minimum)
             or (self.maximum is not None and value > self.maximum)
+            or (self.exclusive_minimum is not None and value <= self.exclusive_minimum)
         ):
             bounds = [
                 f">={self.minimum}" if self.minimum is not None else "",
+                f">{self.exclusive_minimum}"
+                if self.exclusive_minimum is not None
+                else "",
                 f"<={self.maximum}" if self.maximum is not None else "",
             ]
             bounds = " and ".join(b for b in bounds if b)
@@ -135,6 +142,8 @@ class Number(Property):
             out["minimum"] = self.minimum
         if self.maximum is not None:
             out["maximum"] = self.maximum
+        if self.exclusive_minimum is not None:
+            out["exclusiveMinimum"] = self.exclusive_minimum
         return out
 
 
@@ -210,18 +219,47 @@ class Color(Property):
         return {**super().schema(), "format": "color"}
 
 
+class ColorSequence(Property):
+    """A tuple of CSS colors, each normalized by `color_validator`."""
+
+    kind = "colorsequence"
+
+    def validate(self, obj, value):
+        name = type(obj).__name__
+        try:
+            return tuple(
+                color_validator(c, allow_None=False, parent_name=name) for c in value
+            )
+        except TypeError as err:
+            msg = (
+                f"Input {self.name} of {name} must be an "
+                f"iterable of colors; instead received {value!r}."
+            )
+            raise ValueError(msg) from err
+
+    def schema(self):
+        out = super().schema()
+        out["type"] = ["array", "null"]
+        out["items"] = {"type": "string", "format": "color"}
+        return out
+
+
 class Nested(Property):
     """A child `PropertyNode`, instantiated lazily on first access.
 
     Assigning a dict builds a fresh node from it (replace, not merge — use
     ``update()`` to merge); assigning ``None`` resets to a pristine node.
+    With ``from_str``, assigning a string builds a node with that field set,
+    e.g. ``style.description = "hello"`` for ``Nested(Description,
+    from_str="text")``.
     """
 
     kind = "node"
 
-    def __init__(self, node_class, doc=""):
+    def __init__(self, node_class, doc="", from_str=None):
         super().__init__(None, doc)
         self.node_class = node_class
+        self.from_str = from_str
 
     def __get__(self, obj, objtype=None):
         if obj is None:
@@ -236,6 +274,8 @@ class Nested(Property):
             obj.__dict__.pop(self.name, None)  # pristine node on next access
         elif isinstance(value, dict):
             self._adopt(obj, self.node_class(**value))
+        elif isinstance(value, str) and self.from_str:
+            self._adopt(obj, self.node_class(**{self.from_str: value}))
         elif isinstance(value, self.node_class):
             self._adopt(obj, value)
         else:
@@ -291,7 +331,12 @@ class PropertyNode:
             self.update(kwargs)
 
     def __setattr__(self, name, value):
-        if name in self._fields or name.startswith("_"):
+        if (
+            name in self._fields
+            or name.startswith("_")
+            # plain python properties are allowed, e.g. deprecated aliases
+            or isinstance(getattr(type(self), name, None), property)
+        ):
             object.__setattr__(self, name, value)
         else:
             msg = (
@@ -343,7 +388,9 @@ class PropertyNode:
         for key, value in data.items():
             field = self._fields.get(key)
             if field is None:
-                if _match_properties:
+                if isinstance(getattr(type(self), key, None), property):
+                    setattr(self, key, value)  # e.g. deprecated aliases
+                elif _match_properties:
                     msg = (
                         f"{type(self).__name__} has no property {key!r}. "
                         f"Available properties: {list(self._fields)}."

--- a/src/magpylib/_src/defaults/property_tree.py
+++ b/src/magpylib/_src/defaults/property_tree.py
@@ -182,17 +182,33 @@ class String(Property):
 
 
 class Choice(Property):
-    """A field restricted to an explicit set of allowed values."""
+    """A field restricted to a set of allowed values.
+
+    The values are given either directly, or as a single zero-argument
+    callable returning them, for sets that are only known at call time (e.g.
+    the display backends registered so far). A callable is re-evaluated on
+    every `validate()` and `schema()`, so a generated schema describes the
+    choices as they stand at generation time.
+    """
 
     kind = "choice"
 
     def __init__(self, *choices, default=None, doc=""):
         super().__init__(default, doc)
-        self.choices = choices
+        if len(choices) == 1 and callable(choices[0]):
+            self._choices = choices[0]
+        else:
+            self._choices = lambda: choices
+
+    @property
+    def choices(self):
+        """The currently allowed values."""
+        return tuple(self._choices())
 
     def validate(self, obj, value):
-        if value not in self.choices:
-            self._fail(obj, value, f"one of {self.choices}")
+        choices = self.choices
+        if value not in choices:
+            self._fail(obj, value, f"one of {choices}")
         return value
 
     def schema(self):

--- a/src/magpylib/_src/defaults/property_tree.py
+++ b/src/magpylib/_src/defaults/property_tree.py
@@ -56,12 +56,8 @@ class Property:
         self.name = None
 
     def __set_name__(self, owner, name):
-        if "_" in name:
-            msg = (
-                f"Property name {name!r} of {owner.__name__} must not contain "
-                "underscores; they are reserved for magic underscore notation."
-            )
-            raise ValueError(msg)
+        # name validation happens in PropertyNode.__init_subclass__: exceptions
+        # raised in __set_name__ get wrapped in RuntimeError before python 3.12
         self.name = name
 
     def __get__(self, obj, objtype=None):
@@ -325,6 +321,13 @@ class PropertyNode:
             for key, val in vars(klass).items()
             if isinstance(val, Property)
         }
+        for key in cls._fields:
+            if "_" in key:
+                msg = (
+                    f"Property name {key!r} of {cls.__name__} must not contain "
+                    "underscores; they are reserved for magic underscore notation."
+                )
+                raise ValueError(msg)
 
     def __init__(self, **kwargs):
         if kwargs:

--- a/src/magpylib/_src/defaults/property_tree.py
+++ b/src/magpylib/_src/defaults/property_tree.py
@@ -1,0 +1,464 @@
+"""Declarative typed-property tree for style and settings classes.
+
+Successor of ``MagicProperties``: a settings class declares each field once
+as a typed descriptor,
+
+    class Line(PropertyNode):
+        style = Choice(*ALLOWED_LINESTYLES, doc="Line style.")
+        color = Color(doc="Line color.")
+        width = Number(minimum=0, doc="Line width.")
+
+and validation, magic-underscore updates, dict round-tripping, schema
+introspection, change observation and layered resolution all derive
+generically from the declarations.
+
+Value semantics: a field only ever stores explicitly set values; assigning
+``None`` unsets it, after which reading returns the field default (usually
+``None``, meaning "defer to the next defaults layer at display time").
+
+Public contract for GUIs and third-party tooling:
+
+- ``schema()``: JSON-Schema description of the field tree
+- ``get(path)`` / ``set(path, value)``: dotted-path access
+- ``observe(callback)``: change events bubble up the tree and report the
+  dotted path of the changed leaf
+- ``is_set(name)`` / ``set_values()``: distinguish explicitly set values
+  from deferred ones
+- ``merged(*layers)``: first-set-wins resolution across defaults layers
+"""
+
+from copy import deepcopy
+from typing import ClassVar
+
+from magpylib._src.defaults.defaults_utility import (
+    color_validator,
+    linearize_dict,
+    magic_to_dict,
+)
+
+
+class Property:
+    """Base descriptor for a leaf field of a `PropertyNode`.
+
+    Parameters
+    ----------
+    default: any
+        Effective value reported while the field is not explicitly set.
+    doc: str
+        Single-line description, surfaced in `schema()`.
+    """
+
+    kind = "any"
+
+    def __init__(self, default=None, doc=""):
+        self.default = default
+        self.doc = doc
+        self.name = None
+
+    def __set_name__(self, owner, name):
+        if "_" in name:
+            msg = (
+                f"Property name {name!r} of {owner.__name__} must not contain "
+                "underscores; they are reserved for magic underscore notation."
+            )
+            raise ValueError(msg)
+        self.name = name
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return obj.__dict__.get(self.name, self.default)
+
+    def __set__(self, obj, value):
+        if value is None:
+            obj.__dict__.pop(self.name, None)  # unset
+            new = self.default
+        else:
+            new = obj.__dict__[self.name] = self.validate(obj, value)
+        if obj._observed:
+            obj._notify(self.name, new)
+
+    def validate(self, obj, value):  # noqa: ARG002  (interface for subclasses)
+        """Return the validated (possibly normalized) value or raise."""
+        return value
+
+    def _fail(self, obj, value, expected):
+        msg = (
+            f"Input {self.name} of {type(obj).__name__} must be {expected}; "
+            f"instead received {value!r}."
+        )
+        raise ValueError(msg)
+
+    def schema(self):
+        """Return the JSON-Schema description of this field."""
+        out = {"type": [self.json_type, "null"]} if self.json_type else {}
+        if self.doc:
+            out["description"] = self.doc
+        if self.default is not None:
+            out["default"] = self.default
+        return out
+
+    json_type = None
+
+
+class Number(Property):
+    """A float or int field with optional bounds."""
+
+    kind = "number"
+    json_type = "number"
+    _types = (int, float)
+
+    def __init__(self, default=None, doc="", minimum=None, maximum=None):
+        super().__init__(default, doc)
+        self.minimum = minimum
+        self.maximum = maximum
+
+    def validate(self, obj, value):
+        if (
+            not isinstance(value, self._types)
+            or isinstance(value, bool)
+            or (self.minimum is not None and value < self.minimum)
+            or (self.maximum is not None and value > self.maximum)
+        ):
+            bounds = [
+                f">={self.minimum}" if self.minimum is not None else "",
+                f"<={self.maximum}" if self.maximum is not None else "",
+            ]
+            bounds = " and ".join(b for b in bounds if b)
+            expected = f"a {self.kind}" + (f" {bounds}" if bounds else "")
+            self._fail(obj, value, expected)
+        return value
+
+    def schema(self):
+        out = super().schema()
+        if self.minimum is not None:
+            out["minimum"] = self.minimum
+        if self.maximum is not None:
+            out["maximum"] = self.maximum
+        return out
+
+
+class Integer(Number):
+    """An int field with optional bounds."""
+
+    kind = "integer"
+    json_type = "integer"
+    _types = (int,)
+
+
+class Boolean(Property):
+    """A strict True/False field."""
+
+    kind = "boolean"
+    json_type = "boolean"
+
+    def validate(self, obj, value):
+        if value is not True and value is not False:
+            self._fail(obj, value, "either True or False")
+        return value
+
+
+class String(Property):
+    """A string field, optionally coercing any input via str()."""
+
+    kind = "string"
+    json_type = "string"
+
+    def __init__(self, default=None, doc="", coerce=False):
+        super().__init__(default, doc)
+        self.coerce = coerce
+
+    def validate(self, obj, value):
+        if self.coerce:
+            return str(value)
+        if not isinstance(value, str):
+            self._fail(obj, value, "a string")
+        return value
+
+
+class Choice(Property):
+    """A field restricted to an explicit set of allowed values."""
+
+    kind = "choice"
+
+    def __init__(self, *choices, default=None, doc=""):
+        super().__init__(default, doc)
+        self.choices = choices
+
+    def validate(self, obj, value):
+        if value not in self.choices:
+            self._fail(obj, value, f"one of {self.choices}")
+        return value
+
+    def schema(self):
+        out = super().schema()
+        # tuples serialize as JSON arrays
+        out["enum"] = [*self.choices, None]
+        return out
+
+
+class Color(Property):
+    """A CSS color field, normalized by `color_validator`."""
+
+    kind = "color"
+    json_type = "string"
+
+    def validate(self, obj, value):
+        return color_validator(value, parent_name=type(obj).__name__)
+
+    def schema(self):
+        return {**super().schema(), "format": "color"}
+
+
+class Nested(Property):
+    """A child `PropertyNode`, instantiated lazily on first access.
+
+    Assigning a dict builds a fresh node from it (replace, not merge — use
+    ``update()`` to merge); assigning ``None`` resets to a pristine node.
+    """
+
+    kind = "node"
+
+    def __init__(self, node_class, doc=""):
+        super().__init__(None, doc)
+        self.node_class = node_class
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        child = obj.__dict__.get(self.name)
+        if child is None:
+            child = self._adopt(obj, self.node_class())
+        return child
+
+    def __set__(self, obj, value):
+        if value is None:
+            obj.__dict__.pop(self.name, None)  # pristine node on next access
+        elif isinstance(value, dict):
+            self._adopt(obj, self.node_class(**value))
+        elif isinstance(value, self.node_class):
+            self._adopt(obj, value)
+        else:
+            msg = (
+                f"The {self.name} property of {type(obj).__name__} must be an "
+                f"instance of {self.node_class.__name__} or a dictionary with "
+                f"equivalent key/value pairs; instead received {value!r}."
+            )
+            raise TypeError(msg)
+        if obj._observed:
+            obj._notify(self.name, getattr(obj, self.name))
+
+    def _adopt(self, obj, child):
+        object.__setattr__(child, "_parent", obj)
+        object.__setattr__(child, "_name", self.name)
+        object.__setattr__(child, "_observed", obj._observed)
+        obj.__dict__[self.name] = child
+        return child
+
+    def schema(self):
+        out = self.node_class.schema()
+        if self.doc:
+            out["description"] = self.doc
+        return out
+
+
+class PropertyNode:
+    """Base class for nodes of a typed-property tree.
+
+    Subclasses declare fields as `Property` descriptors (multiple
+    inheritance of field mixins is supported). Instances store only
+    explicitly set values; everything else defers to field defaults and,
+    at resolution time, to defaults layers via `merged()`.
+    """
+
+    _fields: ClassVar[dict] = {}
+    _parent = None
+    _name = None
+    _observed = False
+    _observers = ()
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._fields = {
+            key: val
+            for klass in reversed(cls.__mro__)
+            for key, val in vars(klass).items()
+            if isinstance(val, Property)
+        }
+
+    def __init__(self, **kwargs):
+        if kwargs:
+            self.update(kwargs)
+
+    def __setattr__(self, name, value):
+        if name in self._fields or name.startswith("_"):
+            object.__setattr__(self, name, value)
+        else:
+            msg = (
+                f"{type(self).__name__} has no property {name!r}. "
+                f"Available properties: {list(self._fields)}."
+            )
+            raise AttributeError(msg)
+
+    def __repr__(self):
+        args = ", ".join(f"{k}={getattr(self, k)!r}" for k in self._fields)
+        return f"{type(self).__name__}({args})"
+
+    def __eq__(self, other):
+        return type(other) is type(self) and self.as_dict() == other.as_dict()
+
+    __hash__ = None  # mutable container
+
+    # dict round-tripping ------------------------------------------------
+
+    def as_dict(self, flatten=False, separator="."):
+        """Return all effective values as a nested dict (`flatten=True` for
+        a flat dict with `separator`-joined keys)."""
+        dict_ = {
+            name: getattr(self, name).as_dict()
+            if isinstance(field, Nested)
+            else getattr(self, name)
+            for name, field in self._fields.items()
+        }
+        if flatten:
+            dict_ = linearize_dict(dict_, separator=separator)
+        return dict_
+
+    def update(
+        self, arg=None, _match_properties=True, _replace_None_only=False, **kwargs
+    ):
+        """Update properties from a dict and/or keyword arguments, supporting
+        magic underscore notation. Nested dicts merge into child nodes.
+
+        Parameters
+        ----------
+        _match_properties: bool
+            If ``True`` (default), unknown property names raise an
+            AttributeError; if ``False`` they are silently ignored.
+        _replace_None_only: bool
+            If ``True``, only properties that are not explicitly set get
+            updated.
+        """
+        data = magic_to_dict({**(arg or {}), **kwargs})
+        for key, value in data.items():
+            field = self._fields.get(key)
+            if field is None:
+                if _match_properties:
+                    msg = (
+                        f"{type(self).__name__} has no property {key!r}. "
+                        f"Available properties: {list(self._fields)}."
+                    )
+                    raise AttributeError(msg)
+                continue
+            if isinstance(field, Nested) and isinstance(value, dict):
+                getattr(self, key).update(
+                    value,
+                    _match_properties=_match_properties,
+                    _replace_None_only=_replace_None_only,
+                )
+            elif not (_replace_None_only and self.is_set(key)):
+                setattr(self, key, value)
+        return self
+
+    def copy(self):
+        """Return a detached, unobserved deep copy."""
+        new = type(self).__new__(type(self))
+        for key in self.__dict__:
+            if key not in self._fields:
+                continue
+            value = self.__dict__[key]
+            if isinstance(value, PropertyNode):
+                child = value.copy()
+                object.__setattr__(child, "_parent", new)
+                object.__setattr__(child, "_name", key)
+                new.__dict__[key] = child
+            else:
+                new.__dict__[key] = deepcopy(value)
+        return new
+
+    # public contract for GUIs / third-party tooling ---------------------
+
+    @classmethod
+    def schema(cls):
+        """Return the JSON-Schema description of the field tree."""
+        return {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {name: field.schema() for name, field in cls._fields.items()},
+        }
+
+    def get(self, path):
+        """Return the value at a dotted path, e.g. ``'arrow.width'``."""
+        obj = self
+        for part in path.split("."):
+            obj = getattr(obj, part)
+        return obj
+
+    def set(self, path, value):
+        """Set the value at a dotted path and return self."""
+        parent_path, _, leaf = path.rpartition(".")
+        node = self.get(parent_path) if parent_path else self
+        setattr(node, leaf, value)
+        return self
+
+    def is_set(self, name):
+        """Return whether a direct property holds an explicitly set value
+        (for child nodes: whether anything in the subtree is set)."""
+        value = self.__dict__.get(name)
+        if isinstance(value, PropertyNode):
+            return bool(value.set_values())
+        return name in self.__dict__
+
+    def set_values(self, separator="."):
+        """Return a flat ``{dotted_path: value}`` dict of all explicitly set
+        leaf values."""
+        out = {}
+        for name in self._fields:
+            value = self.__dict__.get(name)
+            if value is None:
+                continue
+            if isinstance(value, PropertyNode):
+                for path, leaf in value.set_values(separator).items():
+                    out[f"{name}{separator}{path}"] = leaf
+            else:
+                out[name] = value
+        return out
+
+    def merged(self, *layers):
+        """Return a copy where unset properties are filled from the given
+        layers, first-set-wins (self has the highest priority)."""
+        new = self.copy()
+        for layer in layers:
+            new.update(
+                magic_to_dict(layer.set_values(separator="_")),
+                _match_properties=False,
+                _replace_None_only=True,
+            )
+        return new
+
+    # change observation --------------------------------------------------
+
+    def observe(self, callback):
+        """Register ``callback(path, value)`` to fire on any change in this
+        subtree; ``path`` is the dotted path of the changed property relative
+        to this node."""
+        if not self._observers:
+            object.__setattr__(self, "_observers", [])
+        self._observers.append(callback)
+        self._mark_observed()
+
+    def unobserve(self, callback):
+        """Unregister a previously registered callback."""
+        self._observers.remove(callback)
+
+    def _mark_observed(self):
+        object.__setattr__(self, "_observed", True)
+        for key, value in self.__dict__.items():
+            if key in self._fields and isinstance(value, PropertyNode):
+                value._mark_observed()
+
+    def _notify(self, path, value):
+        for callback in self._observers:
+            callback(path, value)
+        if self._parent is not None:
+            self._parent._notify(f"{self._name}.{path}", value)

--- a/src/magpylib/_src/display/traces_generic.py
+++ b/src/magpylib/_src/display/traces_generic.py
@@ -46,6 +46,8 @@ from magpylib._src.utility import (
 class MagpyMarkers:
     """A class that stores markers 3D-coordinates."""
 
+    _style_family = ("markers",)
+
     def __init__(self, *markers):
         self._style = DefaultMarkers()
         self.markers = np.array(markers)

--- a/src/magpylib/_src/obj_classes/class_BaseExcitations.py
+++ b/src/magpylib/_src/obj_classes/class_BaseExcitations.py
@@ -318,6 +318,7 @@ class BaseMagnet(BaseSource):
     """Provide magnetization and polarization attributes for magnet sources."""
 
     _style_class = MagnetStyle
+    _style_family = ("magnet",)
 
     def __init__(
         self, position, orientation, magnetization, polarization, style, **kwargs
@@ -392,6 +393,7 @@ class BaseCurrent(BaseSource):
     """Provide scalar electric current attribute for current sources."""
 
     _style_class = CurrentStyle
+    _style_family = ("current",)
 
     def __init__(self, position, orientation, current, style, **kwargs):
         super().__init__(position, orientation, style=style, **kwargs)

--- a/src/magpylib/_src/obj_classes/class_BaseGeo.py
+++ b/src/magpylib/_src/obj_classes/class_BaseGeo.py
@@ -73,6 +73,7 @@ class BaseGeo(BaseTransform, ABC):
     """
 
     _style_class = BaseStyle
+    _style_family = ()
 
     def __init__(
         self,

--- a/src/magpylib/_src/obj_classes/class_Sensor.py
+++ b/src/magpylib/_src/obj_classes/class_Sensor.py
@@ -93,6 +93,7 @@ class Sensor(BaseGeo, BaseDisplayRepr):
     """
 
     _style_class = SensorStyle
+    _style_family = ("sensor",)
     _autosize = True
     get_trace = make_Sensor
 

--- a/src/magpylib/_src/obj_classes/class_current_TriangleSheet.py
+++ b/src/magpylib/_src/obj_classes/class_current_TriangleSheet.py
@@ -105,6 +105,7 @@ class TriangleSheet(BaseSource, BaseTarget):
     }
     get_trace = make_TriangleSheet
     _style_class = CurrentSheetStyle
+    _style_family = ("currentsheet",)
 
     def __init__(
         self,

--- a/src/magpylib/_src/obj_classes/class_current_TriangleStrip.py
+++ b/src/magpylib/_src/obj_classes/class_current_TriangleStrip.py
@@ -110,6 +110,7 @@ class TriangleStrip(BaseCurrent, BaseTarget, BaseDipoleMoment):
     }
     get_trace = make_TriangleStrip
     _style_class = CurrentSheetStyle
+    _style_family = ("currentsheet",)
 
     def __init__(
         self,

--- a/src/magpylib/_src/obj_classes/class_magnet_TriangularMesh.py
+++ b/src/magpylib/_src/obj_classes/class_magnet_TriangularMesh.py
@@ -142,6 +142,7 @@ class TriangularMesh(BaseMagnet, BaseTarget, BaseVolume, BaseDipoleMoment):
     _force_type = "magnet"
     get_trace = make_TriangularMesh
     _style_class = TriangularMeshStyle
+    _style_family = ("magnet", "triangularmesh")
 
     def __init__(
         self,

--- a/src/magpylib/_src/obj_classes/class_misc_Dipole.py
+++ b/src/magpylib/_src/obj_classes/class_misc_Dipole.py
@@ -81,6 +81,7 @@ class Dipole(BaseSource, BaseDipoleMoment):
     _force_type = "magnet"
     _field_func_kwargs_ndim: ClassVar[dict[str, int]] = {"moment": 2}
     _style_class = DipoleStyle
+    _style_family = ("dipole",)
     get_trace = make_Dipole
     _autosize = True
 

--- a/src/magpylib/_src/obj_classes/class_misc_Triangle.py
+++ b/src/magpylib/_src/obj_classes/class_misc_Triangle.py
@@ -92,6 +92,7 @@ class Triangle(BaseMagnet):
     }
     get_trace = make_Triangle
     _style_class = TriangleStyle
+    _style_family = ("magnet", "triangle")
 
     def __init__(
         self,

--- a/src/magpylib/_src/style.py
+++ b/src/magpylib/_src/style.py
@@ -15,8 +15,8 @@ import numpy as np
 from magpylib._src.defaults.defaults_utility import (
     ALLOWED_LINESTYLES,
     ALLOWED_SYMBOLS,
-    SUPPORTED_PLOTTING_BACKENDS,
     get_defaults_dict,
+    get_registered_backends,
     magic_to_dict,
     validate_style_keys,
 )
@@ -345,8 +345,10 @@ class Trace3d(PropertyNode):
 
     Parameters
     ----------
-    backend : {'generic', 'matplotlib', 'plotly'}, default 'generic'
-        Plotting backend for this trace.
+    backend : str, default 'generic'
+        Plotting backend for this trace: 'generic', any of the built-in
+        backends in ``magpylib.SUPPORTED_PLOTTING_BACKENDS``, or a backend
+        registered at runtime.
     constructor : str | None, default None
         Name of the constructor function/method to build the 3D model (e.g.,
         ``'plot_trisurf'``, ``'Mesh3d'``). Must match the selected backend.
@@ -367,8 +369,7 @@ class Trace3d(PropertyNode):
     """
 
     backend = Choice(
-        "generic",
-        *SUPPORTED_PLOTTING_BACKENDS,
+        lambda: ("generic", *get_registered_backends()),
         default="generic",
         doc="Plotting backend for this trace.",
     )

--- a/src/magpylib/_src/style.py
+++ b/src/magpylib/_src/style.py
@@ -1,9 +1,10 @@
-"""Collection of classes for display styling."""
+"""Collection of classes for display styling.
 
-# pylint: disable=C0302
-# pylint: disable=too-many-instance-attributes
-# pylint: disable=cyclic-import
-# pylint: disable=too-many-positional-arguments
+All classes are declarative `PropertyNode` trees: each field is declared once
+as a typed descriptor and gains validation, magic underscore access, dict
+round-tripping, schema introspection, change observation and layered
+resolution generically (see ``magpylib._src.defaults.property_tree``).
+"""
 
 import re
 
@@ -13,11 +14,19 @@ from magpylib._src.defaults.defaults_utility import (
     ALLOWED_LINESTYLES,
     ALLOWED_SYMBOLS,
     SUPPORTED_PLOTTING_BACKENDS,
-    MagicProperties,
-    color_validator,
     get_defaults_dict,
-    validate_property_class,
     validate_style_keys,
+)
+from magpylib._src.defaults.property_tree import (
+    Boolean,
+    Choice,
+    Color,
+    ColorSequence,
+    Nested,
+    Number,
+    Property,
+    PropertyNode,
+    String,
 )
 
 ALLOWED_SIZEMODES = ("scaled", "absolute")
@@ -34,419 +43,274 @@ def get_families(obj):
 
 
 def get_style(obj, default_settings, **kwargs):
-    """Returns default style based on increasing priority:
-    - style from defaults
-    - style from object
-    - style from kwargs arguments
+    """Return the resolved style of an object with increasing priority:
+
+    - hardcoded/library defaults (base, then object family sections of
+      ``default_settings.display.style``)
+    - style explicitly set on the object
+    - style from (show) kwargs arguments
     """
-    obj_families = get_families(obj)
-    # parse kwargs into style an non-style arguments
-    style_kwargs = kwargs.get("style", {})
+    # parse kwargs into style and non-style arguments
+    style_kwargs = kwargs.get("style") or {}
     style_kwargs.update(
         {k[6:]: v for k, v in kwargs.items() if k.startswith("style") and k != "style"}
     )
-
-    # retrieve default style dictionary, local import to avoid circular import
-    # pylint: disable=import-outside-toplevel
-
-    default_style = default_settings.display.style
-    base_style_flat = default_style.base.as_dict(flatten=True, separator="_")
-
-    # construct object specific dictionary base on style family and default style
-    for obj_family in obj_families:
-        family_style = getattr(default_style, obj_family, {})
-        if family_style:
-            family_dict = family_style.as_dict(flatten=True, separator="_")
-            base_style_flat.update(
-                {k: v for k, v in family_dict.items() if v is not None}
-            )
     style_kwargs = validate_style_keys(style_kwargs)
 
-    # create style class instance and update based on precedence
+    # apply object style and kwargs (highest priority)
     style = obj.style.copy()
     style_kwargs_specific = {
-        k: v for k, v in style_kwargs.items() if k.split("_")[0] in style.as_dict()
+        k: v for k, v in style_kwargs.items() if k.split("_")[0] in style._fields
     }
-    style.update(**style_kwargs_specific, _match_properties=True)
-    style.update(**base_style_flat, _match_properties=False, _replace_None_only=True)
+    style.update(style_kwargs_specific)
 
-    return style
+    # fill unset properties from the defaults layers, most specific first
+    default_style = default_settings.display.style
+    family_layers = [getattr(default_style, fam) for fam in reversed(get_families(obj))]
+    return style.merged(*family_layers, default_style.base)
 
 
-class Line(MagicProperties):
+# field descriptors specific to style classes ---------------------------
+
+
+class Frames(Property):
+    """Path frames: an integer interval or an iterable of path indices."""
+
+    kind = "frames"
+
+    def validate(self, obj, value):
+        is_valid = True
+        if hasattr(value, "__iter__") and not isinstance(value, str):
+            value = tuple(value)
+            if not all(
+                np.issubdtype(type(v), np.integer) and not isinstance(v, bool)
+                for v in value
+            ):
+                is_valid = False
+        elif not (
+            np.issubdtype(type(value), np.integer) and not isinstance(value, bool)
+        ):
+            is_valid = False
+        if not is_valid:
+            msg = (
+                f"Input frames of {type(obj).__name__} must be either: "
+                "integer i (displays the objects at every i'th path position) or "
+                "array-like, shape (n,), dtype=int (displays objects at given path "
+                f"indices; instead received {value!r}."
+            )
+            raise ValueError(msg)
+        return value
+
+
+class TupleOrCallable(Property):
+    """A tuple, or a callable returning one."""
+
+    def validate(self, obj, value):
+        test_value = value() if callable(value) else value
+        if not isinstance(test_value, tuple):
+            self._fail(obj, value, "a tuple or a callable returning a tuple")
+        return value
+
+
+class DictOrCallable(Property):
+    """A dict, or a callable returning one."""
+
+    def validate(self, obj, value):
+        test_value = value() if callable(value) else value
+        if not isinstance(test_value, dict):
+            self._fail(obj, value, "a dictionary or a callable returning a dictionary")
+        return value
+
+
+class CoordsArgs(Property):
+    """A dict with 'x', 'y', 'z' keys naming coordinate arrays."""
+
+    def validate(self, obj, value):
+        if not (isinstance(value, dict) and all(key in value for key in "xyz")):
+            self._fail(obj, value, "a dictionary with 'x', 'y', 'z' keys")
+        return value
+
+
+def _empty_updatefunc():
+    return {}
+
+
+class UpdateFunc(Property):
+    """A callable with no arguments returning a dict of Trace3d parameters."""
+
+    def validate(self, obj, value):
+        msg = ""
+        valid_props = list(type(obj)._fields)
+        if not callable(value):
+            msg = f"; instead received {type(value).__name__}."
+        else:
+            test_value = value()
+            if not isinstance(test_value, dict):
+                msg = f"; callable returned type {type(test_value).__name__}."
+            else:
+                bad_keys = [k for k in test_value if k not in valid_props]
+                if bad_keys:
+                    msg = f"; invalid output dictionary keys received {bad_keys}."
+        if msg:
+            full_msg = (
+                f"Input updatefunc of {type(obj).__name__} must be a callable returning "
+                f"a dictionary with a subset of these keys: {valid_props}{msg}"
+            )
+            raise ValueError(full_msg)
+        return value
+
+
+class Regex(Property):
+    """A string matching a regex pattern."""
+
+    def __init__(self, pattern, default=None, doc=""):
+        super().__init__(default, doc)
+        self.pattern = pattern
+
+    def validate(self, obj, value):
+        if not re.match(self.pattern, str(value)):
+            self._fail(obj, value, f"matching the regex pattern {self.pattern}")
+        return value
+
+    def schema(self):
+        return {**super().schema(), "type": ["string", "null"], "pattern": self.pattern}
+
+
+class PixelSource(Property):
+    """Pixel field source, e.g. 'Bx', 'Hxy', 'J', a tuple of those, or False."""
+
+    _allowed_vectors = ("B", "H", "M", "J")
+
+    def validate(self, obj, value):
+        valid = True
+        if value is not False:
+            field_str, *coords_str = value
+            if not coords_str:
+                coords_str = list("xyz")
+            if field_str not in self._allowed_vectors and set(coords_str).difference(
+                set("xyz")
+            ):
+                valid = False
+        if not valid:
+            msg = (
+                f"Input source of {type(obj).__name__} must be None or False or start"
+                f" with either {self._allowed_vectors} and be followed by a combination"
+                f" of 'x', 'y', 'z' (e.g. 'Bxy' or ('Bxy', 'Bz') );"
+                f" instead received {value!r}."
+            )
+            raise ValueError(msg)
+        return value
+
+
+# style classes ----------------------------------------------------------
+
+
+class Line(PropertyNode):
     """Defines line styling properties.
 
     Parameters
     ----------
     style: str, default=None
-        Can be one of:
-        `['solid', '-', 'dashed', '--', 'dashdot', '-.', 'dotted', '.', (0, (1, 1)),
-        'loosely dotted', 'loosely dashdotted']`
-
+        Line style, one of ALLOWED_LINESTYLES.
     color: str, default=None
         Line color.
-
     width: float, default=None
         Positive number that defines the line width.
     """
 
-    def __init__(self, style=None, color=None, width=None, **kwargs):
-        super().__init__(style=style, color=color, width=width, **kwargs)
-
-    @property
-    def style(self):
-        """Line style."""
-        return self._style
-
-    @style.setter
-    def style(self, val):
-        assert val is None or val in ALLOWED_LINESTYLES, (
-            f"Input style of {type(self).__name__} must be one of {ALLOWED_LINESTYLES}; "
-            f"instead received {val!r}."
-        )
-        self._style = val
-
-    @property
-    def color(self):
-        """Line color."""
-        return self._color
-
-    @color.setter
-    def color(self, val):
-        self._color = color_validator(val)
-
-    @property
-    def width(self):
-        """Positive number that defines the line width."""
-        return self._width
-
-    @width.setter
-    def width(self, val):
-        assert val is None or (isinstance(val, int | float) and val >= 0), (
-            f"Input width of {type(self).__name__} must be a positive number; "
-            f"instead received {val!r}."
-        )
-        self._width = val
+    style = Choice(*ALLOWED_LINESTYLES, doc="Line style.")
+    color = Color(doc="Line color.")
+    width = Number(minimum=0, doc="Positive number that defines the line width.")
 
 
-class BaseStyle(MagicProperties):
-    """Base class for display styling options of `_BaseGeo` objects.
+class Arrow(Line):
+    """Defines styling properties of current and magnetization arrows.
 
     Parameters
     ----------
-    label: str, default=None
-        Label of the class instance, e.g. to be displayed in the legend.
-
-    description: dict or `Description` object, default=None
-        Object description properties.
-
-    legend: dict or `Legend` object, default=None
-        Object legend properties when displayed in a plot. Legend has the `{label} ({description})`
-        format.
-
-    color: str, default=None
-        A valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`.
-
-    opacity: float, default=None
-        object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
-
-    path: dict or `Path` object, default=None
-        An instance of `Path` or dictionary of equivalent key/value pairs, defining the object
-        path marker and path line properties.
-
-    model3d: list of `Trace3d` objects, default=None
-        A list of traces where each is an instance of `Trace3d` or dictionary of equivalent
-        key/value pairs. Defines properties for an additional user-defined model3d object which is
-        positioned relatively to the main object to be displayed and moved automatically with it.
-        This feature also allows the user to replace the original 3d representation of the object.
+    show: bool, default=None
+        Show/hide arrow.
+    size: float, default=None
+        Positive number defining the arrow size.
+    sizemode: {'scaled', 'absolute'}, default=None
+        Scale reference for the arrow size.
+    offset: float, default=None
+        Arrow offset. ``offset=0`` puts the arrow head coincident to the start
+        of the line, ``offset=1`` to the end.
+    style, color, width:
+        See `Line`.
     """
 
-    def __init__(
-        self,
-        label=None,
-        description=None,
-        legend=None,
-        color=None,
-        opacity=None,
-        path=None,
-        model3d=None,
-        **kwargs,
-    ):
-        super().__init__(
-            label=label,
-            description=description,
-            legend=legend,
-            color=color,
-            opacity=opacity,
-            path=path,
-            model3d=model3d,
-            **kwargs,
-        )
-
-    @property
-    def label(self):
-        """Label of the class instance, e.g. to be displayed in the legend."""
-        return self._label
-
-    @label.setter
-    def label(self, val):
-        self._label = val if val is None else str(val)
-
-    @property
-    def description(self):
-        """Description with 'text' and 'show' properties."""
-        return self._description
-
-    @description.setter
-    def description(self, val):
-        if isinstance(val, str):
-            self._description = Description(text=val)
-        else:
-            self._description = validate_property_class(
-                val, "description", Description, self
-            )
-
-    @property
-    def legend(self):
-        """Legend with 'show' property."""
-        return self._legend
-
-    @legend.setter
-    def legend(self, val):
-        if isinstance(val, str):
-            self._legend = Legend(text=val)
-        else:
-            self._legend = validate_property_class(val, "legend", Legend, self)
-
-    @property
-    def color(self):
-        """A valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`."""
-        return self._color
-
-    @color.setter
-    def color(self, val):
-        self._color = color_validator(val, parent_name=f"{type(self).__name__}")
-
-    @property
-    def opacity(self):
-        """Object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent."""
-        return self._opacity
-
-    @opacity.setter
-    def opacity(self, val):
-        assert val is None or (isinstance(val, float | int) and 0 <= val <= 1), (
-            f"Input opacity of {type(self).__name__} must be a number between 0 and 1; "
-            f"instead received {val!r}."
-        )
-        self._opacity = val
-
-    @property
-    def path(self):
-        """An instance of `Path` or dictionary of equivalent key/value pairs, defining the
-        object path marker and path line properties."""
-        return self._path
-
-    @path.setter
-    def path(self, val):
-        self._path = validate_property_class(val, "path", Path, self)
-
-    @property
-    def model3d(self):
-        """3d object representation properties."""
-        return self._model3d
-
-    @model3d.setter
-    def model3d(self, val):
-        self._model3d = validate_property_class(val, "model3d", Model3d, self)
+    show = Boolean(doc="Show/hide arrow.")
+    size = Number(minimum=0, doc="Positive number defining the size of the arrows.")
+    sizemode = Choice(*ALLOWED_SIZEMODES, doc="Sizemode of the arrows.")
+    offset = Number(minimum=0, maximum=1, doc="Arrow offset between 0 and 1.")
 
 
-class Description(MagicProperties):
+class CurrentLine(Line):
+    """Defines styling properties of current lines.
+
+    Parameters
+    ----------
+    show: bool, default=None
+        Show/hide current line.
+    style, color, width:
+        See `Line`.
+    """
+
+    show = Boolean(doc="Show/hide current line.")
+
+
+class Marker(PropertyNode):
+    """Defines styling properties of plot markers.
+
+    Parameters
+    ----------
+    size: float, default=None
+        Marker size.
+    color: str, default=None
+        Marker color.
+    symbol: str, default=None
+        Marker symbol, one of ALLOWED_SYMBOLS.
+    """
+
+    size = Number(minimum=0, doc="Marker size.")
+    color = Color(doc="Marker color.")
+    symbol = Choice(*ALLOWED_SYMBOLS, doc="Marker symbol.")
+
+
+class Description(PropertyNode):
     """Defines properties for a description object.
 
     Parameters
     ----------
     text: str, default=None
         Object description text.
-
     show: bool, default=None
-        If True, adds legend entry based on value.
+        If True, adds legend entry suffix based on value.
     """
 
-    def __init__(self, text=None, show=None, **kwargs):
-        super().__init__(text=text, show=show, **kwargs)
-
-    @property
-    def text(self):
-        """Description text."""
-        return self._text
-
-    @text.setter
-    def text(self, val):
-        assert val is None or isinstance(val, str), (
-            f"Input text of {type(self).__name__} must be a string; "
-            f"instead received {val!r}."
-        )
-        self._text = val
-
-    @property
-    def show(self):
-        """If True, adds legend entry suffix based on value."""
-        return self._show
-
-    @show.setter
-    def show(self, val):
-        assert val is None or isinstance(val, bool), (
-            f"Input show of {type(self).__name__} must be either True or False; "
-            f"instead received {val!r}."
-        )
-        self._show = val
+    text = String(doc="Description text.")
+    show = Boolean(doc="If True, adds legend entry suffix based on value.")
 
 
-class Legend(MagicProperties):
+class Legend(PropertyNode):
     """Defines properties for a legend object.
 
     Parameters
     ----------
     text: str, default=None
-        Object description text.
-
+        Legend text.
     show: bool, default=None
         If True, adds legend entry based on value.
     """
 
-    def __init__(self, show=None, **kwargs):
-        super().__init__(show=show, **kwargs)
-
-    @property
-    def text(self):
-        """Legend text."""
-        return self._text
-
-    @text.setter
-    def text(self, val):
-        assert val is None or isinstance(val, str), (
-            f"Input text of {type(self).__name__} must be a string; "
-            f"instead received {val!r}."
-        )
-        self._text = val
-
-    @property
-    def show(self):
-        """If True, adds legend entry based on value."""
-        return self._show
-
-    @show.setter
-    def show(self, val):
-        assert val is None or isinstance(val, bool), (
-            f"Input show of {type(self).__name__} must be either True or False; "
-            f"instead received {val!r}."
-        )
-        self._show = val
+    text = String(doc="Legend text.")
+    show = Boolean(doc="If True, adds legend entry based on value.")
 
 
-class Model3d(MagicProperties):
-    """Defines properties for the 3d model representation of magpylib objects.
-
-    Parameters
-    ----------
-    showdefault: bool, default=True
-        Shows/hides default 3d-model.
-
-    data: dict or list of dicts, default=None
-        A trace or list of traces where each is an instance of `Trace3d` or dictionary of equivalent
-        key/value pairs. Defines properties for an additional user-defined model3d object which is
-        positioned relatively to the main object to be displayed and moved automatically with it.
-        This feature also allows the user to replace the original 3d representation of the object.
-    """
-
-    def __init__(self, showdefault=True, data=None, **kwargs):
-        super().__init__(showdefault=showdefault, data=data, **kwargs)
-
-    @property
-    def showdefault(self):
-        """If True, show default model3d object representation, else hide it."""
-        return self._showdefault
-
-    @showdefault.setter
-    def showdefault(self, val):
-        assert isinstance(val, bool), (
-            f"Input showdefault of {type(self).__name__} must be either True or False; "
-            f"instead received {val!r}."
-        )
-        self._showdefault = val
-
-    @property
-    def data(self):
-        """Data of 3d object representation (trace or list of traces)."""
-        return self._data
-
-    @data.setter
-    def data(self, val):
-        self._data = self._validate_data(val)
-
-    def _validate_data(self, traces, **kwargs):
-        if traces is None:
-            traces = []
-        elif not isinstance(traces, list | tuple):
-            traces = [traces]
-        new_traces = []
-        for trace_item in traces:
-            trace = trace_item
-            updatefunc = None
-            if not isinstance(trace, Trace3d) and callable(trace):
-                updatefunc = trace
-                trace = Trace3d()
-            if not isinstance(trace, Trace3d):
-                trace = validate_property_class(trace, "data", Trace3d, self)
-            if updatefunc is not None:
-                trace.updatefunc = updatefunc
-            trace = trace.update(kwargs)
-            new_traces.append(trace)
-        return new_traces
-
-    def add_trace(self, trace=None, **kwargs):
-        """Add a user-defined 3D trace that moves/rotates with this object.
-
-        Parameters
-        ----------
-        trace : Trace3d | dict | callable | None, default None
-            A trace, a dict with equivalent key/value pairs, or a callable returning such a
-            dict. If a callable is given, it is used as ``updatefunc`` and a default
-            ``Trace3d`` is created.
-        backend : {'generic', 'matplotlib', 'plotly'} | None, default None
-            Plotting backend for the trace.
-        constructor : str | None, default None
-            Name of the constructor to build the 3D model (e.g., ``'plot_trisurf'``,
-            ``'Mesh3d'``). Must match the selected backend.
-        args : tuple | callable | None, default None
-            Positional arguments for the constructor, or a callable returning them.
-        kwargs : dict | callable | None, default None
-            Keyword arguments for the constructor, or a callable returning them.
-        coordsargs : dict | None, default None
-            Names of coordinate arrays to be transformed; by default
-            ``{"x": "x", "y": "y", "z": "z"}``. If ``False``, the object is not rotated.
-        show : bool | None, default None
-            Show or hide the resulting model3d trace.
-        scale : float | None, default 1
-            Multiplier applied to the trace vertex coordinates.
-        updatefunc : callable | None, default None
-            Callable with no arguments returning a dictionary of trace parameters to update
-            at show time.
-
-        Returns
-        -------
-        Model3d
-        """
-        self._data += self._validate_data([trace], **kwargs)
-        return self
-
-
-class Trace3d(MagicProperties):
+class Trace3d(PropertyNode):
     """User-defined 3D model trace that moves/rotates with its parent object.
-
-    Use this to attach custom geometry to an object for display. Traces are positioned
-    relative to the object and transformed together with it; they can also replace the
-    default 3D representation if desired.
 
     Parameters
     ----------
@@ -461,210 +325,241 @@ class Trace3d(MagicProperties):
         Keyword arguments for the constructor, or a callable returning them.
     coordsargs : dict | None, default None
         Names of coordinate arrays to be transformed; by default
-        ``{"x": "x", "y": "y", "z": "z"}``. If ``False``, the object is not rotated.
+        ``{"x": "x", "y": "y", "z": "z"}``.
     show : bool, default True
         Show or hide the resulting model3d object.
     scale : float, default 1
         Multiplier applied to the trace vertex coordinates.
     updatefunc : callable | None, default None
-        Callable with no arguments returning a dictionary of trace parameters to update
-        at show time. Enables dynamic, attribute-dependent trace updates.
+        Callable with no arguments returning a dictionary of trace parameters
+        to update at show time.
     """
 
-    def __init__(
-        self,
-        backend="generic",
-        constructor=None,
-        args=None,
-        kwargs=None,
-        coordsargs=None,
-        show=True,
-        scale=1,
-        updatefunc=None,
-        **params,
-    ):
-        super().__init__(
-            backend=backend,
-            constructor=constructor,
-            args=args,
-            kwargs=kwargs,
-            coordsargs=coordsargs,
-            show=show,
-            scale=scale,
-            updatefunc=updatefunc,
-            **params,
-        )
+    backend = Choice(
+        "generic",
+        *SUPPORTED_PLOTTING_BACKENDS,
+        default="generic",
+        doc="Plotting backend for this trace.",
+    )
+    constructor = String(doc="Constructor name to build the 3D model.")
+    args = TupleOrCallable(doc="Positional arguments for the constructor.")
+    kwargs = DictOrCallable(doc="Keyword arguments for the constructor.")
+    coordsargs = CoordsArgs(doc="Names of coordinate arrays to be transformed.")
+    show = Boolean(default=True, doc="Show or hide the model3d trace.")
+    scale = Number(
+        exclusive_minimum=0,
+        default=1,
+        doc="Multiplier applied to the trace vertex coordinates.",
+    )
+    updatefunc = UpdateFunc(
+        default=_empty_updatefunc,
+        doc="Callable updating the trace parameters at show time.",
+    )
 
-    @property
-    def args(self):
-        """Positional arguments for the constructor (``tuple`` or callable)."""
-        return self._args
 
-    @args.setter
-    def args(self, val):
-        if val is not None:
-            test_val = val
-            if callable(val):
-                test_val = val()
-            assert isinstance(test_val, tuple), (
-                f"Input args of {type(self).__name__} must be a tuple or a callable returning a "
-                f"tuple; instead received {type(val).__name__}."
-            )
-        self._args = val
+class TraceData(Property):
+    """List of Trace3d objects; accepts single/list of Trace3d, dict or callable."""
 
-    @property
-    def kwargs(self):
-        """Keyword arguments for the constructor (``dict`` or callable)."""
-        return self._kwargs
+    default = ()
 
-    @kwargs.setter
-    def kwargs(self, val):
-        if val is not None:
-            test_val = val
-            if callable(val):
-                test_val = val()
-            assert isinstance(test_val, dict), (
-                f"Input kwargs of {type(self).__name__} must be a dictionary or a callable "
-                f"returning a dictionary; instead received {type(val).__name__}."
-            )
-        self._kwargs = val
+    def __init__(self, doc=""):
+        super().__init__((), doc)
 
-    @property
-    def constructor(self):
-        """Constructor name to build the 3D model (e.g., ``'plot_trisurf'``, ``'Mesh3d'``).
-        Must match the selected backend.
+    def validate(self, obj, value):
+        return obj._validate_data(value)
+
+
+class Model3d(PropertyNode):
+    """Defines properties for the 3d model representation of magpylib objects.
+
+    Parameters
+    ----------
+    showdefault: bool, default=True
+        Shows/hides default 3d-model.
+    data: dict or list of dicts, default=None
+        A trace or list of traces where each is an instance of `Trace3d` or
+        dictionary of equivalent key/value pairs.
+    """
+
+    showdefault = Boolean(default=True, doc="Shows/hides default 3d-model.")
+    data = TraceData(doc="Data of 3d object representation (trace or list of traces).")
+
+    @staticmethod
+    def _validate_data(traces, **kwargs):
+        if traces is None:
+            traces = []
+        elif not isinstance(traces, list | tuple):
+            traces = [traces]
+        new_traces = []
+        for trace_item in traces:
+            trace = trace_item
+            updatefunc = None
+            if not isinstance(trace, Trace3d) and callable(trace):
+                updatefunc = trace
+                trace = Trace3d()
+            if trace is None:
+                trace = Trace3d()
+            elif isinstance(trace, dict):
+                trace = Trace3d(**trace)
+            if not isinstance(trace, Trace3d):
+                msg = (
+                    "The data property of Model3d must be an instance of Trace3d or "
+                    "a dictionary with equivalent key/value pairs; "
+                    f"instead received {trace!r}."
+                )
+                raise TypeError(msg)
+            if updatefunc is not None:
+                trace.updatefunc = updatefunc
+            trace = trace.update(kwargs)
+            new_traces.append(trace)
+        return new_traces
+
+    def add_trace(self, trace=None, **kwargs):
+        """Add a user-defined 3D trace that moves/rotates with this object.
+
+        Parameters
+        ----------
+        trace : Trace3d | dict | callable | None, default None
+            A trace, a dict with equivalent key/value pairs, or a callable
+            returning such a dict. If a callable is given, it is used as
+            ``updatefunc`` and a default ``Trace3d`` is created.
+        **kwargs
+            Trace3d properties, see `Trace3d`.
+
+        Returns
+        -------
+        Model3d
         """
-        return self._constructor
-
-    @constructor.setter
-    def constructor(self, val):
-        assert val is None or isinstance(val, str), (
-            f"Input constructor of {type(self).__name__} must be a string; instead received {val!r}."
-        )
-        self._constructor = val
-
-    @property
-    def show(self):
-        """Show or hide the model3d trace."""
-        return self._show
-
-    @show.setter
-    def show(self, val):
-        assert isinstance(val, bool), (
-            f"Input show of {type(self).__name__} must be either True or False; instead received {val!r}."
-        )
-        self._show = val
-
-    @property
-    def scale(self):
-        """Multiplier applied to the trace vertex coordinates."""
-        return self._scale
-
-    @scale.setter
-    def scale(self, val):
-        assert isinstance(val, int | float) and val > 0, (  # noqa: PT018
-            f"Input scale of {type(self).__name__} must be a positive number; instead received {val!r}."
-        )
-        self._scale = val
-
-    @property
-    def coordsargs(self):
-        """Names of coordinate arrays to transform; default ``{"x":"x", "y":"y", "z":"z"}``.
-        If ``False``, the object is not rotated.
-        """
-        return self._coordsargs
-
-    @coordsargs.setter
-    def coordsargs(self, val):
-        assert val is None or (
-            isinstance(val, dict) and all(key in val for key in "xyz")
-        ), (
-            f"Input coordsargs of {type(self).__name__} must be a dictionary with 'x', 'y', 'z' keys; "
-            f"instead received {val!r}."
-        )
-        self._coordsargs = val
-
-    @property
-    def backend(self):
-        """Plotting backend for this trace. One of {'generic', 'matplotlib', 'plotly'}."""
-        return self._backend
-
-    @backend.setter
-    def backend(self, val):
-        backends = ["generic", *list(SUPPORTED_PLOTTING_BACKENDS)]
-        assert val is None or val in backends, (
-            f"Input backend of {type(self).__name__} must be one of {backends}; instead received {val!r}."
-        )
-        self._backend = val
-
-    @property
-    def updatefunc(self):
-        """Callable object with no arguments. Should return a dictionary with keys from the
-        trace parameters. If provided, the function is called at show time and updates the
-        trace parameters with the output dictionary. This allows to update a trace dynamically
-        depending on class attributes, and postpone the trace construction to when the object is
-        displayed."""
-        return self._updatefunc
-
-    @updatefunc.setter
-    def updatefunc(self, val):
-        if val is None:
-
-            def val():
-                return {}
-
-        msg = ""
-        valid_props = list(self._property_names_generator())
-        if not callable(val):
-            msg = f"; instead received {type(val).__name__}."
-        else:
-            test_val = val()
-            if not isinstance(test_val, dict):
-                msg = f"; callable returned type {type(test_val).__name__}."
-            else:
-                bad_keys = [k for k in test_val if k not in valid_props]
-                if bad_keys:
-                    msg = f"; invalid output dictionary keys received {bad_keys}."
-
-        assert msg == "", (
-            f"Input updatefunc of {type(self).__name__} must be a callable returning a dictionary "
-            f"with a subset of these keys: {valid_props}{msg}"
-        )
-        self._updatefunc = val
+        self.data = [*self.data, *self._validate_data([trace], **kwargs)]
+        return self
 
 
-class Magnetization(MagicProperties):
+class Path(PropertyNode):
+    """Defines styling properties of an object's path.
+
+    Parameters
+    ----------
+    show: bool, default=None
+        Show/hide path.
+    marker: dict or `Marker` object, default=None
+        Path marker properties.
+    line: dict or `Line` object, default=None
+        Path line properties.
+    frames: int or array-like, shape (n,), default=None
+        Show copies of the 3D-model along the given path indices.
+        - integer i: Displays the object(s) at every i'th path position.
+        - array-like, shape (n,), dtype=int: Displays object(s) at given path
+          indices.
+    numbering: bool, default=False
+        Show/hide numbering on path positions.
+    """
+
+    show = Boolean(doc="Show/hide path.")
+    marker = Nested(Marker, doc="Path marker properties.")
+    line = Nested(Line, doc="Path line properties.")
+    frames = Frames(doc="Show copies of the 3D-model along the given path indices.")
+    numbering = Boolean(doc="Show/hide numbering on path positions.")
+
+
+class BaseStyle(PropertyNode):
+    """Base class for display styling options of `_BaseGeo` objects.
+
+    Parameters
+    ----------
+    label: str, default=None
+        Label of the class instance, e.g. to be displayed in the legend.
+    description: dict or `Description` object, default=None
+        Object description properties.
+    legend: dict or `Legend` object, default=None
+        Object legend properties. Legend has the `{label} ({description})`
+        format.
+    color: str, default=None
+        A valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c',
+        'k', 'w']`.
+    opacity: float, default=None
+        Object opacity between 0 and 1, where 1 is fully opaque and 0 is fully
+        transparent.
+    path: dict or `Path` object, default=None
+        Object path marker and path line properties.
+    model3d: dict or `Model3d` object, default=None
+        Properties for an additional user-defined 3d model object which is
+        positioned relatively to the main object to be displayed and moved
+        automatically with it. Can also replace the original 3d representation.
+    """
+
+    label = String(coerce=True, doc="Label of the class instance.")
+    description = Nested(
+        Description, from_str="text", doc="Object description properties."
+    )
+    legend = Nested(Legend, from_str="text", doc="Object legend properties.")
+    color = Color(doc="A valid css color.")
+    opacity = Number(minimum=0, maximum=1, doc="Object opacity between 0 and 1.")
+    path = Nested(Path, doc="Object path marker and path line properties.")
+    model3d = Nested(Model3d, doc="3d object representation properties.")
+
+
+class MagnetizationColor(PropertyNode):
+    """Defines the magnetization direction color styling properties. (Only
+    relevant for the plotly backend)
+
+    Parameters
+    ----------
+    north: str, default=None
+        Color of the magnetic north pole.
+    south: str, default=None
+        Color of the magnetic south pole.
+    middle: str, default=None
+        Color between the magnetic poles.
+    transition: float, default=None
+        Transition smoothness between pole colors, between 0 (discrete) and
+        1 (smooth).
+    mode: {'bicolor', 'tricolor', 'tricycle'}, default=None
+        Coloring mode for the magnetization.
+        - `'bicolor'`: Only north and south pole colors are shown.
+        - `'tricolor'`: Both pole colors and middle color are shown.
+        - `'tricycle'`: Both pole colors are shown and middle color is
+          replaced by a color cycling through the default color sequence.
+    """
+
+    north = Color(doc="Color of the magnetic north pole.")
+    south = Color(doc="Color of the magnetic south pole.")
+    middle = Color(doc="Color between the magnetic poles.")
+    transition = Number(
+        minimum=0, maximum=1, doc="Transition smoothness between pole colors."
+    )
+    mode = Choice(
+        "bicolor", "tricolor", "tricycle", doc="Coloring mode for the magnetization."
+    )
+
+
+class Magnetization(PropertyNode):
     """Defines magnetization styling properties.
 
     Parameters
     ----------
     show : bool, default=None
         If ``True`` show magnetization direction.
-    color: dict or MagnetizationColor object, default=None
-        Color properties showing the magnetization direction (for the plotly backend).
-        Only applies if `show=True`.
-    arrow: dict or Arrow object, default=None,
-        Arrow properties. Only applies if mode='arrow'.
-    mode: {"auto", "arrow", "color", "arrow+color"}, default="auto"
-        Magnetization can be displayed via arrows, color or both. By default `mode='auto'` means
-        that the chosen backend determines which mode is applied by its capability. If the backend
-        can display both and `auto` is chosen, the priority is given to `color`.
+    arrow: dict or `Arrow` object, default=None
+        Arrow properties. Only applies if `mode='arrow'`.
+    color: dict or `MagnetizationColor` object, default=None
+        Color properties showing the magnetization direction (for the plotly
+        backend). Only applies if `show=True`.
+    mode: {'auto', 'arrow', 'color', 'arrow+color'}, default=None
+        Magnetization can be displayed via arrows, color or both. With
+        `mode='auto'` the chosen backend determines the mode by capability.
     """
 
-    def __init__(self, show=None, size=None, color=None, mode=None, **kwargs):
-        super().__init__(show=show, size=size, color=color, mode=mode, **kwargs)
-
-    @property
-    def show(self):
-        """If True, show magnetization direction."""
-        return self._show
-
-    @show.setter
-    def show(self, val):
-        assert val is None or isinstance(val, bool), (
-            f"Input show of {type(self).__name__} must be either True or False; instead received {val!r}."
-        )
-        self._show = val
+    show = Boolean(doc="If True, show magnetization direction.")
+    arrow = Nested(Arrow, doc="Magnetization arrow properties.")
+    color = Nested(MagnetizationColor, doc="Magnetization color properties.")
+    mode = Choice(
+        "auto",
+        "arrow",
+        "color",
+        "arrow+color",
+        "color+arrow",
+        doc="Magnetization display mode.",
+    )
 
     @property
     def size(self):
@@ -676,179 +571,20 @@ class Magnetization(MagicProperties):
         if val is not None:
             self.arrow.size = val
 
-    @property
-    def color(self):
-        """Color properties showing the magnetization direction (for the plotly backend).
-        Applies only if `show=True`.
-        """
-        return self._color
 
-    @color.setter
-    def color(self, val):
-        self._color = validate_property_class(val, "color", MagnetizationColor, self)
+class MagnetProperties(PropertyNode):
+    """Defines styling properties of homogeneous magnet classes."""
 
-    @property
-    def arrow(self):
-        """`Arrow` object or dict with `show, size, width, style, color` properties/keys."""
-        return self._arrow
-
-    @arrow.setter
-    def arrow(self, val):
-        self._arrow = validate_property_class(val, "magnetization", Arrow, self)
-
-    @property
-    def mode(self):
-        """One of {"auto", "arrow", "color", "arrow+color"}, default="auto"
-        Magnetization can be displayed via arrows, color or both. By default `mode='auto'` means
-        that the chosen backend determines which mode is applied by its capability. If the backend
-        can display both and `auto` is chosen, the priority is given to `color`."""
-        return self._mode
-
-    @mode.setter
-    def mode(self, val):
-        allowed = ("auto", "arrow", "color", "arrow+color", "color+arrow")
-        assert val is None or val in allowed, (
-            f"Input mode of {type(self).__name__} must be one of {allowed} or None; instead received {val!r}."
-        )
-        self._mode = val
+    magnetization = Nested(Magnetization, doc="Magnetization styling properties.")
 
 
-class MagnetizationColor(MagicProperties):
-    """Defines the magnetization direction color styling properties. (Only relevant for
-    the plotly backend)
-
-    Parameters
-    ----------
-    north: str, default=None
-        Defines the color of the magnetic north pole.
-
-    south: str, default=None
-        Defines the color of the magnetic south pole.
-
-    middle: str, default=None
-        Defines the color between the magnetic poles.
-
-    transition: float, default=None
-        Sets the transition smoothness between poles colors. Can be any value
-        in-between 0 (discrete) and 1(smooth).
-
-    mode: str, default=None
-        Sets the coloring mode for the magnetization.
-        - `'bicolor'`: Only north and south pole colors are shown.
-        - `'tricolor'`: Both pole colors and middle color are shown.
-        - `'tricycle'`: Both pole colors are shown and middle color is replaced by a color cycling
-            through the default color sequence.
-    """
-
-    _allowed_modes = ("bicolor", "tricolor", "tricycle")
-
-    def __init__(
-        self, north=None, south=None, middle=None, transition=None, mode=None, **kwargs
-    ):
-        super().__init__(
-            north=north,
-            middle=middle,
-            south=south,
-            transition=transition,
-            mode=mode,
-            **kwargs,
-        )
-
-    @property
-    def north(self):
-        """Color of the magnetic north pole."""
-        return self._north
-
-    @north.setter
-    def north(self, val):
-        self._north = color_validator(val)
-
-    @property
-    def south(self):
-        """Color of the magnetic south pole."""
-        return self._south
-
-    @south.setter
-    def south(self, val):
-        self._south = color_validator(val)
-
-    @property
-    def middle(self):
-        """Color between the magnetic poles."""
-        return self._middle
-
-    @middle.setter
-    def middle(self, val):
-        self._middle = color_validator(val)
-
-    @property
-    def transition(self):
-        """Sets the transition smoothness between poles colors. Can be any value
-        in-between 0 (discrete) and 1(smooth).
-        """
-        return self._transition
-
-    @transition.setter
-    def transition(self, val):
-        assert val is None or (isinstance(val, float | int) and 0 <= val <= 1), (
-            f"Input transition of {type(self).__name__} must be a number between 0 and 1; "
-            f"instead received {val!r}."
-        )
-        self._transition = val
-
-    @property
-    def mode(self):
-        """Sets the coloring mode for the magnetization.
-        - `'bicolor'`: Only north and south pole colors are shown.
-        - `'tricolor'`: Both pole colors and middle color are shown.
-        - `'tricycle'`: Both pole colors are shown and middle color is replaced by a color cycling
-            through the default color sequence.
-        """
-        return self._mode
-
-    @mode.setter
-    def mode(self, val):
-        assert val is None or val in self._allowed_modes, (
-            f"Input mode of {type(self).__name__} must be one of {list(self._allowed_modes)}; "
-            f"instead received {val!r}."
-        )
-        self._mode = val
-
-
-class MagnetProperties:
+class DefaultMagnet(MagnetProperties):
     """Defines styling properties of homogeneous magnet classes.
 
     Parameters
     ----------
     magnetization: dict or `Magnetization` object, default=None
-        `Magnetization` instance with `'show'`, `'size'`, `'color'` properties
-        or a dictionary with equivalent key/value pairs.
     """
-
-    @property
-    def magnetization(self):
-        """`Magnetization` instance with `'show'`, `'size'`, `'color'` properties
-        or a dictionary with equivalent key/value pairs.
-        """
-        return self._magnetization
-
-    @magnetization.setter
-    def magnetization(self, val):
-        self._magnetization = validate_property_class(
-            val, "magnetization", Magnetization, self
-        )
-
-
-class DefaultMagnet(MagicProperties, MagnetProperties):
-    """Defines styling properties of homogeneous magnet classes.
-
-    Parameters
-    ----------
-    magnetization: dict or Magnetization, default=None
-    """
-
-    def __init__(self, magnetization=None, **kwargs):
-        super().__init__(magnetization=magnetization, **kwargs)
 
 
 class MagnetStyle(BaseStyle, MagnetProperties):
@@ -856,387 +592,115 @@ class MagnetStyle(BaseStyle, MagnetProperties):
 
     Parameters
     ----------
-    label : str | None, default None
-        Label of the class instance, e.g., to be displayed in the legend.
-    description : dict | Description | None, default None
-        Object description properties.
-    color : str | None, default None
-        A valid CSS color. May also be one of {'r', 'g', 'b', 'y', 'm', 'c', 'k', 'w'}.
-    opacity : float | None, default None
-        Object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
-    path : dict | Path | None, default None
-        Instance of ``Path`` or dict with equivalent key/value pairs; defines path marker
-        and path line properties.
-    model3d : list[Trace3d | dict] | None, default None
-        List of traces where each is a ``Trace3d`` instance or dict of equivalent key/value
-        pairs. Defines an additional user-defined 3D model positioned relative to the main
-        object and transformed with it. Can replace the original 3D representation.
-    magnetization : dict | Magnetization | None, default None
-        Magnetization styling with keys ``'show'``, ``'size'``, ``'color'``, or a
-        ``Magnetization`` instance.
+    magnetization: dict or `Magnetization` object, default=None
+        Magnetization styling properties.
+    label, description, legend, color, opacity, path, model3d:
+        See `BaseStyle`.
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
 
-
-class MarkerLineProperties:
+class MarkerLineProperties(PropertyNode):
     """Defines styling properties of Markers and Lines."""
 
-    @property
-    def show(self):
-        """Show/hide path.
-        - False: Shows object(s) at final path position and hides paths lines and markers.
-        - True: Shows object(s) shows object paths depending on `line`, `marker` and `frames`
-        parameters.
-        """
-        return self._show
-
-    @show.setter
-    def show(self, val):
-        assert val is None or isinstance(val, bool), (
-            f"Input show of {type(self).__name__} must be either True or False; instead received {val!r}."
-        )
-        self._show = val
-
-    @property
-    def marker(self):
-        """`Markers` object with 'color', 'symbol', 'size' properties."""
-        return self._marker
-
-    @marker.setter
-    def marker(self, val):
-        self._marker = validate_property_class(val, "marker", Marker, self)
-
-    @property
-    def line(self):
-        """`Line` object with 'color', 'type', 'width' properties."""
-        return self._line
-
-    @line.setter
-    def line(self, val):
-        self._line = validate_property_class(val, "line", Line, self)
+    show = Boolean(doc="Show/hide lines and markers.")
+    marker = Nested(Marker, doc="Marker properties.")
+    line = Nested(Line, doc="Line properties.")
 
 
-class GridMesh(MagicProperties, MarkerLineProperties):
-    """Defines styling properties of GridMesh objects
+class GridMesh(MarkerLineProperties):
+    """Defines styling properties of GridMesh objects."""
+
+
+class OpenMesh(MarkerLineProperties):
+    """Defines styling properties of OpenMesh objects."""
+
+
+class DisconnectedMesh(MarkerLineProperties):
+    """Defines styling properties of DisconnectedMesh objects.
 
     Parameters
     ----------
     show: bool, default=None
-        Show/hide Lines and Markers
-
-    marker: dict or `Markers` object, default=None
-        `Markers` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
-
+        Show/hide Lines and Markers.
+    marker: dict or `Marker` object, default=None
     line: dict or `Line` object, default=None
-        `Line` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
+    colorsequence: iterable, default=None
+        An iterable of color values used to cycle through for every
+        disconnected part of disconnected triangular mesh object.
     """
 
-
-class OpenMesh(MagicProperties, MarkerLineProperties):
-    """Defines styling properties of OpenMesh objects
-
-    Parameters
-    ----------
-    show: bool, default=None
-        Show/hide Lines and Markers
-
-    marker: dict or `Markers` object, default=None
-        `Markers` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
-
-    line: dict or `Line` object, default=None
-        `Line` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
-    """
+    colorsequence = ColorSequence(
+        doc="Colors cycled through for every disconnected mesh part."
+    )
 
 
-class DisconnectedMesh(MagicProperties, MarkerLineProperties):
-    """Defines styling properties of DisconnectedMesh objects
-
-    Parameters
-    ----------
-    show: bool, default=None
-        Show/hide Lines and Markers
-
-    marker: dict or `Markers` object, default=None
-        `Markers` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
-
-    line: dict or `Line` object, default=None
-        `Line` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
-
-    colorsequence: iterable, default=["red", "blue", "green", "cyan", "magenta", "yellow"]
-        An iterable of color values used to cycle through for every disconnected part of
-        disconnected triangular mesh object.
-        A color may be specified by
-      - a hex string (e.g. '#ff0000')
-      - an rgb/rgba string (e.g. 'rgb(255, 0, 0)')
-      - an hsl/hsla string (e.g. 'hsl(0, 100%, 50%)')
-      - an hsv/hsva string (e.g. 'hsv(0, 100%, 100%)')
-      - a named CSS color
-    """
-
-    @property
-    def colorsequence(self):
-        """An iterable of color values used to cycle through for every disconnected part of
-        disconnected triangular mesh object.
-          A color may be specified by
-        - a hex string (e.g. '#ff0000')
-        - an rgb/rgba string (e.g. 'rgb(255, 0, 0)')
-        - an hsl/hsla string (e.g. 'hsl(0, 100%, 50%)')
-        - an hsv/hsva string (e.g. 'hsv(0, 100%, 100%)')
-        - a named CSS color"""
-        return self._colorsequence
-
-    @colorsequence.setter
-    def colorsequence(self, val):
-        if val is not None:
-            name = type(self).__name__
-            try:
-                val = tuple(
-                    color_validator(c, allow_None=False, parent_name=f"{name}")
-                    for c in val
-                )
-            except TypeError as err:
-                msg = (
-                    f"Input colorsequence of {name} must be an "
-                    f"iterable of colors; instead received {val!r}."
-                )
-                raise ValueError(msg) from err
-
-        self._colorsequence = val
+class SelfIntersectingMesh(MarkerLineProperties):
+    """Defines styling properties of SelfIntersectingMesh objects."""
 
 
-class SelfIntersectingMesh(MagicProperties, MarkerLineProperties):
-    """Defines styling properties of SelfIntersectingMesh objects
-
-    Parameters
-    ----------
-    show: bool, default=None
-        Show/hide Lines and Markers
-
-    marker: dict or `Markers` object, default=None
-        `Markers` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
-
-    line: dict or `Line` object, default=None
-        `Line` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
-    """
-
-
-class TriMesh(MagicProperties):
+class TriMesh(PropertyNode):
     """Defines TriMesh mesh properties.
 
     Parameters
     ----------
-    grid: dict or GridMesh,  default=None
+    grid: dict or `GridMesh` object, default=None
         All mesh vertices and edges of a TriangularMesh object.
-
-    open: dict or OpenMesh,  default=None
+    open: dict or `OpenMesh` object, default=None
         Shows open mesh vertices and edges of a TriangularMesh object, if any.
-
-    disconnected: dict or DisconnectedMesh, default=None
+    disconnected: dict or `DisconnectedMesh` object, default=None
         Shows disconnected bodies of a TriangularMesh object, if any.
-
-    selfintersecting: dict or SelfIntersectingMesh, default=None
+    selfintersecting: dict or `SelfIntersectingMesh` object, default=None
         Shows self-intersecting triangles of a TriangularMesh object, if any.
     """
 
-    @property
-    def grid(self):
-        """GridMesh` instance with `'show'` property
-        or a dictionary with equivalent key/value pairs.
-        """
-        return self._grid
-
-    @grid.setter
-    def grid(self, val):
-        self._grid = validate_property_class(val, "grid", GridMesh, self)
-
-    @property
-    def open(self):
-        """OpenMesh` instance with `'show'` property
-        or a dictionary with equivalent key/value pairs.
-        """
-        return self._open
-
-    @open.setter
-    def open(self, val):
-        self._open = validate_property_class(val, "open", OpenMesh, self)
-
-    @property
-    def disconnected(self):
-        """`DisconnectedMesh` instance with `'show'` property
-        or a dictionary with equivalent key/value pairs.
-        """
-        return self._disconnected
-
-    @disconnected.setter
-    def disconnected(self, val):
-        self._disconnected = validate_property_class(
-            val, "disconnected", DisconnectedMesh, self
-        )
-
-    @property
-    def selfintersecting(self):
-        """`SelfIntersectingMesh` instance with `'show'` property
-        or a dictionary with equivalent key/value pairs.
-        """
-        return self._selfintersecting
-
-    @selfintersecting.setter
-    def selfintersecting(self, val):
-        self._selfintersecting = validate_property_class(
-            val, "selfintersecting", SelfIntersectingMesh, self
-        )
+    grid = Nested(GridMesh, doc="All mesh vertices and edges.")
+    open = Nested(OpenMesh, doc="Open mesh vertices and edges, if any.")
+    disconnected = Nested(DisconnectedMesh, doc="Disconnected mesh bodies, if any.")
+    selfintersecting = Nested(
+        SelfIntersectingMesh, doc="Self-intersecting triangles, if any."
+    )
 
 
-class DirectionProperties:
-    """Defines direction properties, common for CurrentSheet, Triangle and Triangularmesh."""
-
-    _allowed_symbols = ("cone", "arrow3d")
-
-    @property
-    def show(self):
-        """Show/hide arrow."""
-        return self._show
-
-    @show.setter
-    def show(self, val):
-        assert val is None or isinstance(val, bool), (
-            f"Input show of {type(self).__name__} must be either True or False; instead received {val!r}."
-        )
-        self._show = val
-
-    @property
-    def size(self):
-        """Positive float for ratio of sensor to canvas size."""
-        return self._size
-
-    @size.setter
-    def size(self, val):
-        assert val is None or (isinstance(val, int | float) and val >= 0), (
-            f"Input size of {type(self).__name__} must be a positive number; instead received {val!r}."
-        )
-        self._size = val
-
-    @property
-    def color(self):
-        """A valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`."""
-        return self._color
-
-    @color.setter
-    def color(self, val):
-        self._color = color_validator(val, parent_name=f"{type(self).__name__}")
-
-    @property
-    def symbol(self):
-        """Pixel symbol. Can be one of ("cone", "arrow3d")`."""
-        return self._symbol
-
-    @symbol.setter
-    def symbol(self, val):
-        assert val is None or val in self._allowed_symbols, (
-            f"Input symbol of {type(self).__name__} must be one of {self._allowed_symbols}; instead received {val!r}."
-        )
-        self._symbol = val
-
-
-class OffsetProperties:
-    """Defines orientation properties, common for Triangle and Triangularmesh."""
-
-    @property
-    def offset(self):
-        """Defines the orientation symbol offset, normal to the triangle surface. `offset=0` results
-        in the cone/arrow head to be coincident to the triangle surface and `offset=1` with the
-        base.
-        """
-        return self._offset
-
-    @offset.setter
-    def offset(self, val):
-        assert val is None or (isinstance(val, float | int)), (
-            f"Input offset of {type(self).__name__} must be a number; instead received {val!r}."
-        )
-        self._offset = val
-
-
-class Orientation(MagicProperties, DirectionProperties, OffsetProperties):
+class Orientation(PropertyNode):
     """Defines Triangle orientation properties.
 
     Parameters
     ----------
-    show: bool, default=True
+    show: bool, default=None
         Show/hide orientation symbol.
-
-    size: float, default=1,
-        Size of the orientation symbol
-
+    size: float, default=None
+        Size of the orientation symbol.
     color: str, default=None
-        A valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`.
-
-    symbol: {"cone", "arrow3d"}:
+        A valid css color.
+    symbol: {'cone', 'arrow3d'}, default=None
         Orientation symbol for the triangular faces.
-
-    offset: float, default=0.1
-        Defines the orientation symbol offset, normal to the triangle surface. Must be a number
-        between [0, 1], 0 resulting in the cone/arrow head to be coincident to the triangle surface
-        and 1 with the base.
+    offset: float, default=None
+        Orientation symbol offset, normal to the triangle surface. ``offset=0``
+        results in the cone/arrow head being coincident to the triangle surface
+        and ``offset=1`` with the base.
     """
 
-    def __init__(
-        self, show=None, size=None, color=None, symbol=None, offset=None, **kwargs
-    ):
-        super().__init__(
-            show=show, size=size, color=color, symbol=symbol, offset=offset, **kwargs
-        )
+    show = Boolean(doc="Show/hide orientation symbol.")
+    size = Number(minimum=0, doc="Size of the orientation symbol.")
+    color = Color(doc="Orientation symbol color.")
+    symbol = Choice("cone", "arrow3d", doc="Orientation symbol.")
+    offset = Number(doc="Orientation symbol offset, normal to the triangle surface.")
 
 
-class TriangleProperties:
-    """Defines Triangle properties.
+class TriangleProperties(PropertyNode):
+    """Defines Triangle properties."""
 
-    Parameters
-    ----------
-    orientation: dict or Orientation,  default=None,
-        Orientation styling of triangles.
-    """
-
-    @property
-    def orientation(self):
-        """`Orientation` instance with `'show'` property
-        or a dictionary with equivalent key/value pairs.
-        """
-        return self._orientation
-
-    @orientation.setter
-    def orientation(self, val):
-        self._orientation = validate_property_class(
-            val, "orientation", Orientation, self
-        )
+    orientation = Nested(Orientation, doc="Orientation styling of triangles.")
 
 
-class DefaultTriangle(MagicProperties, MagnetProperties, TriangleProperties):
+class DefaultTriangle(MagnetProperties, TriangleProperties):
     """Defines styling properties of the Triangle class.
 
     Parameters
     ----------
-    magnetization: dict or Magnetization, default=None
-        Magnetization styling with `'show'`, `'size'`, `'color'` properties
-        or a dictionary with equivalent key/value pairs.
-
-    orientation: dict or Orientation,  default=None,
-        Orientation of triangles styling with `'show'`, `'size'`, `'color', `'pivot'`, `'symbol'``
-        properties or a dictionary with equivalent key/value pairs..
+    magnetization: dict or `Magnetization` object, default=None
+    orientation: dict or `Orientation` object, default=None
     """
-
-    def __init__(self, magnetization=None, orientation=None, **kwargs):
-        super().__init__(magnetization=magnetization, orientation=orientation, **kwargs)
 
 
 class TriangleStyle(MagnetStyle, TriangleProperties):
@@ -1244,78 +708,30 @@ class TriangleStyle(MagnetStyle, TriangleProperties):
 
     Parameters
     ----------
-    label: str, default=None
-        Label of the class instance, e.g. to be displayed in the legend.
-
-    description: dict or `Description` object, default=None
-        Object description properties.
-
-    color: str, default=None
-        A valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`.
-
-    opacity: float, default=None
-        Object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
-
-    path: dict or `Path` object, default=None
-        An instance of `Path` or dictionary of equivalent key/value pairs, defining the object
-        path marker and path line properties.
-
-    model3d: list of `Trace3d` objects, default=None
-        A list of traces where each is an instance of `Trace3d` or dictionary of equivalent
-        key/value pairs. Defines properties for an additional user-defined model3d object which is
-        positioned relatively to the main object to be displayed and moved automatically with it.
-        This feature also allows the user to replace the original 3d representation of the object.
-
-    magnetization: dict or Magnetization, default=None
-        Magnetization styling with `'show'`, `'size'`, `'color'` properties
-        or a dictionary with equivalent key/value pairs.
-
-    orientation: dict or Orientation,  default=None,
-        Orientation styling of triangles.
+    magnetization: dict or `Magnetization` object, default=None
+    orientation: dict or `Orientation` object, default=None
+    label, description, legend, color, opacity, path, model3d:
+        See `BaseStyle`.
     """
 
-    def __init__(self, orientation=None, **kwargs):
-        super().__init__(orientation=orientation, **kwargs)
 
-
-class TriangularMeshProperties:
+class TriangularMeshProperties(PropertyNode):
     """Defines TriangularMesh properties."""
 
-    @property
-    def mesh(self):
-        """`TriMesh` instance with `'show', 'markers', 'line'` properties
-        or a dictionary with equivalent key/value pairs.
-        """
-        return self._mesh
-
-    @mesh.setter
-    def mesh(self, val):
-        self._mesh = validate_property_class(val, "mesh", TriMesh, self)
+    mesh = Nested(TriMesh, doc="TriMesh styling properties.")
 
 
 class DefaultTriangularMesh(
-    MagicProperties, MagnetProperties, TriangleProperties, TriangularMeshProperties
+    MagnetProperties, TriangleProperties, TriangularMeshProperties
 ):
     """Defines styling properties of homogeneous TriangularMesh magnet classes.
 
     Parameters
     ----------
-    magnetization: dict or Magnetization, default=None
-        Magnetization styling with `'show'`, `'size'`, `'color'` properties
-        or a dictionary with equivalent key/value pairs.
-
-    orientation: dict or Orientation,  default=None
-        Orientation of triangles styling with `'show'`, `'size'`, `'color', `'pivot'`, `'symbol'``
-        properties or a dictionary with equivalent key/value pairs.
-
-    mesh: dict or TriMesh, default=None
-        TriMesh styling properties (e.g. `'grid', 'open', 'disconnected'`)
+    magnetization: dict or `Magnetization` object, default=None
+    orientation: dict or `Orientation` object, default=None
+    mesh: dict or `TriMesh` object, default=None
     """
-
-    def __init__(self, magnetization=None, orientation=None, mesh=None, **kwargs):
-        super().__init__(
-            magnetization=magnetization, orientation=orientation, mesh=mesh, **kwargs
-        )
 
 
 class TriangularMeshStyle(MagnetStyle, TriangleProperties, TriangularMeshProperties):
@@ -1323,437 +739,140 @@ class TriangularMeshStyle(MagnetStyle, TriangleProperties, TriangularMeshPropert
 
     Parameters
     ----------
-    label: str, default=None
-        Label of the class instance, e.g. to be displayed in the legend.
-
-    description: dict or `Description` object, default=None
-        Object description properties.
-
-    color: str, default=None
-        A valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`.
-
-    opacity: float, default=None
-        Object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
-
-    path: dict or `Path` object, default=None
-        An instance of `Path` or dictionary of equivalent key/value pairs, defining the object
-        path marker and path line properties.
-
-    model3d: list of `Trace3d` objects, default=None
-        A list of traces where each is an instance of `Trace3d` or dictionary of equivalent
-        key/value pairs. Defines properties for an additional user-defined model3d object which is
-        positioned relatively to the main object to be displayed and moved automatically with it.
-        This feature also allows the user to replace the original 3d representation of the object.
-
-    magnetization: dict or Magnetization, default=None
-        Magnetization styling with `'show'`, `'size'`, `'color'` properties
-        or a dictionary with equivalent key/value pairs.
-
-    orientation: dict or Orientation,  default=None,
-        Orientation styling of triangles.
-
-    mesh: dict or TriMesh,  default=None,
-        mesh styling of triangles.
+    magnetization: dict or `Magnetization` object, default=None
+    orientation: dict or `Orientation` object, default=None
+    mesh: dict or `TriMesh` object, default=None
+    label, description, legend, color, opacity, path, model3d:
+        See `BaseStyle`.
     """
 
-    def __init__(self, orientation=None, **kwargs):
-        super().__init__(orientation=orientation, **kwargs)
+
+class CurrentGridMesh(MarkerLineProperties):
+    """Defines styling properties of CurrentGridMesh objects."""
 
 
-class CurrentMesh(MagicProperties):
-    """Defines TriMesh mesh properties.
+class CurrentMesh(PropertyNode):
+    """Defines CurrentSheet mesh properties.
 
     Parameters
     ----------
-    grid: dict or GridMesh,  default=None
-        All mesh vertices and edges of a TriangularMesh object.
+    grid: dict or `CurrentGridMesh` object, default=None
+        All mesh vertices and edges of a CurrentSheet object.
     """
 
-    @property
-    def grid(self):
-        """GridMesh` instance with `'show'` property
-        or a dictionary with equivalent key/value pairs.
-        """
-        return self._grid
-
-    @grid.setter
-    def grid(self, val):
-        self._grid = validate_property_class(val, "grid", CurrentGridMesh, self)
+    grid = Nested(CurrentGridMesh, doc="All mesh vertices and edges.")
 
 
-class CurrentGridMesh(MagicProperties, MarkerLineProperties):
-    """Defines styling properties of CurrentGridMesh objects
+class CurrentDirection(PropertyNode):
+    """Defines CurrentSheet direction properties.
 
     Parameters
     ----------
     show: bool, default=None
-        Show/hide Lines and Markers
-
-    marker: dict or `Markers` object, default=None
-        `Markers` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
-
-    line: dict or `Line` object, default=None
-        `Line` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
-    """
-
-
-class CurrentDirection(MagicProperties, DirectionProperties):
-    """Defines CurrentSheet direction properties.
-    Parameters
-    ----------
-    show: bool, default=True
-        Show/hide orientation symbol.
-
-    size: float, default=1,
-        Size of the orientation symbol
-
+        Show/hide direction symbol.
+    size: float, default=None
+        Size of the direction symbol.
     color: str, default=None
-        A valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`.
-
-    symbol: {"cone", "arrow3d"}:
+        A valid css color.
+    symbol: {'cone', 'arrow3d'}, default=None
         Current direction symbol for the triangular faces.
     """
 
-    def __init__(self, show=None, color=None, size=None, symbol=None, **kwargs):
-        super().__init__(show=show, color=color, size=size, symbol=symbol, **kwargs)
+    show = Boolean(doc="Show/hide direction symbol.")
+    size = Number(minimum=0, doc="Size of the direction symbol.")
+    color = Color(doc="Direction symbol color.")
+    symbol = Choice("cone", "arrow3d", doc="Current direction symbol.")
 
 
-class CurrentSheetProperties:
-    """Defines CurrentMesh properties."""
+class CurrentSheetProperties(PropertyNode):
+    """Defines CurrentSheet properties."""
 
-    @property
-    def mesh(self):
-        """`CurrentMesh` instance with `'show', 'markers', 'line'` properties
-        or a dictionary with equivalent key/value pairs.
-        """
-        return self._mesh
-
-    @mesh.setter
-    def mesh(self, val):
-        self._mesh = validate_property_class(val, "mesh", CurrentMesh, self)
-
-    @property
-    def direction(self):
-        """`CurrentDirection` instance with `'show'` property
-        or a dictionary with equivalent key/value pairs.
-        """
-        return self._direction
-
-    @direction.setter
-    def direction(self, val):
-        self._direction = validate_property_class(
-            val, "direction", CurrentDirection, self
-        )
+    direction = Nested(CurrentDirection, doc="Current direction styling.")
+    mesh = Nested(CurrentMesh, doc="CurrentMesh styling properties.")
 
 
-class DefaultCurrentSheet(MagicProperties, CurrentSheetProperties):
-    """Defines styling properties of the DefaultCurrentSheet class.
+class DefaultCurrentSheet(CurrentSheetProperties):
+    """Defines styling properties of the CurrentSheet classes.
 
     Parameters
     ----------
-    direction: dict or CurrentDirection,  default=None
-        CurrentDirection styling of triangles.
-
-    mesh: dict or CurrentMesh, default=None
-        CurrentMesh styling properties (`'show', 'markers', 'line'`)
+    direction: dict or `CurrentDirection` object, default=None
+    mesh: dict or `CurrentMesh` object, default=None
     """
-
-    def __init__(self, direction=None, mesh=None, **kwargs):
-        super().__init__(direction=direction, mesh=mesh, **kwargs)
 
 
 class CurrentSheetStyle(BaseStyle, CurrentSheetProperties):
-    """Defines styling properties of the CurrentSheet magnet class.
+    """Defines styling properties of the CurrentSheet classes.
 
     Parameters
     ----------
-    label: str, default=None
-        Label of the class instance, e.g. to be displayed in the legend.
-
-    description: dict or `Description` object, default=None
-        Object description properties.
-
-    color: str, default=None
-        A valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`.
-
-    opacity: float, default=None
-        Object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
-
-    path: dict or `Path` object, default=None
-        An instance of `Path` or dictionary of equivalent key/value pairs, defining the object
-        path marker and path line properties.
-
-    model3d: list of `Trace3d` objects, default=None
-        A list of traces where each is an instance of `Trace3d` or dictionary of equivalent
-        key/value pairs. Defines properties for an additional user-defined model3d object which is
-        positioned relatively to the main object to be displayed and moved automatically with it.
-        This feature also allows the user to replace the original 3d representation of the object.
-
-    direction: dict or CurrentDirection,  default=None,
-        CurrentDirection styling of triangles.
-
-    mesh: dict or CurrentMesh, default=None
-        CurrentMesh styling properties (`'show', 'markers', 'line'`)
+    direction: dict or `CurrentDirection` object, default=None
+        Current direction styling.
+    mesh: dict or `CurrentMesh` object, default=None
+        CurrentMesh styling properties.
+    label, description, legend, color, opacity, path, model3d:
+        See `BaseStyle`.
     """
 
-    def __init__(self, direction=None, mesh=None, **kwargs):
-        super().__init__(direction=direction, mesh=mesh, **kwargs)
 
-
-class ArrowCS(MagicProperties):
-    """Defines triple coordinate system arrow properties.
-
-    Parameters
-    ----------
-    x: dict or `ArrowSingle` object, default=None
-        x-direction `Arrowsingle` object or dict with equivalent key/value pairs
-        (e.g. `color`, `show`).
-    y: dict or `ArrowSingle` object, default=None
-        y-direction `Arrowsingle` object or dict with equivalent key/value pairs
-        (e.g. `color`, `show`).
-    z: dict or `ArrowSingle` object, default=None
-        z-direction `Arrowsingle` object or dict with equivalent key/value pairs
-        (e.g. `color`, `show`).
-    """
-
-    def __init__(self, x=None, y=None, z=None):
-        super().__init__(x=x, y=y, z=z)
-
-    @property
-    def x(self):
-        """
-        `ArrowSingle` object or dict with equivalent key/value pairs (e.g. `color`, `show`).
-        """
-        return self._x
-
-    @x.setter
-    def x(self, val):
-        self._x = validate_property_class(val, "x", ArrowSingle, self)
-
-    @property
-    def y(self):
-        """
-        `ArrowSingle` object or dict with equivalent key/value pairs (e.g. `color`, `show`).
-        """
-        return self._y
-
-    @y.setter
-    def y(self, val):
-        self._y = validate_property_class(val, "y", ArrowSingle, self)
-
-    @property
-    def z(self):
-        """
-        `ArrowSingle` object or dict with equivalent key/value pairs (e.g. `color`, `show`).
-        """
-        return self._z
-
-    @z.setter
-    def z(self, val):
-        self._z = validate_property_class(val, "z", ArrowSingle, self)
-
-
-class ArrowSingle(MagicProperties):
+class ArrowSingle(PropertyNode):
     """Single coordinate system arrow properties.
 
     Parameters
     ----------
     show: bool, default=True
         Show/hide arrow.
-
-    color: color, default=None
-        Valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`.
+    color: str, default=None
+        A valid css color.
     """
 
-    def __init__(self, show=True, color=None):
-        super().__init__(show=show, color=color)
-
-    @property
-    def show(self):
-        """Show/hide arrow."""
-        return self._show
-
-    @show.setter
-    def show(self, val):
-        assert val is None or isinstance(val, bool), (
-            f"Input show of {type(self).__name__} must be either True or False; instead received {val!r}."
-        )
-        self._show = val
-
-    @property
-    def color(self):
-        """A valid css color. Can also be one of `['r', 'g', 'b', 'y', 'm', 'c', 'k', 'w']`."""
-        return self._color
-
-    @color.setter
-    def color(self, val):
-        self._color = color_validator(val, parent_name=f"{type(self).__name__}")
+    show = Boolean(default=True, doc="Show/hide arrow.")
+    color = Color(doc="Arrow color.")
 
 
-class SensorProperties:
-    """Defines the specific styling properties of the Sensor class.
+class ArrowCS(PropertyNode):
+    """Defines triple coordinate system arrow properties.
 
     Parameters
     ----------
-    size: float, default=None
-        Positive float for ratio of sensor to canvas size.
-
-    sizemode: {'scaled', 'absolute'}, default='scaled'
-        Defines the scale reference for the sensor size. If 'absolute', the `size` parameters
-        becomes the sensor size in units (m).
-
-    pixel: dict, Pixel, default=None
-        `Pixel` object or dict with equivalent key/value pairs (e.g. `color`, `size`).
-
-    arrows: dict, ArrowCS, default=None
-        `ArrowCS` object or dict with equivalent key/value pairs (e.g. `color`, `size`).
+    x: dict or `ArrowSingle` object, default=None
+        x-direction arrow properties (e.g. `color`, `show`).
+    y: dict or `ArrowSingle` object, default=None
+        y-direction arrow properties (e.g. `color`, `show`).
+    z: dict or `ArrowSingle` object, default=None
+        z-direction arrow properties (e.g. `color`, `show`).
     """
 
-    @property
-    def size(self):
-        """Positive float for ratio of sensor to canvas size."""
-        return self._size
-
-    @size.setter
-    def size(self, val):
-        assert val is None or (isinstance(val, int | float) and val >= 0), (
-            f"Input size of {type(self).__name__} must be a positive number; instead received {val!r}."
-        )
-        self._size = val
-
-    @property
-    def sizemode(self):
-        """Sizemode of the sensor."""
-        return self._sizemode
-
-    @sizemode.setter
-    def sizemode(self, val):
-        assert val is None or val in ALLOWED_SIZEMODES, (
-            f"Input sizemode of {type(self).__name__} must be one of {ALLOWED_SIZEMODES}; instead received {val!r}."
-        )
-        self._sizemode = val
-
-    @property
-    def pixel(self):
-        """`Pixel` object or dict with equivalent key/value pairs (e.g. `color`, `size`)."""
-        return self._pixel
-
-    @pixel.setter
-    def pixel(self, val):
-        self._pixel = validate_property_class(val, "pixel", Pixel, self)
-
-    @property
-    def arrows(self):
-        """`ArrowCS` object or dict with equivalent key/value pairs (e.g. `color`, `size`)."""
-        return self._arrows
-
-    @arrows.setter
-    def arrows(self, val):
-        self._arrows = validate_property_class(val, "arrows", ArrowCS, self)
+    x = Nested(ArrowSingle, doc="x-direction arrow properties.")
+    y = Nested(ArrowSingle, doc="y-direction arrow properties.")
+    z = Nested(ArrowSingle, doc="z-direction arrow properties.")
 
 
-class DefaultSensor(MagicProperties, SensorProperties):
-    """Defines styling properties of the Sensor class.
-
-    Parameters
-    ----------
-    size: float, default=None
-        Positive float for ratio of sensor to canvas size.
-
-    sizemode: {'scaled', 'absolute'}, default='scaled'
-        Defines the scale reference for the sensor size. If 'absolute', the `size` parameters
-        becomes the sensor size in units (m).
-
-    pixel: dict, Pixel, default=None
-        `Pixel` object or dict with equivalent key/value pairs (e.g. `color`, `size`).
-
-    arrows: dict, ArrowCS, default=None
-        `ArrowCS` object or dict with equivalent key/value pairs (e.g. `color`, `size`).
-    """
-
-    def __init__(
-        self,
-        size=None,
-        sizemode=None,
-        pixel=None,
-        arrows=None,
-        **kwargs,
-    ):
-        super().__init__(
-            size=size,
-            sizemode=sizemode,
-            pixel=pixel,
-            arrows=arrows,
-            **kwargs,
-        )
-
-
-class SensorStyle(BaseStyle, SensorProperties):
-    """Styling properties for the Sensor class.
-
-    Parameters
-    ----------
-    label : str | None, default None
-        Label of the class instance, e.g., to be displayed in the legend.
-    description : dict | Description | None, default None
-        Object description properties.
-    color : str | None, default None
-        A valid CSS color. May also be one of {'r', 'g', 'b', 'y', 'm', 'c', 'k', 'w'}.
-    opacity : float | None, default None
-        Object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
-    path : dict | Path | None, default None
-        Instance of ``Path`` or dict with equivalent key/value pairs; defines path marker
-        and path line properties.
-    model3d : list[Trace3d | dict] | None, default None
-        List of traces where each is a ``Trace3d`` instance or dict of equivalent key/value
-        pairs. Defines an additional user-defined 3D model positioned relative to the main
-        object and transformed with it. Can replace the original 3D representation.
-    size : float | None, default None
-        Ratio of sensor size to canvas size (positive).
-    pixel : dict | Pixel | None, default None
-        ``Pixel`` instance or dict with equivalent key/value pairs (e.g., ``color``, ``size``).
-    arrows : dict | ArrowCS | None, default None
-        ``ArrowCS`` instance or dict with equivalent key/value pairs (e.g., ``color``, ``size``).
-    """
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-
-class PixelField(MagicProperties):
-    """Defines the styling properties of sensor pixels.
+class PixelField(PropertyNode):
+    """Defines the styling properties of sensor pixel fields.
 
     Parameters
     ----------
     source: str, default=None
-        The pixel color source (e.g. "Bx", "Hxy", "J", etc.). If not specified,
-        the amplitude of the `source` value is used.
-
-    colormap: str, default="Inferno",
+        The pixel color source (e.g. "Bx", "Hxy", "J", etc.).
+    colormap: str, default=None
         The colormap used with `source`.
-
-    shownull: bool, default=True
-        Show/hide null or invalid field values
-
-    symbol: {"cone", "arrow", "arrow3d"}:
+    shownull: bool, default=None
+        Show/hide null or invalid field values.
+    symbol: {'cone', 'arrow', 'arrow3d', 'none'}, default=None
         Orientation symbol for field vector.
-
-    sizescaling: {"uniform", "linear","log","log^[2-9]"}
-        Symbol size scaling relative the the field magnitude.
-
-    sizemin: float, default=0.
+    sizescaling: {'uniform', 'linear', 'log', 'log^[2-9]'}, default=None
+        Symbol size scaling relative to the field magnitude.
+    sizemin: float, default=None
         Minimum relative size of field symbols (0 to 1).
-
-    colorscaling: {"uniform", "linear","log","log^[2-9]"}
-        Color scale scaling relative the the field magnitude.
+    colorscaling: {'uniform', 'linear', 'log', 'log^[2-9]'}, default=None
+        Color scale scaling relative to the field magnitude.
     """
 
     _allowed_scalings_pattern = r"^(uniform|linear|(log)+|log\^[2-9])$"
-    _allowed_vectors = ("B", "H", "M", "J")
-    _allowed_symbols = ("cone", "arrow", "arrow3d", "none")
-    _allowed_colormaps = (
+
+    source = PixelSource(doc="Pixel field source.")
+    colormap = Choice(
         "Viridis",
         "Jet",
         "Rainbow",
@@ -1779,243 +898,101 @@ class PixelField(MagicProperties):
         "PuBuGn",
         "BuGn",
         "YlGn",
+        doc="Colormap used with source.",
+    )
+    shownull = Boolean(doc="Show/hide null or invalid field values.")
+    symbol = Choice(
+        "cone", "arrow", "arrow3d", "none", doc="Orientation symbol for field vector."
+    )
+    sizescaling = Regex(
+        _allowed_scalings_pattern, doc="Symbol size scaling relative to field."
+    )
+    sizemin = Number(
+        minimum=0, maximum=1, doc="Minimum relative size of field symbols."
+    )
+    colorscaling = Regex(
+        _allowed_scalings_pattern, doc="Color scale scaling relative to field."
     )
 
-    @property
-    def source(self):
-        """Pixel vector source."""
-        return self._source
 
-    @source.setter
-    def source(self, val):
-        valid = True
-        if val not in (None, False):
-            field_str, *coords_str = val
-            if not coords_str:
-                coords_str = list("xyz")
-            if field_str not in self._allowed_vectors and set(coords_str).difference(
-                set("xyz")
-            ):
-                valid = False
-        assert valid, (
-            f"Input source of {self} must be None or False or start"
-            f" with either {self._allowed_vectors} and be followed by a combination of"
-            f" 'x', 'y', 'z' (e.g. 'Bxy' or ('Bxy', 'Bz') ); instead received {val!r}."
-        )
-        self._source = val
-
-    @property
-    def colormap(self):
-        """Pixel vector source."""
-        return self._colormap
-
-    @colormap.setter
-    def colormap(self, val):
-        assert val is None or val in self._allowed_colormaps, (
-            f"Input colormap of {self} must be one of "
-            f"{self._allowed_colormaps}; "
-            f"instead received {val!r}."
-        )
-        self._colormap = val
-
-    @property
-    def shownull(self):
-        """Show/hide null or invalid field values"""
-        return self._shownull
-
-    @shownull.setter
-    def shownull(self, val):
-        assert val is None or isinstance(val, bool), (
-            f"Input shownull of {self} must be either True or False; "
-            f"instead received {val!r}."
-        )
-        self._shownull = val
-
-    @property
-    def symbol(self):
-        """Pixel symbol. Can be one of `{"cone", "arrow", "arrow3d"}`."""
-        return self._symbol
-
-    @symbol.setter
-    def symbol(self, val):
-        assert val is None or val in self._allowed_symbols, (
-            f"Input symbol of {self} must be one of"
-            f"{self._allowed_symbols},\n"
-            f"but received {val!r} instead."
-        )
-        self._symbol = val
-
-    @property
-    def sizescaling(self):
-        """Pixel sizescaling. Can be one of `{"uniform", "linear","log","log^[2-9]"}`."""
-        return self._sizescaling
-
-    @sizescaling.setter
-    def sizescaling(self, val):
-        self._sizescaling = self._validate_scaling(val, name="sizescaling")
-
-    @property
-    def sizemin(self):
-        """Minimum relative size of field symbols (0 to 1)."""
-        return self._sizemin
-
-    @sizemin.setter
-    def sizemin(self, val):
-        assert val is None or (isinstance(val, float | int) and 0 <= val <= 1), (
-            f"Input sizemin must be a value between 0 and 1; instead received {val!r}."
-        )
-        self._sizemin = val
-
-    @property
-    def colorscaling(self):
-        """Pixel colorscaling. Can be one of `{"uniform", "linear","log","log^[2-9]"}`."""
-        return self._colorscaling
-
-    @colorscaling.setter
-    def colorscaling(self, val):
-        self._colorscaling = self._validate_scaling(val, name="colorscaling")
-
-    def _validate_scaling(self, val, name):
-        assert val is None or re.match(self._allowed_scalings_pattern, str(val)), (
-            f"Input {name} of {self} must match the regex pattern"
-            f" {self._allowed_scalings_pattern}; "
-            f"instead received {val!r}."
-        )
-        return val
-
-
-class Pixel(MagicProperties):
+class Pixel(PropertyNode):
     """Defines the styling properties of sensor pixels.
 
     Parameters
     ----------
     size: float, default=1
         Positive float for relative pixel size.
-        - Matplotlib backend: Pixel size is the marker size.
-        - plotly backend: Relative distance to nearest neighbor pixel.
-
-    sizemode: {'scaled', 'absolute'}, default='scaled'
-        Defines the scale reference for the pixel size. If 'absolute', the `size` parameters
-        becomes the pixel size in units (m).
-
+    sizemode: {'scaled', 'absolute'}, default=None
+        Scale reference for the pixel size.
     color: str, default=None
-        Defines the pixel color@property.
-
+        Pixel color.
     symbol: str, default=None
-        Pixel symbol. Can be one of `['.', 'o', '+', 'D', 'd', 's', 'x']`.
-        Only applies for Matplotlib plotting backend.
+        Pixel symbol, one of `['cube', '.', 'o', '+', 'D', 'd', 's', 'x']`.
+    field: dict or `PixelField` object, default=None
+        Pixel field styling properties.
     """
 
-    _allowed_symbols = ("cube", *ALLOWED_SYMBOLS)
-
-    def __init__(self, size=1, sizemode=None, color=None, symbol=None, **kwargs):
-        super().__init__(
-            size=size,
-            sizemode=sizemode,
-            color=color,
-            symbol=symbol,
-            **kwargs,
-        )
-
-    @property
-    def size(self):
-        """Positive float for relative pixel size.
-        - Matplotlib backend: Pixel size is the marker size.
-        - plotly backend: Relative distance to nearest neighbor pixel."""
-        return self._size
-
-    @size.setter
-    def size(self, val):
-        assert val is None or (isinstance(val, int | float) and val >= 0), (
-            f"Input size of {type(self).__name__} must be a positive number; instead received {val!r}."
-        )
-        self._size = val
-
-    @property
-    def sizemode(self):
-        """Sizemode of the pixel."""
-        return self._sizemode
-
-    @sizemode.setter
-    def sizemode(self, val):
-        assert val is None or val in ALLOWED_SIZEMODES, (
-            f"Input sizemode of {type(self).__name__} must be one of {ALLOWED_SIZEMODES}; instead received {val!r}."
-        )
-        self._sizemode = val
-
-    @property
-    def color(self):
-        """Pixel color."""
-        return self._color
-
-    @color.setter
-    def color(self, val):
-        self._color = color_validator(val, parent_name=f"{type(self).__name__}")
-
-    @property
-    def symbol(self):
-        """Pixel symbol. Can be one of `['cube', '.', 'o', '+', 'D', 'd', 's', 'x']`."""
-        return self._symbol
-
-    @symbol.setter
-    def symbol(self, val):
-        assert val is None or val in self._allowed_symbols, (
-            f"Input symbol of {type(self).__name__} must be one of {self._allowed_symbols}; instead received {val!r}."
-        )
-        self._symbol = val
-
-    @property
-    def field(self):
-        """`PixelField` object or dict."""
-        return self._field
-
-    @field.setter
-    def field(self, val):
-        self._field = validate_property_class(val, "pixel", PixelField, self)
+    size = Number(minimum=0, default=1, doc="Positive float for relative pixel size.")
+    sizemode = Choice(*ALLOWED_SIZEMODES, doc="Sizemode of the pixel.")
+    color = Color(doc="Pixel color.")
+    symbol = Choice("cube", *ALLOWED_SYMBOLS, doc="Pixel symbol.")
+    field = Nested(PixelField, doc="Pixel field styling properties.")
 
 
-class CurrentProperties:
-    """Defines styling properties of line current classes.
+class SensorProperties(PropertyNode):
+    """Defines the specific styling properties of the Sensor class."""
+
+    size = Number(minimum=0, doc="Positive float for ratio of sensor to canvas size.")
+    sizemode = Choice(*ALLOWED_SIZEMODES, doc="Sizemode of the sensor.")
+    pixel = Nested(Pixel, doc="Pixel styling properties.")
+    arrows = Nested(ArrowCS, doc="Coordinate system arrows properties.")
+
+
+class DefaultSensor(SensorProperties):
+    """Defines styling properties of the Sensor class.
 
     Parameters
     ----------
-    arrow: dict or `Arrow` object, default=None
-        `Arrow` object or dict with `show, size, width, style, color` properties/keys.
-
-    line: dict or `Line` object, default=None
-        `Line` object or dict with `show, width, style, color` properties/keys.
+    size: float, default=None
+    sizemode: {'scaled', 'absolute'}, default=None
+    pixel: dict or `Pixel` object, default=None
+    arrows: dict or `ArrowCS` object, default=None
     """
 
-    @property
-    def arrow(self):
-        """`Arrow` object or dict with `show, size, width, style, color` properties/keys."""
-        return self._arrow
 
-    @arrow.setter
-    def arrow(self, val):
-        self._arrow = validate_property_class(val, "current", Arrow, self)
+class SensorStyle(BaseStyle, SensorProperties):
+    """Styling properties for the Sensor class.
 
-    @property
-    def line(self):
-        """`Line` object or dict with `show, width, style, color` properties/keys."""
-        return self._line
+    Parameters
+    ----------
+    size: float, default=None
+        Positive float for ratio of sensor to canvas size.
+    sizemode: {'scaled', 'absolute'}, default=None
+        Scale reference for the sensor size.
+    pixel: dict or `Pixel` object, default=None
+        Pixel styling properties.
+    arrows: dict or `ArrowCS` object, default=None
+        Coordinate system arrows properties.
+    label, description, legend, color, opacity, path, model3d:
+        See `BaseStyle`.
+    """
 
-    @line.setter
-    def line(self, val):
-        self._line = validate_property_class(val, "line", CurrentLine, self)
+
+class CurrentProperties(PropertyNode):
+    """Defines styling properties of line current classes."""
+
+    arrow = Nested(Arrow, doc="Current arrow properties.")
+    line = Nested(CurrentLine, doc="Current line properties.")
 
 
-class DefaultCurrent(MagicProperties, CurrentProperties):
+class DefaultCurrent(CurrentProperties):
     """Defines the specific styling properties of line current classes.
 
     Parameters
     ----------
-    arrow: dict or `Arrow`object, default=None
-        `Arrow` object or dict with 'show', 'size' properties/keys.
+    arrow: dict or `Arrow` object, default=None
+    line: dict or `CurrentLine` object, default=None
     """
-
-    def __init__(self, arrow=None, **kwargs):
-        super().__init__(arrow=arrow, **kwargs)
 
 
 class CurrentStyle(BaseStyle, CurrentProperties):
@@ -2023,196 +1000,13 @@ class CurrentStyle(BaseStyle, CurrentProperties):
 
     Parameters
     ----------
-    label : str | None, default None
-        Label of the class instance, e.g., to be displayed in the legend.
-    description : dict | Description | None, default None
-        Object description properties.
-    color : str | None, default None
-        A valid CSS color. May also be one of {'r', 'g', 'b', 'y', 'm', 'c', 'k', 'w'}.
-    opacity : float | None, default None
-        Object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
-    path : dict | Path | None, default None
-        Instance of ``Path`` or dict with equivalent key/value pairs; defines path marker
-        and path line properties.
-    model3d : list[Trace3d | dict] | None, default None
-        List of traces where each is a ``Trace3d`` instance or dict of equivalent key/value
-        pairs. Defines an additional user-defined 3D model positioned relative to the main
-        object and transformed with it. Can replace the original 3D representation.
-    arrow : dict | Arrow | None, default None
-        ``Arrow`` instance or dict with keys ``'show'``, ``'size'``.
+    arrow: dict or `Arrow` object, default=None
+        Current arrow properties.
+    line: dict or `CurrentLine` object, default=None
+        Current line properties.
+    label, description, legend, color, opacity, path, model3d:
+        See `BaseStyle`.
     """
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-
-class Arrow(Line):
-    """Defines styling properties of current arrows.
-
-    Parameters
-    ----------
-    show: bool, default=None
-        Show/Hide arrow
-
-    size: float, default=None
-        Positive number defining the size of the arrows. Effective value depends on the
-        `sizemode` parameter.
-
-    sizemode: {'scaled', 'absolute'}, default='scaled'
-        Defines the scale reference for the arrow size. If 'absolute', the `size` parameters
-        becomes the arrow length in units (m).
-
-    offset: float, default=0.5
-        Defines the arrow offset. `offset=0` results in the arrow head to be coincident to start
-        of the line, and `offset=1` with the end.
-
-    style: str, default=None
-        Can be one of:
-        `['solid', '-', 'dashed', '--', 'dashdot', '-.', 'dotted', '.', (0, (1, 1)),
-        'loosely dotted', 'loosely dashdotted']`
-
-    color: str, default=None
-        Line color.
-
-    width: float, default=None
-        Positive number that defines the line width.
-    """
-
-    def __init__(self, show=None, size=None, **kwargs):
-        super().__init__(show=show, size=size, **kwargs)
-
-    @property
-    def show(self):
-        """Show/hide arrow showing current direction."""
-        return self._show
-
-    @show.setter
-    def show(self, val):
-        assert val is None or isinstance(val, bool), (
-            f"Input show of {type(self).__name__} must be either True or False; instead received {val!r}."
-        )
-        self._show = val
-
-    @property
-    def size(self):
-        """Positive number defining the size of the arrows."""
-        return self._size
-
-    @size.setter
-    def size(self, val):
-        assert val is None or (isinstance(val, int | float) and val >= 0), (
-            f"Input size of {type(self).__name__} must be a positive number; instead received {val!r}."
-        )
-        self._size = val
-
-    @property
-    def sizemode(self):
-        """Sizemode of the arrows."""
-        return self._sizemode
-
-    @sizemode.setter
-    def sizemode(self, val):
-        assert val is None or val in ALLOWED_SIZEMODES, (
-            f"Input sizemode of {type(self).__name__} must be one of {ALLOWED_SIZEMODES}; instead received {val!r}."
-        )
-        self._sizemode = val
-
-    @property
-    def offset(self):
-        """Defines the arrow offset. `offset=0` results in the arrow head to be coincident to start
-        of the line, and `offset=1` with the end.
-        """
-        return self._offset
-
-    @offset.setter
-    def offset(self, val):
-        assert val is None or ((isinstance(val, float | int)) and 0 <= val <= 1), (
-            f"Input offset of {type(self).__name__} must be a number between 0 and 1; instead received {val!r}."
-        )
-        self._offset = val
-
-
-class CurrentLine(Line):
-    """Defines styling properties of current lines.
-
-    Parameters
-    ----------
-    show: bool, default=None
-        Show/Hide arrow
-
-    style: str, default=None
-        Can be one of:
-        `['solid', '-', 'dashed', '--', 'dashdot', '-.', 'dotted', '.', (0, (1, 1)),
-        'loosely dotted', 'loosely dashdotted']`
-
-    color: str, default=None
-        Line color.
-
-    width: float, default=None
-        Positive number that defines the line width.
-    """
-
-    @property
-    def show(self):
-        """Show/hide current line."""
-        return self._show
-
-    @show.setter
-    def show(self, val):
-        assert val is None or isinstance(val, bool), (
-            f"Input show of {type(self).__name__} must be either True or False; instead received {val!r}."
-        )
-        self._show = val
-
-
-class Marker(MagicProperties):
-    """Defines styling properties of plot markers.
-
-    Parameters
-    ----------
-    size: float, default=None
-        Marker size.
-    color: str, default=None
-        Marker color.
-    symbol: str, default=None
-        Marker symbol. Can be one of `['.', 'o', '+', 'D', 'd', 's', 'x']`.
-    """
-
-    def __init__(self, size=None, color=None, symbol=None, **kwargs):
-        super().__init__(size=size, color=color, symbol=symbol, **kwargs)
-
-    @property
-    def size(self):
-        """Marker size."""
-        return self._size
-
-    @size.setter
-    def size(self, val):
-        assert val is None or (isinstance(val, int | float) and val >= 0), (
-            f"Input size of {type(self).__name__} must be a positive number; instead received {val!r}."
-        )
-        self._size = val
-
-    @property
-    def color(self):
-        """Marker color."""
-        return self._color
-
-    @color.setter
-    def color(self, val):
-        self._color = color_validator(val)
-
-    @property
-    def symbol(self):
-        """Marker symbol. Can be one of `['.', 'o', '+', 'D', 'd', 's', 'x']`."""
-        return self._symbol
-
-    @symbol.setter
-    def symbol(self, val):
-        assert val is None or val in ALLOWED_SYMBOLS, (
-            f"Input symbol of {type(self).__name__} must be one of {ALLOWED_SYMBOLS}; instead received {val!r}."
-        )
-        self._symbol = val
 
 
 class DefaultMarkers(BaseStyle):
@@ -2220,102 +1014,35 @@ class DefaultMarkers(BaseStyle):
 
     Parameters
     ----------
-    marker: dict or `Markers` object, default=None
-        `Markers` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
+    marker: dict or `Marker` object, default=None
+        Marker properties.
     """
 
-    def __init__(self, marker=None, **kwargs):
-        super().__init__(marker=marker, **kwargs)
-
-    @property
-    def marker(self):
-        """`Markers` object with 'color', 'symbol', 'size' properties."""
-        return self._marker
-
-    @marker.setter
-    def marker(self, val):
-        self._marker = validate_property_class(val, "marker", Marker, self)
+    marker = Nested(Marker, doc="Marker properties.")
 
 
-class DipoleProperties:
+class DipoleProperties(PropertyNode):
+    """Defines styling properties of dipoles."""
+
+    size = Number(minimum=0, doc="Positive float for ratio of dipole to canvas size.")
+    sizemode = Choice(*ALLOWED_SIZEMODES, doc="Sizemode of the dipole.")
+    pivot = Choice(
+        "tail",
+        "middle",
+        "tip",
+        doc="Part of the arrow anchored to the grid, about which it rotates.",
+    )
+
+
+class DefaultDipole(DipoleProperties):
     """Defines styling properties of dipoles.
 
     Parameters
     ----------
-    size: float
-        Positive value for ratio of dipole size to canvas size.
-
-    sizemode: {'scaled', 'absolute'}, default='scaled'
-        Defines the scale reference for the dipole size. If 'absolute', the `size` parameters
-        becomes the dipole size in units (m).
-
-    pivot: str
-        The part of the arrow that is anchored to the X, Y grid.
-        The arrow rotates about this point. Can be one of `['tail', 'middle', 'tip']`.
-    """
-
-    _allowed_pivots = ("tail", "middle", "tip")
-
-    @property
-    def size(self):
-        """Positive value for ratio of dipole size to canvas size."""
-        return self._size
-
-    @size.setter
-    def size(self, val):
-        assert val is None or (isinstance(val, int | float) and val >= 0), (
-            f"Input size of {type(self).__name__} must be a positive number; instead received {val!r}."
-        )
-        self._size = val
-
-    @property
-    def sizemode(self):
-        """Sizemode of the dipole."""
-        return self._sizemode
-
-    @sizemode.setter
-    def sizemode(self, val):
-        assert val is None or val in ALLOWED_SIZEMODES, (
-            f"Input sizemode of {type(self).__name__} must be one of {ALLOWED_SIZEMODES}; instead received {val!r}."
-        )
-        self._sizemode = val
-
-    @property
-    def pivot(self):
-        """The part of the arrow that is anchored to the X, Y grid.
-        The arrow rotates about this point. Can be one of `['tail', 'middle', 'tip']`.
-        """
-        return self._pivot
-
-    @pivot.setter
-    def pivot(self, val):
-        assert val is None or val in (self._allowed_pivots), (
-            f"Input pivot of {type(self).__name__} must be one of {self._allowed_pivots}; instead received {val!r}."
-        )
-        self._pivot = val
-
-
-class DefaultDipole(MagicProperties, DipoleProperties):
-    """
-    Defines styling properties of dipoles.
-
-    Parameters
-    ----------
     size: float, default=None
-        Positive float for ratio of dipole size to canvas size.
-
-    sizemode: {'scaled', 'absolute'}, default='scaled'
-        Defines the scale reference for the dipole size. If 'absolute', the `size` parameters
-        becomes the dipole size in units (m).
-
-    pivot: str, default=None
-        The part of the arrow that is anchored to the X, Y grid.
-        The arrow rotates about this point. Can be one of `['tail', 'middle', 'tip']`.
+    sizemode: {'scaled', 'absolute'}, default=None
+    pivot: {'tail', 'middle', 'tip'}, default=None
     """
-
-    def __init__(self, size=None, sizemode=None, pivot=None, **kwargs):
-        super().__init__(size=size, sizemode=sizemode, pivot=pivot, **kwargs)
 
 
 class DipoleStyle(BaseStyle, DipoleProperties):
@@ -2323,250 +1050,53 @@ class DipoleStyle(BaseStyle, DipoleProperties):
 
     Parameters
     ----------
-    label : str | None, default None
-        Label of the class instance, e.g., to be displayed in the legend.
-    description : dict | Description | None, default None
-        Object description properties.
-    color : str | None, default None
-        A valid CSS color. May also be one of {'r', 'g', 'b', 'y', 'm', 'c', 'k', 'w'}.
-    opacity : float | None, default None
-        Object opacity between 0 and 1, where 1 is fully opaque and 0 is fully transparent.
-    path : dict | Path | None, default None
-        Instance of ``Path`` or dict with equivalent key/value pairs; defines path marker
-        and path line properties.
-    model3d : list[Trace3d | dict] | None, default None
-        List of traces where each is a ``Trace3d`` instance or dict of equivalent key/value
-        pairs. Defines an additional user-defined 3D model positioned relative to the main
-        object and transformed with it. Can replace the original 3D representation.
-    size : float | None, default None
-        Ratio of dipole size to canvas size (positive).
-    pivot : {'tail', 'middle', 'tip'} | None, default None
+    size: float, default=None
+        Positive float for ratio of dipole to canvas size.
+    sizemode: {'scaled', 'absolute'}, default=None
+        Scale reference for the dipole size.
+    pivot: {'tail', 'middle', 'tip'}, default=None
         The part of the arrow anchored to the grid about which it rotates.
+    label, description, legend, color, opacity, path, model3d:
+        See `BaseStyle`.
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
 
-
-class Path(MagicProperties, MarkerLineProperties):
-    """Defines styling properties of an object's path.
+class DisplayStyle(PropertyNode):
+    """Base class containing styling properties for all object families.
 
     Parameters
     ----------
-    show: bool, default=None
-        Show/hide path.
-        - False: Shows object(s) at final path position and hides paths lines and markers.
-        - True: Shows object(s) shows object paths depending on `line`, `marker` and `frames`
-        parameters.
-
-    marker: dict or `Markers` object, default=None
-        `Markers` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
-
-    line: dict or `Line` object, default=None
-        `Line` object with 'color', 'symbol', 'size' properties, or dictionary with equivalent
-        key/value pairs.
-
-    frames: int or array-like, shape (n,), default=None
-        Show copies of the 3D-model along the given path indices.
-        - integer i: Displays the object(s) at every i'th path position.
-        - array-like, shape (n,), dtype=int: Displays object(s) at given path indices.
-
-    numbering: bool, default=False
-        Show/hide numbering on path positions.
-    """
-
-    def __init__(
-        self, show=None, marker=None, line=None, frames=None, numbering=None, **kwargs
-    ):
-        super().__init__(
-            show=show,
-            marker=marker,
-            line=line,
-            frames=frames,
-            numbering=numbering,
-            **kwargs,
-        )
-
-    @property
-    def frames(self):
-        """Show copies of the 3D-model along the given path indices.
-        - integer i: Displays the object(s) at every i'th path position.
-        - array-like shape (n,) of integers: Displays object(s) at given path indices.
-        """
-        return self._frames
-
-    @frames.setter
-    def frames(self, val):
-        is_valid_path = True
-        if hasattr(val, "__iter__") and not isinstance(val, str):
-            val = tuple(val)
-            if not all(np.issubdtype(type(v), int) for v in val):
-                is_valid_path = False
-        elif not (val is None or np.issubdtype(type(val), int)):
-            is_valid_path = False
-        assert is_valid_path, (
-            f"Input frames of {type(self).__name__} must be either: "
-            "integer i (displays the objects at every i'th path position) or "
-            "array-like, shape (n,), dtype=int (displays objects at given path "
-            f"indices; instead received {val!r}."
-        )
-        self._frames = val
-
-    @property
-    def numbering(self):
-        """Show/hide numbering on path positions. Only applies if show=True."""
-        return self._numbering
-
-    @numbering.setter
-    def numbering(self, val):
-        assert val is None or isinstance(val, bool), (
-            f"Input numbering of {type(self).__name__} must be either True or False; instead received {val!r}."
-        )
-        self._numbering = val
-
-
-class DisplayStyle(MagicProperties):
-    """Base class containing styling properties for all object families. The properties of the
-    sub-classes are set to hard coded defaults at class instantiation.
-
-    Parameters
-    ----------
-    base: dict or `Base` object, default=None
+    base: dict or `BaseStyle` object, default=None
         Base properties common to all families.
-
-    magnet: dict or `Magnet` object, default=None
+    magnet: dict or `DefaultMagnet` object, default=None
         Magnet properties.
-
-    current: dict or `Current` object, default=None
+    current: dict or `DefaultCurrent` object, default=None
         Current properties.
-
-    dipole: dict or `Dipole` object, default=None
+    currentsheet: dict or `DefaultCurrentSheet` object, default=None
+        CurrentSheet properties.
+    dipole: dict or `DefaultDipole` object, default=None
         Dipole properties.
-
-    triangle: dict or `Triangle` object, default=None
-        Triangle properties
-
-    sensor: dict or `Sensor` object, default=None
+    triangle: dict or `DefaultTriangle` object, default=None
+        Triangle properties.
+    triangularmesh: dict or `DefaultTriangularMesh` object, default=None
+        TriangularMesh properties.
+    sensor: dict or `DefaultSensor` object, default=None
         Sensor properties.
-
-    markers: dict or `Markers` object, default=None
+    markers: dict or `DefaultMarkers` object, default=None
         Markers properties.
     """
 
-    def __init__(
-        self,
-        base=None,
-        magnet=None,
-        current=None,
-        currentsheet=None,
-        dipole=None,
-        triangle=None,
-        triangularmesh=None,
-        sensor=None,
-        markers=None,
-        **kwargs,
-    ):
-        super().__init__(
-            base=base,
-            magnet=magnet,
-            current=current,
-            currentsheet=currentsheet,
-            dipole=dipole,
-            triangle=triangle,
-            triangularmesh=triangularmesh,
-            sensor=sensor,
-            markers=markers,
-            **kwargs,
-        )
-        # self.reset()
+    base = Nested(BaseStyle, doc="Base properties common to all families.")
+    magnet = Nested(DefaultMagnet, doc="Magnet default style.")
+    current = Nested(DefaultCurrent, doc="Current default style.")
+    currentsheet = Nested(DefaultCurrentSheet, doc="CurrentSheet default style.")
+    dipole = Nested(DefaultDipole, doc="Dipole default style.")
+    triangle = Nested(DefaultTriangle, doc="Triangle default style.")
+    triangularmesh = Nested(DefaultTriangularMesh, doc="TriangularMesh default style.")
+    sensor = Nested(DefaultSensor, doc="Sensor default style.")
+    markers = Nested(DefaultMarkers, doc="Markers default style.")
 
     def reset(self):
         """Resets all nested properties to their hard coded default values."""
         self.update(get_defaults_dict("display.style"), _match_properties=False)
         return self
-
-    @property
-    def base(self):
-        """Base properties common to all families."""
-        return self._base
-
-    @base.setter
-    def base(self, val):
-        self._base = validate_property_class(val, "base", BaseStyle, self)
-
-    @property
-    def magnet(self):
-        """Magnet default style class."""
-        return self._magnet
-
-    @magnet.setter
-    def magnet(self, val):
-        self._magnet = validate_property_class(val, "magnet", DefaultMagnet, self)
-
-    @property
-    def triangularmesh(self):
-        """TriangularMesh default style class."""
-        return self._triangularmesh
-
-    @triangularmesh.setter
-    def triangularmesh(self, val):
-        self._triangularmesh = validate_property_class(
-            val, "triangularmesh", DefaultTriangularMesh, self
-        )
-
-    @property
-    def current(self):
-        """Current default style class."""
-        return self._current
-
-    @current.setter
-    def current(self, val):
-        self._current = validate_property_class(val, "current", DefaultCurrent, self)
-
-    @property
-    def currentsheet(self):
-        """CurrentSheet default style class."""
-        return self._currentsheet
-
-    @currentsheet.setter
-    def currentsheet(self, val):
-        self._currentsheet = validate_property_class(
-            val, "currentsheet", DefaultCurrentSheet, self
-        )
-
-    @property
-    def dipole(self):
-        """Dipole default style class."""
-        return self._dipole
-
-    @dipole.setter
-    def dipole(self, val):
-        self._dipole = validate_property_class(val, "dipole", DefaultDipole, self)
-
-    @property
-    def triangle(self):
-        """Triangle default style class."""
-        return self._triangle
-
-    @triangle.setter
-    def triangle(self, val):
-        self._triangle = validate_property_class(val, "triangle", DefaultTriangle, self)
-
-    @property
-    def sensor(self):
-        """Sensor default style class."""
-        return self._sensor
-
-    @sensor.setter
-    def sensor(self, val):
-        self._sensor = validate_property_class(val, "sensor", DefaultSensor, self)
-
-    @property
-    def markers(self):
-        """Markers default style class."""
-        return self._markers
-
-    @markers.setter
-    def markers(self, val):
-        self._markers = validate_property_class(val, "markers", DefaultMarkers, self)

--- a/src/magpylib/_src/style.py
+++ b/src/magpylib/_src/style.py
@@ -6,6 +6,8 @@ round-tripping, schema introspection, change observation and layered
 resolution generically (see ``magpylib._src.defaults.property_tree``).
 """
 
+# pylint: disable=too-many-lines
+
 import re
 
 import numpy as np

--- a/src/magpylib/_src/style.py
+++ b/src/magpylib/_src/style.py
@@ -17,6 +17,7 @@ from magpylib._src.defaults.defaults_utility import (
     ALLOWED_SYMBOLS,
     SUPPORTED_PLOTTING_BACKENDS,
     get_defaults_dict,
+    magic_to_dict,
     validate_style_keys,
 )
 from magpylib._src.defaults.property_tree import (
@@ -44,6 +45,29 @@ def get_families(obj):
     return getattr(type(obj), "_style_family", ())
 
 
+def _resolved_default_style(style_class, families, default_style):
+    """Return the cached fully-merged default style for a style class.
+
+    All objects of the same class resolve against the same defaults layers,
+    so the merge of family and base sections is computed once and cached on
+    the ``default_style`` node. The cache is invalidated through the node's
+    own change observation, so user mutations of ``magpy.defaults`` take
+    effect immediately.
+    """
+    cache = getattr(default_style, "_resolved_cache", None)
+    if cache is None:
+        cache = {}
+        default_style._resolved_cache = cache
+        default_style.observe(lambda _path, _value: cache.clear())
+    key = (style_class, families)
+    resolved = cache.get(key)
+    if resolved is None:
+        family_layers = [getattr(default_style, fam) for fam in reversed(families)]
+        resolved = style_class().merged(*family_layers, default_style.base)
+        cache[key] = resolved
+    return resolved
+
+
 def get_style(obj, default_settings, **kwargs):
     """Return the resolved style of an object with increasing priority:
 
@@ -59,17 +83,22 @@ def get_style(obj, default_settings, **kwargs):
     )
     style_kwargs = validate_style_keys(style_kwargs)
 
-    # apply object style and kwargs (highest priority)
-    style = obj.style.copy()
+    # apply kwargs onto a copy of the object style (highest priority; an
+    # explicit None kwarg unsets, deferring to the defaults below)
+    obj_style = obj.style.copy()
     style_kwargs_specific = {
-        k: v for k, v in style_kwargs.items() if k.split("_")[0] in style._fields
+        k: v for k, v in style_kwargs.items() if k.split("_")[0] in obj_style._fields
     }
-    style.update(style_kwargs_specific)
+    obj_style.update(style_kwargs_specific)
 
-    # fill unset properties from the defaults layers, most specific first
-    default_style = default_settings.display.style
-    family_layers = [getattr(default_style, fam) for fam in reversed(get_families(obj))]
-    return style.merged(*family_layers, default_style.base)
+    # overlay the explicitly set values onto the cached resolved defaults
+    style = _resolved_default_style(
+        type(obj_style), get_families(obj), default_settings.display.style
+    ).copy()
+    set_values = obj_style.set_values(separator="_")
+    if set_values:
+        style.update(magic_to_dict(set_values))
+    return style
 
 
 # field descriptors specific to style classes ---------------------------

--- a/src/magpylib/_src/style.py
+++ b/src/magpylib/_src/style.py
@@ -24,48 +24,13 @@ ALLOWED_SIZEMODES = ("scaled", "absolute")
 
 
 def get_families(obj):
-    """get obj families"""
-    # pylint: disable=import-outside-toplevel
-    # pylint: disable=possibly-unused-variable
-    # pylint: disable=redefined-outer-name
-    # ruff: noqa: F401
-    from magpylib._src.display.traces_generic import MagpyMarkers as Markers  # noqa: I001, PLC0415
-    from magpylib._src.obj_classes.class_BaseExcitations import BaseCurrent as Current  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_BaseExcitations import BaseMagnet as Magnet  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_current_Circle import Circle  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_current_Polyline import Polyline  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_current_TriangleSheet import TriangleSheet  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_current_TriangleStrip import TriangleStrip  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_magnet_Cuboid import Cuboid  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_magnet_Cylinder import Cylinder  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_magnet_CylinderSegment import CylinderSegment  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_magnet_Sphere import Sphere  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_magnet_Tetrahedron import Tetrahedron  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_magnet_TriangularMesh import TriangularMesh  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_misc_CustomSource import CustomSource  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_misc_Dipole import Dipole  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_misc_Triangle import Triangle  # noqa: PLC0415
-    from magpylib._src.obj_classes.class_Sensor import Sensor  # noqa: PLC0415
+    """Return the style family names of an object, generic first.
 
-    loc = locals()
-    parent_map = {TriangleSheet: "currentsheet", TriangleStrip: "currentsheet"}
-    parent_exclude_map = {
-        TriangleStrip: "current"
-    }  # TriangleStrip is a Current but has not current style
-    obj_families = []
-    for item, val in loc.items():
-        if not item.startswith("_"):
-            try:
-                if isinstance(obj, val):
-                    obj_families.append(item.lower())
-                    if val in parent_map:
-                        obj_families.append(parent_map[val].lower())
-            except TypeError:
-                pass
-    for item, exclude in parent_exclude_map.items():
-        if isinstance(obj, item) and exclude in obj_families:
-            obj_families.remove(exclude)
-    return obj_families
+    Families are declared as a ``_style_family`` class attribute and name the
+    sections of the default style (``magpy.defaults.display.style``) that apply
+    to the object, e.g. ``("magnet", "triangularmesh")`` for a TriangularMesh.
+    """
+    return getattr(type(obj), "_style_family", ())
 
 
 def get_style(obj, default_settings, **kwargs):

--- a/src/magpylib/_src/utility.py
+++ b/src/magpylib/_src/utility.py
@@ -497,23 +497,31 @@ def merge_dicts_with_conflict_check(objs, *, target, identifiers, unique_fields)
 
 @contextmanager
 def style_temp_edit(*objs, styles_temp=None):
-    """Temporary replace style to allow edits before returning to original state"""
+    """Temporarily replace object styles for the duration of a render.
+
+    When a temporary style is provided for an object, rendering reads and
+    mutates that temporary style, so the original ``_style`` instance is
+    untouched and gets restored as-is - preserving its identity (and any
+    change observers bound to it, e.g. a GUI). When no temporary style is
+    provided, rendering mutates the object's own style in place, so a snapshot
+    copy is restored instead.
+    """
     # pylint: disable=protected-access
     styles_temp = {} if styles_temp is None else styles_temp
     orig_styles = {}
     try:
         for obj in objs:
             style_temp = styles_temp.get(obj, None)
-            orig_styles[obj] = getattr(obj, "_style", None)
-            # temporary save original style
-            if orig_styles[obj] is not None:
-                orig_styles[obj] = obj._style.copy()
+            orig = getattr(obj, "_style", None)
             if style_temp is not None:
+                orig_styles[obj] = orig  # untouched during render; restore instance
                 obj._style = style_temp
+            elif orig is not None:
+                orig_styles[obj] = orig.copy()  # mutated in place; restore snapshot
         yield
     finally:
-        for obj in objs:
-            obj._style = orig_styles[obj]
+        for obj, orig in orig_styles.items():
+            obj._style = orig
 
 
 def is_array_like(inp):

--- a/tests/test_default_utils.py
+++ b/tests/test_default_utils.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 
+import numpy as np
 import pytest
 
 from magpylib._src.defaults.defaults_utility import (
@@ -109,6 +110,11 @@ def test_linearize_dict():
         ("rgb(127, 127, 127)", True, "#7f7f7f"),
         ((0, 0, 0, 0), False, "#000000"),
         ((0.1, 0.2, 0.3), False, "#19334c"),
+        ([127, 127, 127], True, "#7f7f7f"),
+        ([0.1, 0.2, 0.3], False, "#19334c"),
+        pytest.param(
+            np.array([0.1, 0.2, 0.3]), False, "#19334c", id="ndarray-uncached"
+        ),
     ]
     + [(shortC, True, longC) for shortC, longC in COLORS_SHORT_TO_LONG.items()],
 )

--- a/tests/test_default_utils.py
+++ b/tests/test_default_utils.py
@@ -1,66 +1,13 @@
-from copy import deepcopy
-
 import numpy as np
 import pytest
 
 from magpylib._src.defaults.defaults_utility import (
     COLORS_SHORT_TO_LONG,
-    MagicProperties,
     color_validator,
     get_defaults_dict,
     linearize_dict,
     magic_to_dict,
-    update_nested_dict,
 )
-
-
-def test_update_nested_dict():
-    """test all argument combinations of update_nested_dicts"""
-    # d gets updated, that's why we deepcopy it
-    d = {"a": 1, "b": {"c": 2, "d": None}, "f": None, "g": {"c": None, "d": 2}, "h": 1}
-    u = {"a": 2, "b": 3, "e": 5, "g": {"c": 7, "d": 5}, "h": {"i": 3}}
-    res = update_nested_dict(
-        deepcopy(d), u, same_keys_only=False, replace_None_only=False
-    )
-    assert res == {
-        "a": 2,
-        "b": 3,
-        "e": 5,
-        "f": None,
-        "g": {"c": 7, "d": 5},
-        "h": {"i": 3},
-    }, "failed updating nested dict"
-    res = update_nested_dict(
-        deepcopy(d), u, same_keys_only=True, replace_None_only=False
-    )
-    assert res == {
-        "a": 2,
-        "b": 3,
-        "f": None,
-        "g": {"c": 7, "d": 5},
-        "h": {"i": 3},
-    }, "failed updating nested dict"
-    res = update_nested_dict(
-        deepcopy(d), u, same_keys_only=True, replace_None_only=True
-    )
-    assert res == {
-        "a": 1,
-        "b": {"c": 2, "d": None},
-        "f": None,
-        "g": {"c": 7, "d": 2},
-        "h": 1,
-    }, "failed updating nested dict"
-    res = update_nested_dict(
-        deepcopy(d), u, same_keys_only=False, replace_None_only=True
-    )
-    assert res == {
-        "a": 1,
-        "b": {"c": 2, "d": None},
-        "f": None,
-        "g": {"c": 7, "d": 2},
-        "e": 5,
-        "h": 1,
-    }, "failed updating nested dict"
 
 
 def test_magic_to_dict():
@@ -143,84 +90,6 @@ def test_bad_colors(color, allow_None, expected_exception):
 
     with pytest.raises(expected_exception):
         color_validator(color, allow_None=allow_None)
-
-
-def test_MagicProperties():
-    """test MagicProperties class"""
-
-    class BPsub1(MagicProperties):
-        "MagicProperties class"
-
-        @property
-        def prop1(self):
-            """prop1"""
-            return self._prop1
-
-        @prop1.setter
-        def prop1(self, val):
-            self._prop1 = val
-
-    class BPsub2(MagicProperties):
-        "MagicProperties class"
-
-        @property
-        def prop2(self):
-            """prop2"""
-            return self._prop2
-
-        @prop2.setter
-        def prop2(self, val):
-            self._prop2 = val
-
-    bp1 = BPsub1(prop1=1)
-
-    # check setting attribute/property
-    assert bp1.prop1 == 1, "bp1.prop1 should be 1"
-    with pytest.raises(AttributeError):
-        bp1.prop1e = "val"  # only properties are allowed to be set
-
-    assert bp1.as_dict() == {"prop1": 1}, "as_dict method failed"
-
-    bp2 = BPsub2(prop2=2)
-    bp1.prop1 = bp2  # assigning class to subproperty
-
-    # check as_dict method
-    assert bp1.as_dict() == {"prop1": {"prop2": 2}}, "as_dict method failed"
-
-    # check update method with different parameters
-    assert bp1.update(prop1_prop2=10).as_dict() == {"prop1": {"prop2": 10}}, (
-        "magic property setting failed"
-    )
-
-    with pytest.raises(AttributeError):
-        bp1.update(prop1_prop2=10, prop3=4)
-    assert bp1.update(prop1_prop2=10, prop3=4, _match_properties=False).as_dict() == {
-        "prop1": {"prop2": 10}
-    }, "magic property setting failed, should ignore 'prop3'"
-
-    assert bp1.update(prop1_prop2=20, _replace_None_only=True).as_dict() == {
-        "prop1": {"prop2": 10}
-    }, "magic property setting failed, prop2 should be remained unchanged 10"
-
-    # check copy method
-
-    bp3 = bp2.copy()
-    assert bp3 is not bp2, "failed copying, should return a different id"
-    assert bp3.as_dict() == bp2.as_dict(), (
-        "failed copying, should return the same property values"
-    )
-
-    # check flatten dict
-    assert bp3.as_dict(flatten=True) == bp2.as_dict(flatten=True), (
-        "failed copying, should return the same property values"
-    )
-
-    # check failing init
-    with pytest.raises(AttributeError):
-        BPsub1(a=0)  # a is not a property in the class
-
-    # check repr
-    assert repr(MagicProperties()) == "MagicProperties()", "repr failed"
 
 
 def test_get_defaults_dict():

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import magpylib as magpy
@@ -6,7 +8,9 @@ from magpylib._src.defaults.defaults_utility import (
     ALLOWED_LINESTYLES,
     ALLOWED_SYMBOLS,
     SUPPORTED_PLOTTING_BACKENDS,
+    get_registered_backends,
 )
+from magpylib._src.display.display import RegisteredBackend
 from magpylib._src.style import DisplayStyle
 
 bad_inputs = {
@@ -246,6 +250,69 @@ def test_bad_default_classes():
         match=r"The style property of Display must be",
     ):
         magpy.defaults.display.style = "wrong input"
+
+
+@pytest.fixture
+def dummy_backend():
+    """Register a do-nothing display backend for the duration of a test."""
+    name = "dummy"
+    RegisteredBackend(
+        name=name,
+        show_func=lambda data, **_kwargs: data,
+        supports_animation=False,
+        supports_subplots=False,
+        supports_colorgradient=False,
+        supports_animation_output=False,
+    )
+    default_backend = magpy.defaults.display.backend
+    try:
+        yield name
+    finally:
+        magpy.defaults.display.backend = default_backend
+        RegisteredBackend.backends.pop(name, None)
+
+
+def test_backend_fields_follow_the_registry(dummy_backend):
+    """Backend fields accept backends registered after import time.
+
+    The allowed set is resolved from `RegisteredBackend.backends` on every
+    use, not frozen when the property tree is declared. Should the registry
+    ever move, `get_registered_backends` must follow it or this fails.
+    """
+    assert dummy_backend in get_registered_backends()
+
+    magpy.defaults.display.backend = dummy_backend
+    assert magpy.defaults.display.backend == dummy_backend
+
+    obj = magpy.magnet.Cuboid(dimension=(1, 1, 1), polarization=(0, 0, 1))
+    obj.style.model3d.add_trace(backend=dummy_backend, constructor="Mesh3d")
+    assert obj.style.model3d.data[0].backend == dummy_backend
+
+    # the generated schema reports the backends registered at generation time
+    enum = magpy.defaults.display.schema()["properties"]["backend"]["enum"]
+    assert dummy_backend in enum
+
+
+def test_registered_backends_falls_back_to_builtins(monkeypatch):
+    """Without the registry imported, the built-in backends are reported.
+
+    `DefaultSettings()` validates `display.backend` while `magpylib` is still
+    importing, before the registry module exists -- importing it from the
+    defaults would be circular.
+    """
+    monkeypatch.delitem(sys.modules, "magpylib._src.display.display")
+    assert get_registered_backends() == SUPPORTED_PLOTTING_BACKENDS
+    assert DefaultSettings().display.backend == "auto"
+
+
+def test_backend_fields_still_reject_unknown_names():
+    """Opening the choice set to the registry does not accept anything."""
+    with pytest.raises(ValueError, match="one of"):
+        magpy.defaults.display.backend = "plotty"
+
+    obj = magpy.magnet.Cuboid(dimension=(1, 1, 1), polarization=(0, 0, 1))
+    with pytest.raises(ValueError, match="one of"):
+        obj.style.model3d.add_trace(backend="plotty", constructor="Mesh3d")
 
 
 def test_bad_deferred_style():

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -76,19 +76,12 @@ bad_inputs = {
 
 def get_bad_test_data():
     """create parametrized bad style test data"""
-    # pylint: disable=possibly-used-before-assignment
-    bad_test_data = []
-    for k, tup in bad_inputs.items():
-        for v in tup:
-            if "description_text" not in k:
-                if "color" in k and "transition" not in k and "mode" not in k:
-                    # color attributes use a the color validator, which raises a ValueError
-                    errortype = ValueError
-                else:
-                    # all other parameters raise AssertionError
-                    errortype = AssertionError
-            bad_test_data.append((k, v, pytest.raises(errortype)))
-    return bad_test_data
+    # all property validators raise ValueError
+    return [
+        (k, v, pytest.raises(ValueError, match=r".*"))
+        for k, tup in bad_inputs.items()
+        for v in tup
+    ]
 
 
 @pytest.mark.parametrize(
@@ -170,7 +163,7 @@ good_inputs = {
         "tip",
     ),  # pivot middle, tail, tip
     "display_style_triangle_orientation_show": (True, False),
-    "display_style_triangle_orientation_size": (True, False),
+    "display_style_triangle_orientation_size": (0, 1),  # float>=0
     "display_style_triangle_orientation_color": ("yellow",),
     "display_style_triangle_orientation_offset": (-1, 0.5, 2),  # float, int
     "display_style_triangle_orientation_symbol": ("cone", "arrow3d"),

--- a/tests/test_display_matplotlib.py
+++ b/tests/test_display_matplotlib.py
@@ -417,19 +417,19 @@ def test_matplotlib_model3d_extra_updatefunc():
         obj.style.model3d.add_trace(updatefunc)
 
     updatefunc = "not callable"
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match=r"Input updatefunc of Trace3d"):
         obj.style.model3d.add_trace(updatefunc=updatefunc)
 
     def updatefunc():
         return "bad output type"
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match=r"Input updatefunc of Trace3d"):
         obj.style.model3d.add_trace(updatefunc=updatefunc)
 
     def updatefunc():
         return {"bad_key": "some_value"}
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match=r"Input updatefunc of Trace3d"):
         obj.style.model3d.add_trace(updatefunc=updatefunc)
 
 

--- a/tests/test_obj_BaseGeo.py
+++ b/tests/test_obj_BaseGeo.py
@@ -705,15 +705,17 @@ def test_describe_with_exclude_None():
         "  • handedness: right",
         "  • pixel: None",
         (
-            "  • style: SensorStyle(arrows=ArrowCS(x=ArrowSingle(color=None, show=True),"
-            " y=ArrowSingle(color=None, show=True), z=ArrowSingle(color=None, show=True)),"
-            " color=None, description=Description(show=None, text=None), label=None,"
-            " legend=Legend(show=None, text=None), model3d=Model3d(data=[], showdefault=True),"
-            " opacity=None, path=Path(frames=None, line=Line(color=None, style=None, width=None),"
-            " marker=Marker(color=None, size=None, symbol=None), numbering=None, show=None),"
-            " pixel=Pixel(color=None, field=PixelField(colormap=None, colorscaling=None, shownull=None,"
-            " sizemin=None, sizescaling=None, source=None, symbol=None), size=1,"
-            " sizemode=None, symbol=None), size=None, sizemode=None)"
+            "  • style: SensorStyle(size=None, sizemode=None,"
+            " pixel=Pixel(size=1, sizemode=None, color=None, symbol=None,"
+            " field=PixelField(source=None, colormap=None, shownull=None, symbol=None,"
+            " sizescaling=None, sizemin=None, colorscaling=None)),"
+            " arrows=ArrowCS(x=ArrowSingle(show=True, color=None),"
+            " y=ArrowSingle(show=True, color=None), z=ArrowSingle(show=True, color=None)),"
+            " label=None, description=Description(text=None, show=None),"
+            " legend=Legend(text=None, show=None), color=None, opacity=None,"
+            " path=Path(show=None, marker=Marker(size=None, color=None, symbol=None),"
+            " line=Line(style=None, color=None, width=None), frames=None, numbering=None),"
+            " model3d=Model3d(showdefault=True, data=()))"
         ),
     ]
     match_string_up_to_id(test, x.describe(exclude=None, return_string=True))

--- a/tests/test_property_tree.py
+++ b/tests/test_property_tree.py
@@ -96,6 +96,24 @@ def test_validation():
     assert style.label == "42"
 
 
+def test_choice_from_callable_resolves_at_call_time():
+    """A Choice built from a callable re-reads its choices on every use."""
+    allowed = ["red"]
+
+    class Dynamic(PropertyNode):
+        color = Choice(lambda: tuple(allowed), doc="Dynamic color.")
+
+    dyn = Dynamic()
+    assert Dynamic.__dict__["color"].choices == ("red",)
+    assert Dynamic.schema()["properties"]["color"]["enum"] == ["red", None]
+    with pytest.raises(ValueError, match="one of"):
+        dyn.color = "green"
+
+    allowed.append("green")
+    dyn.color = "green"  # now allowed, without redefining the class
+    assert Dynamic.schema()["properties"]["color"]["enum"] == ["red", "green", None]
+
+
 def test_unknown_property_raises():
     """The attribute set is frozen: typos raise with available properties."""
     with pytest.raises(AttributeError, match="Available properties"):

--- a/tests/test_property_tree.py
+++ b/tests/test_property_tree.py
@@ -1,0 +1,295 @@
+"""Tests for the declarative typed-property tree (successor of MagicProperties)."""
+
+import json
+
+import pytest
+
+from magpylib._src.defaults.property_tree import (
+    Boolean,
+    Choice,
+    Color,
+    Integer,
+    Nested,
+    Number,
+    Property,
+    PropertyNode,
+    String,
+)
+
+
+class Line(PropertyNode):
+    style = Choice("solid", "dashed", "dotted", doc="Line style.")
+    color = Color(doc="Line color.")
+    width = Number(minimum=0, doc="Line width.")
+
+
+class Marker(PropertyNode):
+    size = Number(minimum=0)
+    symbol = String()
+
+
+class Path(PropertyNode):
+    line = Nested(Line)
+    marker = Nested(Marker)
+    show = Boolean(default=True)
+    frames = Integer(minimum=1)
+
+
+class LabelMixin(PropertyNode):
+    label = String(coerce=True, doc="Object label.")
+
+
+class Style(LabelMixin):
+    path = Nested(Path)
+    opacity = Number(minimum=0, maximum=1)
+
+
+# field registration ---------------------------------------------------
+
+
+def test_fields_registration_and_inheritance():
+    """Fields are collected per class, through multiple inheritance,
+    subclass declarations overriding base ones."""
+    assert list(Line._fields) == ["style", "color", "width"]
+    assert list(Style._fields) == ["label", "path", "opacity"]
+
+    class Special(Style):
+        opacity = Number()  # override without bounds
+
+    assert Special._fields["opacity"].maximum is None
+    assert Style._fields["opacity"].maximum == 1
+
+
+def test_underscore_field_names_are_rejected():
+    """Underscores in field names would break magic underscore notation."""
+    with pytest.raises(ValueError, match="underscore"):
+
+        class Bad(PropertyNode):
+            show_default = Boolean()
+
+
+# validation ------------------------------------------------------------
+
+
+def test_validation():
+    """Each descriptor type validates on assignment with a ValueError."""
+    line = Line()
+    with pytest.raises(ValueError, match="one of"):
+        line.style = "wiggly"
+    with pytest.raises(ValueError, match="number >=0"):
+        line.width = -1
+    with pytest.raises(ValueError, match="color"):
+        line.color = "notacolor"
+    line.color = [0.1, 0.2, 0.3]  # normalized like all validated colors
+    assert line.color == "#19334c"
+
+    path = Path()
+    with pytest.raises(ValueError, match="True or False"):
+        path.show = 1
+    with pytest.raises(ValueError, match="integer"):
+        path.frames = 2.5
+
+    style = Style()
+    with pytest.raises(ValueError, match="<=1"):
+        style.opacity = 2
+    style.label = 42  # coercing string
+    assert style.label == "42"
+
+
+def test_unknown_property_raises():
+    """The attribute set is frozen: typos raise with available properties."""
+    with pytest.raises(AttributeError, match="Available properties"):
+        Line().colour = "red"
+    with pytest.raises(AttributeError, match="Available properties"):
+        Line(colour="red")
+
+
+# set/unset semantics ----------------------------------------------------
+
+
+def test_unset_returns_default_and_none_unsets():
+    """Unset fields report their default; assigning None resets to it."""
+    path = Path()
+    assert path.show is True  # non-None default
+    assert path.frames is None
+    assert not path.is_set("show")
+
+    path.show = False
+    assert path.is_set("show")
+    path.show = None
+    assert path.show is True
+    assert not path.is_set("show")
+
+
+def test_set_values_flat_dict():
+    """set_values returns only explicitly set leaves, as a flat dict."""
+    style = Style(opacity=0.5)
+    style.path.line.width = 2
+    assert style.set_values() == {"opacity": 0.5, "path.line.width": 2}
+    assert style.is_set("path")
+    assert not Style().is_set("path")
+
+
+# dict round-tripping ----------------------------------------------------
+
+
+def test_magic_underscore_init_update_and_as_dict():
+    """Constructor kwargs, update() and dicts support magic underscores."""
+    s1 = Style(path_line_width=2, opacity=0.5)
+    s2 = Style().update({"path": {"line": {"width": 2}}, "opacity": 0.5})
+    assert s1 == s2
+    assert s1.as_dict()["path"]["line"]["width"] == 2
+    assert s1.as_dict(flatten=True)["path.line.width"] == 2
+
+    s1.update(path_line_style="dashed")
+    assert s1.path.line.style == "dashed"
+    assert s1.path.line.width == 2  # update merges, does not reset siblings
+
+    with pytest.raises(AttributeError, match="no property"):
+        s1.update(bananas=5)
+    s1.update(bananas=5, _match_properties=False)  # silently ignored
+
+
+def test_update_replace_none_only():
+    """_replace_None_only fills only unset properties."""
+    style = Style(opacity=0.5)
+    style.update(opacity=0.9, path_show=False, _replace_None_only=True)
+    assert style.opacity == 0.5  # already set, kept
+    assert style.path.show is False  # was unset, filled
+
+
+def test_nested_assignment_replaces():
+    """Assigning a dict or None to a child node replaces it wholesale."""
+    style = Style(path_line_width=2)
+    style.path = {"line": {"style": "dotted"}}
+    assert style.path.line.style == "dotted"
+    assert style.path.line.width is None  # replaced, not merged
+    style.path = None
+    assert style.set_values() == {}
+    with pytest.raises(TypeError, match="instance of Path"):
+        style.path = "bad"
+
+
+def test_copy_is_detached():
+    """Copies are independent of the original and unobserved."""
+    style = Style(path_line_width=2)
+    clone = style.copy()
+    clone.path.line.width = 5
+    assert style.path.line.width == 2
+    assert clone == Style(path_line_width=5)
+    assert clone != style
+
+
+# lazy children -----------------------------------------------------------
+
+
+def test_children_are_lazy():
+    """Child nodes are only instantiated on first access."""
+    style = Style()
+    assert "path" not in style.__dict__
+    _ = style.path
+    assert "path" in style.__dict__
+
+
+# dotted-path access -------------------------------------------------------
+
+
+def test_get_set_by_path():
+    """get/set navigate dotted paths; unknown segments raise."""
+    style = Style()
+    style.set("path.line.width", 3).set("opacity", 0.1)
+    assert style.get("path.line.width") == 3
+    assert style.get("path.line") is style.path.line
+    with pytest.raises(AttributeError):
+        style.get("path.nope")
+    with pytest.raises(ValueError, match=">=0"):
+        style.set("path.line.width", -1)
+
+
+# layered resolution --------------------------------------------------------
+
+
+def test_merged_first_set_wins():
+    """merged() fills unset values from layers, earlier layers first."""
+    obj = Style(opacity=0.5)
+    family = Style(opacity=0.9, path_line_width=2, label="family")
+    base = Style(path_line_width=7, path_line_style="dashed")
+
+    resolved = obj.merged(family, base)
+    assert resolved.opacity == 0.5  # self wins
+    assert resolved.path.line.width == 2  # first layer wins
+    assert resolved.path.line.style == "dashed"  # second layer fills the rest
+    assert resolved.label == "family"
+    # inputs are untouched
+    assert obj.set_values() == {"opacity": 0.5}
+    assert base.path.line.width == 7
+
+
+# observation ---------------------------------------------------------------
+
+
+def test_observe_bubbles_with_dotted_path():
+    """Observers receive dotted paths relative to the observed node, for
+    both direct and nested changes, including on lazily created children."""
+    style = Style()
+    events = []
+    style.observe(lambda path, value: events.append((path, value)))
+
+    style.opacity = 0.5
+    style.path.line.width = 2  # path/line created lazily after observe()
+    style.set("path.line.width", None)
+    assert events == [
+        ("opacity", 0.5),
+        ("path.line.width", 2),
+        ("path.line.width", None),
+    ]
+
+    # observer on a subnode sees subtree changes only, with relative paths
+    sub_events = []
+    callback = lambda path, _: sub_events.append(path)  # noqa: E731
+    style.path.observe(callback)
+    style.path.line.style = "dotted"
+    style.label = "x"
+    assert sub_events == ["line.style"]
+
+    style.path.unobserve(callback)
+    style.path.line.style = "dashed"
+    assert sub_events == ["line.style"]
+
+
+def test_unobserved_sets_have_no_bookkeeping():
+    """Without observers, assignments leave no observation state behind."""
+    style = Style(path_line_width=2)
+    assert style._observed is False
+    assert style.path._observed is False
+
+
+# schema ---------------------------------------------------------------------
+
+
+def test_schema():
+    """schema() describes the tree as JSON-serializable JSON Schema."""
+    schema = Style.schema()
+    props = schema["properties"]
+    assert schema["additionalProperties"] is False
+    assert props["opacity"] == {"type": ["number", "null"], "minimum": 0, "maximum": 1}
+    assert props["label"]["description"] == "Object label."
+    line = props["path"]["properties"]["line"]["properties"]
+    assert line["style"]["enum"] == ["solid", "dashed", "dotted", None]
+    assert line["color"]["format"] == "color"
+    assert props["path"]["properties"]["show"]["default"] is True
+    json.dumps(schema)  # JSON-serializable
+
+
+# base Property ---------------------------------------------------------------
+
+
+def test_plain_property_accepts_anything():
+    """The untyped base Property performs no validation."""
+
+    class Free(PropertyNode):
+        anything = Property(doc="No validation.")
+
+    free = Free(anything=object)
+    assert free.anything is object
+    assert Free.schema()["properties"]["anything"] == {"description": "No validation."}

--- a/tests/test_style_resolution.py
+++ b/tests/test_style_resolution.py
@@ -230,3 +230,23 @@ def test_e2e_mutated_base_default_reaches_figure():
     magpy.defaults.display.style.base.color = "black"
     fig = magpy.show(make_cuboid(), **SHOW_KW)
     assert fig.data[0].color == "black"
+
+
+def test_show_preserves_style_instance_and_observers():
+    """show() must not swap out the object's style instance or drop change
+    observers bound to it - GUIs and other tools hold references across
+    renders. (Rendering temporarily replaces the style internally, but the
+    original instance is restored as-is.)"""
+    cuboid = make_cuboid()
+    cuboid.style.magnetization.mode = "arrow"
+    style_before = cuboid.style
+    events = []
+    cuboid.style.observe(lambda path, value: events.append((path, value)))
+
+    magpy.show(cuboid, **SHOW_KW)
+
+    assert cuboid.style is style_before  # same instance, not a restored copy
+    assert cuboid.style.magnetization.mode == "arrow"  # user value intact
+    # the observer bound before the render still fires afterwards
+    cuboid.style.opacity = 0.5
+    assert events == [("opacity", 0.5)]

--- a/tests/test_style_resolution.py
+++ b/tests/test_style_resolution.py
@@ -177,6 +177,25 @@ def test_get_style_does_not_mutate_inputs():
     assert magpy.defaults.display.style.as_dict() == defaults_before
 
 
+def test_resolution_cache_invalidation_and_isolation():
+    """The cached defaults layer must refresh on magpy.defaults mutations and
+    every resolved style must be an independent copy of the cache entry."""
+    cuboid = make_cuboid()
+    assert get_style(cuboid, default_settings).magnetization.show is True
+    # mutation after a cache-priming resolution must take effect
+    magpy.defaults.display.style.magnet.magnetization.show = False
+    assert get_style(cuboid, default_settings).magnetization.show is False
+
+    # resolved styles are detached copies, not shared cache objects
+    first = get_style(cuboid, default_settings)
+    first.magnetization.arrow.width = 99
+    second = get_style(cuboid, default_settings)
+    assert second.magnetization.arrow.width != 99
+    # mutable leaves (model3d traces) are not shared with the object style
+    second.model3d.add_trace({"constructor": "Mesh3d"})
+    assert cuboid.style.model3d.data == ()
+
+
 # ------------------------------------------------------------------
 # end-to-end: resolved styles must reach the rendered figure
 # ------------------------------------------------------------------

--- a/tests/test_style_resolution.py
+++ b/tests/test_style_resolution.py
@@ -1,0 +1,213 @@
+"""Characterization tests for display style resolution.
+
+Pins the precedence chain implemented by ``magpylib._src.style.get_style``:
+
+    show() kwargs  >  obj.style  >  family defaults  >  base defaults  >  hardcoded
+
+where family/base defaults live on ``magpy.defaults.display.style`` and an
+explicitly set ``None`` on the object defers to the next layer down. Any
+refactor of the style internals must keep this suite green.
+"""
+
+import pytest
+
+import magpylib as magpy
+from magpylib._src.defaults.defaults_classes import default_settings
+from magpylib._src.style import CurrentStyle, MagnetStyle, SensorStyle, get_style
+
+
+@pytest.fixture(autouse=True)
+def _reset_defaults():
+    """Isolate each test from magpy.defaults mutations."""
+    magpy.defaults.reset()
+    yield
+    magpy.defaults.reset()
+
+
+def make_cuboid(**kwargs):
+    """Return a simple magnet object of the 'magnet' style family."""
+    return magpy.magnet.Cuboid(polarization=(0, 0, 1), dimension=(1, 1, 1), **kwargs)
+
+
+# ------------------------------------------------------------------
+# unit level: get_style
+# ------------------------------------------------------------------
+
+
+def test_magpy_defaults_is_default_settings():
+    """The display machinery resolves against the same instance exposed as
+    magpy.defaults, so user mutations of magpy.defaults must affect show()."""
+    assert magpy.defaults is default_settings
+
+
+def test_hardcoded_defaults_resolution():
+    """Untouched objects resolve to the hardcoded base + family defaults and
+    to the family-specific style class."""
+    style = get_style(make_cuboid(), default_settings)
+    assert isinstance(style, MagnetStyle)
+    # base defaults
+    assert style.opacity == 1
+    assert style.path.line.width == 1
+    assert style.path.marker.size == 3
+    assert style.color is None  # colorsequence is applied later, not here
+    # magnet family defaults
+    assert style.magnetization.show is True
+    assert style.magnetization.arrow.offset == 1
+    # color validation lowercases hex values ("#E71111" in DEFAULTS)
+    assert style.magnetization.color.north == "#e71111"
+
+    style = get_style(magpy.current.Circle(current=1, diameter=1), default_settings)
+    assert isinstance(style, CurrentStyle)
+    # current family defaults
+    assert style.arrow.offset == 0.5
+    assert style.line.width == 2
+
+
+def test_family_default_mutation_applies():
+    """A mutated family default wins over the hardcoded value, only for
+    objects of that family, without touching the objects themselves."""
+    magpy.defaults.display.style.magnet.magnetization.show = False
+    cuboid = make_cuboid()
+    assert get_style(cuboid, default_settings).magnetization.show is False
+    # the object style itself remains unset
+    assert cuboid.style.magnetization.show is None
+    # other families are unaffected
+    sensor_style = get_style(magpy.Sensor(), default_settings)
+    assert isinstance(sensor_style, SensorStyle)
+    assert sensor_style.size == 1
+
+
+def test_base_default_mutation_applies():
+    """A mutated base default applies to all object families."""
+    magpy.defaults.display.style.base.color = "black"
+    assert get_style(make_cuboid(), default_settings).color == "black"
+    assert get_style(magpy.Sensor(), default_settings).color == "black"
+
+
+def test_object_style_overrides_defaults():
+    """Values set on obj.style win over family and base defaults."""
+    cuboid = make_cuboid()
+    cuboid.style.magnetization.show = False  # family default is True
+    cuboid.style.opacity = 0.5  # base default is 1
+    style = get_style(cuboid, default_settings)
+    assert style.magnetization.show is False
+    assert style.opacity == 0.5
+
+
+def test_show_kwargs_override_object_style():
+    """style_* kwargs (as passed through show()) win over obj.style."""
+    cuboid = make_cuboid()
+    cuboid.style.magnetization.show = False
+    cuboid.style.color = "blue"
+    style = get_style(
+        cuboid, default_settings, style_magnetization_show=True, style_color="red"
+    )
+    assert style.magnetization.show is True
+    assert style.color == "red"
+
+
+def test_explicit_none_defers_to_defaults():
+    """An explicit None on obj.style falls through to the defaults layer,
+    whatever that layer currently holds."""
+    cuboid = make_cuboid()
+    cuboid.style.magnetization.show = None
+    cuboid.style.opacity = None
+    style = get_style(cuboid, default_settings)
+    assert style.magnetization.show is True  # hardcoded family default
+    assert style.opacity == 1  # hardcoded base default
+
+    magpy.defaults.display.style.magnet.magnetization.show = False
+    assert get_style(cuboid, default_settings).magnetization.show is False
+
+
+def test_style_dict_equals_underscore_kwargs():
+    """The style dict form and the magic underscore form resolve identically."""
+    cuboid = make_cuboid()
+    from_dict = get_style(
+        cuboid, default_settings, style={"magnetization": {"show": False}}
+    )
+    from_kwargs = get_style(cuboid, default_settings, style_magnetization_show=False)
+    assert from_dict.as_dict() == from_kwargs.as_dict()
+
+
+def test_constructor_kwarg_equals_attribute_set():
+    """Styles set via constructor kwarg, style dict, or attribute assignment
+    resolve identically."""
+    via_kwarg = make_cuboid(style_label="mag1")
+    via_dict = make_cuboid(style={"label": "mag1"})
+    via_attr = make_cuboid()
+    via_attr.style.label = "mag1"
+    dicts = [
+        get_style(obj, default_settings).as_dict()
+        for obj in (via_kwarg, via_dict, via_attr)
+    ]
+    assert dicts[0]["label"] == "mag1"
+    assert dicts[0] == dicts[1] == dicts[2]
+
+
+def test_foreign_family_key_silently_filtered():
+    """A style key valid for another family (magnetization on a Sensor) is
+    filtered out without error and without corrupting resolution."""
+    style = get_style(magpy.Sensor(), default_settings, style_magnetization_show=False)
+    assert isinstance(style, SensorStyle)
+    assert "magnetization" not in style.as_dict()
+
+
+def test_invalid_style_key_raises():
+    """A style key unknown to every family raises a ValueError."""
+    with pytest.raises(ValueError, match="invalid"):
+        get_style(make_cuboid(), default_settings, style_bananas=5)
+
+
+def test_get_style_does_not_mutate_inputs():
+    """Resolution must be pure: neither obj.style nor magpy.defaults may be
+    modified by a get_style call with overriding kwargs."""
+    cuboid = make_cuboid()
+    cuboid.style.magnetization.show = False
+    obj_before = cuboid.style.as_dict()
+    defaults_before = magpy.defaults.display.style.as_dict()
+    get_style(
+        cuboid,
+        default_settings,
+        style_color="red",
+        style_opacity=0.1,
+        style_magnetization_show=True,
+    )
+    assert cuboid.style.as_dict() == obj_before
+    assert magpy.defaults.display.style.as_dict() == defaults_before
+
+
+# ------------------------------------------------------------------
+# end-to-end: resolved styles must reach the rendered figure
+# ------------------------------------------------------------------
+
+SHOW_KW = {"backend": "plotly", "return_fig": True, "style_magnetization_show": False}
+
+
+def test_e2e_show_kwarg_beats_object_style():
+    """show() style kwarg wins over obj.style in the rendered trace."""
+    cuboid = make_cuboid()
+    cuboid.style.color = "blue"
+    fig = magpy.show(cuboid, **SHOW_KW, style_color="red")
+    assert fig.data[0].color == "red"
+
+
+def test_e2e_object_style_reaches_figure():
+    """obj.style values survive into the rendered trace; unset color falls
+    back to the first colorsequence entry."""
+    cuboid = make_cuboid()
+    cuboid.style.opacity = 0.3
+    cuboid.style.label = "MyMag"
+    fig = magpy.show(cuboid, **SHOW_KW)
+    assert fig.data[0].opacity == 0.3
+    assert fig.data[0].name.startswith("MyMag")
+    first_cycle_color = magpy.defaults.display.colorsequence[0].lower()
+    assert fig.data[0].color == first_cycle_color
+
+
+def test_e2e_mutated_base_default_reaches_figure():
+    """A mutated base default color reaches the trace instead of the
+    colorsequence fallback."""
+    magpy.defaults.display.style.base.color = "black"
+    fig = magpy.show(make_cuboid(), **SHOW_KW)
+    assert fig.data[0].color == "black"


### PR DESCRIPTION
> [!NOTE]
> **Rebased onto `main` and unstacked from #916 (2026-08-04).** This PR previously targeted `feat/extend-paths-to-properties`; it now stands alone. The style rewrite turned out not to depend on #916 at all — the diff against `main` is identical to the diff that was against #916 (20 files, +2494/−3198), and the full suite passes on `main` without it. Rebasing required only dropping #916's `_path_properties` declarations from three classes, which don't exist on `main`.
>
> **If you had this branch checked out, it was force-pushed — reset rather than merge.**

## Motivation

The style system's *usage* (`obj.style.magnetization.show`, magic underscore kwargs, `None` defers to defaults) is good — its *internals* were not:

- every field was written three times: a hand-written property+setter in `style.py` (~2600 lines), a parallel nested dict in `defaults_values.py`, and the numpydoc docstring;
- validation used `assert`, which silently disappears under `python -O`;
- introspection was `dir()`-scanning on every `as_dict`/`update`/`repr` call;
- style resolution deep-copied and re-merged nested dicts per object per `show()` — **455 µs/object**, the dominant cost of scene assembly;
- there was no machine-readable schema or change notification, making it hard for third-party libraries to build GUIs on top.

## What this does

**Declarative typed-property tree** (`property_tree.py`, ~500 lines): each field is declared once as a typed descriptor and generically gains validation on assignment, magic underscore updates, dict round-tripping, lazy child creation, and a public introspection contract:

```python
class Line(PropertyNode):
    style = Choice(*ALLOWED_LINESTYLES, doc="Line style.")
    color = Color(doc="Line color.")
    width = Number(minimum=0, doc="Positive number that defines the line width.")
```

The public contract for GUIs / third-party tooling is four primitives on every node:

| Primitive | Purpose |
|---|---|
| `schema()` | JSON-Schema description of the field tree (enums, bounds, defaults, docs) |
| `get(path)` / `set(path, value)` | dotted-path access, e.g. `"magnetization.arrow.width"` |
| `observe(cb)` | change events bubble to any ancestor with the dotted leaf path; zero overhead when unobserved |
| `is_set` / `set_values` / `merged()` | set-vs-inherited introspection and first-set-wins layered resolution |

**Port of all style & defaults classes** onto this system (2600+ lines → ~1100), public API preserved: class names, nested attribute access, magic underscore kwargs, dict assignment, string coercion for `label`/`description`/`legend`, `Model3d.add_trace`, deprecated `magnetization.size` alias. `MagicProperties` and its helpers are deleted.

**Backend fields resolve against the registry, not a frozen tuple.** `Choice` also accepts a zero-argument callable for its allowed values, re-evaluated on every `validate()` and `schema()`. The two backend fields — `magpy.defaults.display.backend` and `style.model3d.data[].backend` — use it to read `RegisteredBackend.backends` at call time.

This is here to avoid *narrowing* behaviour. On `main` both sites are runtime `assert`s against `SUPPORTED_PLOTTING_BACKENDS`, re-evaluated per call; turning them into ordinary descriptor enums would freeze the allowed set at import time and make a backend registered afterwards permanently unacceptable. Third-party backends still aren't usable end to end (`check_format_input_backend` gates on the same tuple) — this only ensures the property tree isn't the thing standing in the way when that gate is opened.

Two notes for reviewers:

- `get_registered_backends()` reads the registry out of `sys.modules` rather than importing it. `defaults_classes.py` instantiates `DefaultSettings()` at import time, which validates `display.backend`, and `traces_generic.py` imports `default_settings` at module level — so importing the registry from the defaults is circular. The lookup is exact rather than approximate: registering a backend requires importing the registry, so while that module is absent the registered set *is* the built-in set.
- `schema()` now emits a **dynamic** `enum` for these two fields, so a generated JSON schema describes the backends registered at generation time. Relevant to anything generating schema files for GUI widgets.

**Fixes along the way**: `color_validator` crashed with `TypeError: unhashable type` on the documented list form (lru_cache applied before normalization); `get_families()` imported 17 classes and isinstance-scanned `locals()` per call — replaced with a `_style_family` class attribute verified equivalent for all 16 object types.

## Performance

A/B benchmarks against the pre-refactor commit (same venv, best of 5):

| Operation | Before | After |
|---|---|---|
| `show()` 50 objects (plotly) | 34.4 ms | **11.1 ms** |
| `show()` 8000 cuboids (plotly) | ~5 s | **~1.0 s** |
| `get_style()` per object | 455 µs | **8 µs** |
| style class instantiation | 65 µs | < 0.1 µs |
| `as_dict()` | 46 µs | 4.3 µs |
| object creation | unchanged | unchanged |

The final `get_style` number comes from caching the fully merged default style per style class on the `DisplayStyle` node, invalidated through the node's own change observation — the observer contract's first internal consumer.

Style resolution was the dominant cost of `show()` scene assembly; trace building now is.

## Verification

- **Characterization suite first** (`test_style_resolution.py`, first commit): pins the full resolution precedence chain (show kwargs > obj.style > family defaults > base defaults > hardcoded), `None`-defers semantics, input-form equivalence, family scoping, purity, and end-to-end hand-off into plotly figures. It stayed green through the entire port.
- **Seeded defaults tree diffed value-identical** against the old implementation for all ~200 defaults (old module loaded from git, flattened dicts compared).
- Full suite on `main`: 1213 passed; nox lint/pylint (10.00/10)/tests all green.

## Behavior changes (intentional)

- Validation errors are proper `ValueError`s instead of `assert` statements; test expectations updated.
- Booleans are no longer accepted by number-valued properties (`bool` is an `int` subclass; the old asserts let `size=True` through).
- Assigning `None` to always-set fields (e.g. `model3d.showdefault`) now resets to the default instead of raising.
- `as_dict()` no longer includes the deprecated `magnetization.size` alias key (still readable/writable as an attribute).

## Design note

`defaults_values.py` deliberately stays: family default values cannot live as descriptor defaults because node classes (e.g. `Magnetization`) are shared across families while object styles must report `None` when unset. The dict is now the single seeding source rather than a duplicate of the class tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
