### PR TITLE
ci: ignore vtk numpy 2.5 shape deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,9 @@ addopts = ["-ra", "--showlocals"]
 strict = true
 filterwarnings = [
   "error",
+  # vtk's numpy_support is not NumPy 2.5 compatible (uses `arr.shape = ...`);
+  # remove once VTK ships a fix (surfaces through pyvista)
+  "ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning",
 ]
 log_level = "INFO"
 testpaths = [


### PR DESCRIPTION
## What

Adds one message-targeted entry to the pytest `filterwarnings` config, suppressing:

```
DeprecationWarning: Setting the shape on a NumPy array has been deprecated in NumPy 2.5.
```

## Why

NumPy 2.5 deprecated in-place shape assignment (`arr.shape = ...`). VTK's `vtkmodules/util/numpy_support.py` still uses it, and the warning surfaces through pyvista. With `filterwarnings = ["error"]`, **every test touching pyvista/VTK fails** (22 failures + 3 teardown errors) in any environment that resolves `numpy>=2.5.0` — e.g. the fresh venv built by `nox -s tests` since numpy 2.5.1 released.

## Why this fix

- The offending code is VTK's, not magpylib's — nothing actionable here beyond suppression.
- pyvista carries the [identical filter](https://github.com/pyvista/pyvista/blob/main/pyproject.toml) in its own test config.
- A `numpy<2.5` pin was deliberately **not** added: the full magpylib suite passes on numpy 2.5.1 apart from this warning (1174 green), and a pin would stop CI from testing what users actually install.
- The message-targeted ignore keeps warnings-as-errors intact for everything else and self-retires once VTK ships a fix (no VTK merge request addressing it exists yet; they fixed comparable numpy deprecations in [MR 4847](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/4847) and [MR 11238](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/11238)).

## Verification

In a numpy 2.5.1 / pyvista 0.48.4 environment: the 31 previously failing pyvista/TriangularMesh tests pass, full suite 1174 passed (the `Renderer.__del__` unraisable-exception errors were fallout of the same warning and are cleared too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
