### PR TITLE
Let an entry-point backend import the module it subclasses from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,10 @@
   ship it in a package through the `magpylib.backends` entry-point group, where
   `pip install` is enough to make it available. A registered name is then
   accepted everywhere a built-in one is: `show(backend=...)`,
-  `magpy.defaults.display.backend` and `style.model3d.data[].backend`.
+  `magpy.defaults.display.backend` and `style.model3d.data[].backend`. Entry
+  points are resolved on the first backend-name lookup after `import magpylib`
+  returns, rather than during the import itself, so importing magpylib no longer
+  loads the backends installed alongside it.
 - `show()` now hands a backend a single typed `Scene` — panels, frames,
   animation settings, canvas and leftover options — rather than seven loose
   arguments. Traces stay plain dicts in Magpylib's own dialect, so the envelope

--- a/docs/_pages/user_guide/docs/docs_graphics_backends.md
+++ b/docs/_pages/user_guide/docs/docs_graphics_backends.md
@@ -47,7 +47,7 @@ Declaring the class registers it. A backend shipped in a package should instead 
 counter = "my_package:CounterBackend"
 ```
 
-Entry points are resolved lazily, the first time a backend name is looked up. For a backend defined in a script or notebook, `magpy.register_backend(name, show_func, ...)` is the imperative equivalent.
+Entry points are resolved lazily, the first time a backend name is looked up after `import magpylib` has returned — so magpylib is fully imported before your module runs, and `from magpylib.graphics.backend import DisplayBackend` at module scope is safe. An entry point may name the class or the module that defines it; if loading it registers no backend, magpylib says so rather than leaving the name quietly missing. For a backend defined in a script or notebook, `magpy.register_backend(name, show_func, ...)` is the imperative equivalent.
 
 ## What `show` receives
 

--- a/src/magpylib/__init__.py
+++ b/src/magpylib/__init__.py
@@ -8,6 +8,7 @@ from scipy.constants import mu_0
 from magpylib import core, current, func, graphics, magnet, misc
 from magpylib._src.defaults.defaults_classes import default_settings as defaults
 from magpylib._src.defaults.defaults_utility import SUPPORTED_PLOTTING_BACKENDS
+from magpylib._src.display import api as _display_api
 from magpylib._src.display.backend_registry import register_backend
 from magpylib._src.display.display import show, show_context
 from magpylib._src.fields import getB, getFT, getH, getJ, getM
@@ -38,3 +39,9 @@ __all__ = [
     "show",
     "show_context",
 ]
+
+# Everything a third-party backend might import from magpylib is in place now,
+# so entry points may be resolved. They still are not, until something asks
+# about a backend name -- this only lifts the bar that kept the first such
+# lookup, which happens during this import, from resolving them too early.
+_display_api.DisplayBackend._importing = False

--- a/src/magpylib/_src/display/api.py
+++ b/src/magpylib/_src/display/api.py
@@ -234,6 +234,16 @@ class DisplayBackend:
 
     _discovered: ClassVar[bool] = False
 
+    #: Cleared at the end of ``magpylib/__init__.py``. Until then no entry
+    #: point may be loaded: loading one runs third-party code that imports
+    #: magpylib back, and the module it is told to subclass from --
+    #: ``magpylib.graphics.backend`` -- cannot be imported while this package
+    #: is still executing. Its parent's ``__init__`` pulls the style and
+    #: display stack, which comes back round to ``default_settings`` before
+    #: that name is bound, so the backend fails to load with a circular-import
+    #: error and never registers.
+    _importing: ClassVar[bool] = True
+
     def __init_subclass__(cls, **kwargs):
         """Register any subclass that names itself."""
         super().__init_subclass__(**kwargs)
@@ -244,18 +254,28 @@ class DisplayBackend:
     def discover(cls):
         """Load backends advertised by installed packages, once.
 
-        Resolved on the first backend-name lookup and cached, rather than at
-        every lookup. In practice that first lookup happens while magpylib is
-        imported, when the defaults tree validates its own default backend, so
-        the scan does contribute to import time (a few ms, growing with the
-        number of installed distributions).
+        Resolved on the first backend-name lookup after magpylib has finished
+        importing, and cached. A lookup during the import -- the defaults tree
+        validating its own default backend is one -- is not the first lookup
+        for this purpose: it is answered from the built-ins alone, and the scan
+        waits. Otherwise a third-party backend would be imported into a
+        half-built magpylib and fail (see `_importing`).
+
+        Deferring it also keeps the scan (a few ms, growing with the number of
+        installed distributions) off the import path entirely, for a program
+        that imports magpylib without ever drawing anything.
         """
-        if cls._discovered:
+        if cls._discovered or DisplayBackend._importing:
             return
         # set on the base, not on cls: discovering through a subclass must
         # still mark it done globally, or the base would rediscover later
         DisplayBackend._discovered = True
         for entry in entry_points(group=ENTRY_POINT_GROUP):
+            # what this entry finds registered before it runs. Importing the
+            # module its value names is itself what registers a backend, via
+            # __init_subclass__, so "did this entry give us anything" cannot be
+            # answered by looking at `loaded` alone.
+            known = set(cls.backends)
             try:
                 loaded = entry.load()
             except Exception as err:  # noqa: BLE001  # pylint: disable=broad-exception-caught
@@ -272,6 +292,24 @@ class DisplayBackend:
                 key = loaded.name or entry.name
                 if key not in cls.backends:
                     cls.backends[key] = loaded()
+            elif entry.name not in cls.backends and set(cls.backends) == known:
+                # A module or an instance is a legitimate thing for an entry
+                # point to name -- importing it defines the subclass, which
+                # registers itself -- so what is reported is the absence of a
+                # backend, not the shape of what was loaded. Both tests apply:
+                # the name may already be there because the module was
+                # imported earlier, in which case nothing appeared here either.
+                # Silence is the failure worth naming: a package whose class
+                # comes out None on the magpylib it found looks installed and
+                # does nothing.
+                what = getattr(loaded, "__name__", None) or repr(loaded)
+                warnings.warn(
+                    f"Display backend {entry.name!r} advertised by "
+                    f"{entry.value!r} registered no backend ({what}); it is "
+                    "ignored. An entry point should name a DisplayBackend "
+                    "subclass, or a module that defines one.",
+                    stacklevel=2,
+                )
 
     @property
     def supports(self) -> dict[str, bool]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,15 @@ import pytest
 import magpylib as magpy
 from magpylib._src.display.api import DisplayBackend
 
+# Resolve entry-point backends here, before anything is snapshotted. They are
+# discovered on the first backend-name lookup, which is now inside whichever
+# test happens to look one up first -- after the fixture below has taken its
+# snapshot, so teardown would evict a backend that a plugin installed in this
+# environment provides, and discovery runs once so it would never come back.
+# Doing it at collection also keeps a plugin's load warning out of a test,
+# where `filterwarnings = ["error"]` would fail whichever one ran first.
+DisplayBackend.discover()
+
 
 @pytest.fixture(autouse=True)
 def _restore_display_backends():

--- a/tests/test_display_registry.py
+++ b/tests/test_display_registry.py
@@ -1,5 +1,8 @@
 """Tests for the display-backend registry."""
 
+import subprocess
+import sys
+import types
 import warnings
 
 import numpy as np
@@ -657,3 +660,144 @@ def test_units_length_default_scales_what_the_backend_receives():
     assert extent() == 1000.0
 
     assert extent(units_length="km") == 0.001
+
+
+def test_discovery_waits_until_the_import_has_finished(monkeypatch):
+    """A lookup during `import magpylib` must not resolve entry points.
+
+    The defaults tree validates its own default backend while this package is
+    still executing, and that is a backend-name lookup. Resolving entry points
+    there loads third-party code into a half-built magpylib: the module a
+    backend is told to subclass from -- `magpylib.graphics.backend` -- imports
+    the style and display stack, which comes back round to `default_settings`
+    before that name is bound. Every backend shipped the documented way failed
+    with a circular import, and none of them registered.
+    """
+    calls = []
+    monkeypatch.setattr(
+        "magpylib._src.display.api.entry_points",
+        lambda *, group: calls.append(group) or [],
+        raising=True,
+    )
+    monkeypatch.setattr(DisplayBackend, "_discovered", False, raising=False)
+    monkeypatch.setattr(DisplayBackend, "_importing", True, raising=False)
+
+    DisplayBackend.discover()
+
+    assert calls == [], "no entry point may be loaded while magpylib imports"
+    assert not DisplayBackend._discovered, "the scan must still be pending"
+
+    monkeypatch.setattr(DisplayBackend, "_importing", False, raising=False)
+    DisplayBackend.discover()
+
+    assert calls == ["magpylib.backends"], "and run on the first lookup after"
+
+
+def test_importing_magpylib_resolves_no_entry_points():
+    """End to end, in an interpreter that has only just imported magpylib.
+
+    In-process this cannot be observed -- by the time a test runs, something
+    has looked a backend name up -- so it is asked of a fresh one.
+    """
+    code = (
+        "import magpylib\n"
+        "from magpylib._src.display.api import DisplayBackend\n"
+        "print(DisplayBackend._discovered, DisplayBackend._importing)\n"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.split() == ["False", "False"], out.stderr
+
+
+def test_an_entry_point_that_is_not_a_backend_warns(monkeypatch):
+    """Silence here is the worst outcome: the name advertised simply is not
+    there, and the package looks installed and inert."""
+
+    class NotABackend:
+        name = "impostor"
+        value = "somewhere:Thing"
+
+        def load(self):
+            return None
+
+    monkeypatch.setattr(
+        "magpylib._src.display.api.entry_points",
+        lambda *, group: [NotABackend()],  # noqa: ARG005
+        raising=True,
+    )
+    monkeypatch.setattr(DisplayBackend, "_discovered", False, raising=False)
+
+    with pytest.warns(UserWarning, match="registered no backend"):
+        DisplayBackend.discover()
+
+    assert "impostor" not in DisplayBackend.backends
+
+
+def test_an_entry_point_naming_a_module_is_not_reported_as_broken(monkeypatch):
+    """Importing the module is what registers the backend, so nothing is wrong.
+
+    The entry-point value may name the class or the module defining it. In the
+    second case `load()` returns a module, and the backend is already in the
+    registry by then -- reporting that as "not a DisplayBackend" would call a
+    working install broken, and under `-W error` would break it.
+    """
+    module = types.ModuleType("fake_backend_package")
+
+    class ModuleBackend(DisplayBackend):
+        name = "from_a_module"
+
+        def show(self, scene):
+            return scene
+
+    module.ModuleBackend = ModuleBackend
+
+    class Entry:
+        name = "from_a_module"
+        value = "fake_backend_package"
+
+        def load(self):
+            return module
+
+    monkeypatch.setattr(
+        "magpylib._src.display.api.entry_points",
+        lambda *, group: [Entry()],  # noqa: ARG005
+        raising=True,
+    )
+    monkeypatch.setattr(DisplayBackend, "_discovered", False, raising=False)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        DisplayBackend.discover()
+
+    assert "from_a_module" in DisplayBackend.backends
+
+
+def test_the_report_names_the_object_it_got(monkeypatch):
+    """`type(loaded).__name__` is the metaclass for a class -- "type", which
+    tells the author nothing about what magpylib actually found."""
+
+    class Plain:
+        pass
+
+    class Entry:
+        name = "plain"
+        value = "somewhere:Plain"
+
+        def load(self):
+            return Plain
+
+    monkeypatch.setattr(
+        "magpylib._src.display.api.entry_points",
+        lambda *, group: [Entry()],  # noqa: ARG005
+        raising=True,
+    )
+    monkeypatch.setattr(DisplayBackend, "_discovered", False, raising=False)
+
+    with pytest.warns(UserWarning, match="Plain"):
+        DisplayBackend.discover()


### PR DESCRIPTION
A backend advertised through the `magpylib.backends` entry point never
registers: it cannot import `magpylib.graphics.backend`, the module
`graphics/backend.py` tells it to subclass from.

`discover()` runs while magpylib is still importing — the defaults tree
validating its own default backend is a backend-name lookup — so the entry
point is loaded into a half-built magpylib, and `magpylib.graphics.__init__`
comes back round to `default_settings` before that name is bound:

```
UserWarning: Could not load display backend 'demo' advertised by
'demo_backend:DemoBackend': ImportError: cannot import name 'default_settings'
from partially initialized module 'magpylib._src.defaults.defaults_classes'
```

Discovery now waits for the import to finish and runs on the first lookup
after, which is what `test_entry_point_discovery_is_lazy_and_runs_once` already
claimed happened. A lookup during the import is answered from the built-ins —
all it has ever needed there, since the default being validated is magpylib's
own `"auto"`. Third-party backends leave the import path entirely as a result.

Also here: an entry point that loads to something that is not a
`DisplayBackend` subclass is reported rather than skipped in silence. That is
the failure that hid this one.

Three tests, including one asked of a fresh interpreter. Full suite passes.

Found writing a backend for magpylib-studio, which is on the private
`magpylib._src.display.api` import today because of this.
