### PR TITLE
Check the built package with a Twine that can read it

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      # Pinned to a full version on purpose: v3 stopped force-tagging `@v3`
+      # and `@v3.0`, so there is no moving tag to follow. Dependabot bumps it.
+      # It has to be v3 at least -- v2 pins Twine 6.2, which rejects the
+      # Metadata-Version 2.5 that hatchling now writes, failing every build.
+      - uses: hynek/build-and-inspect-python-package@v3.0.1
 
   publish:
     needs: [dist]


### PR DESCRIPTION
CD fails on every push and PR, at the build:

```
ERROR InvalidDistribution: Invalid distribution metadata:
'2.5' is not a valid metadata version
```

hatchling now writes `Metadata-Version: 2.5`, and the Twine that reads it is
pinned inside the action: `@v2` resolves to a release pinning Twine 6.2, which
does not know 2.5. Reproduced against those exact versions — Twine 6.2 rejects
our wheel, Twine 7 passes it — so it is the reader that is behind, and capping
hatchling would have been treating the symptom.

v3 of the action carries Twine 7, whose release notes give metadata 2.5 as the
reason. The same release stopped force-tagging `@v3` and `@v3.0`, which is why
`@v2` sat frozen instead of picking the fix up, and why this points at a full
version. Dependabot bumps it from here.
