### PR TITLE
Update from scientific-python/cookie template `2026.08.14`

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: 2026.04.04
+_commit: 2026.08.14
 _src_path: gh:scientific-python/cookie
 backend: hatch
 docs: sphinx

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,8 @@ on:
     types:
       - published
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -23,10 +25,13 @@ jobs:
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       # Pinned to a full version on purpose: v3 stopped force-tagging `@v3`
@@ -53,7 +58,7 @@ jobs:
           path: dist
 
       - name: Generate artifact attestation for sdist and wheel
-        uses: actions/attest-build-provenance@v4.2.2
+        uses: actions/attest@v4
         with:
           subject-path: "dist/*"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -21,16 +23,19 @@ jobs:
   lint:
     name: Format
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v9.0.0
 
       - uses: j178/prek-action@v2
 
@@ -40,6 +45,8 @@ jobs:
   checks:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -57,19 +64,19 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install OpenBLAS
         if: runner.os == 'Linux' && startsWith(matrix.python-version, 'pypy')
         run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
 
-      - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v9.0.0
 
       - name: Install package
         run: uv sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
+    env:
+      # Pin the interpreter uv resolves to, instead of letting it discover one
+      # off PATH -- a mismatch here would silently test the same version twice.
+      UV_PYTHON: ${{ matrix.python-version }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+# Configuration for zizmor (https://docs.zizmor.sh)
+rules:
+  unpinned-uses:
+    config:
+      # Feel free to switch to hash pinning, then this can be removed.
+      policies:
+        "*": ref-pin

--- a/.gitignore
+++ b/.gitignore
@@ -143,7 +143,7 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
-# mkdocs documentation
+# mkdocs/properdocs documentation
 /site
 
 # mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,6 @@ ci:
 exclude: ^.cruft.json|.copier-answers.yml$
 
 repos:
-  - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.20.0"
-    hooks:
-      - id: blacken-docs
-        additional_dependencies: [black==26.*]
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v6.0.0"
     hooks:
@@ -46,15 +40,16 @@ repos:
         exclude: ^docs/|^tests/.*\.ya?ml$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.16.1"
+    rev: "v0.16.2"
     hooks:
       - id: ruff-check
         args: ["--fix"]
       - id: ruff-format
+        types_or: [python, pyi, jupyter, markdown, pyproject]
 
   # TODO: enforce type checking in new PR
   # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: "v1.19.1"
+  #   rev: "v2.3.0"
   #   hooks:
   #     - id: mypy
   #       files: src|tests|noxfile.py
@@ -91,8 +86,13 @@ repos:
         additional_dependencies: ["validate-pyproject-schema-store[all]"]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.37.4"
+    rev: "0.38.0"
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
       - id: check-readthedocs
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: "v1.29.0"
+    hooks:
+      - id: zizmor

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.14"
   apt_packages:
     - libgl1-mesa-dev # pyvista/VTK needs OpenGL libs
   commands:

--- a/docs/_pages/user_guide/examples/examples_force_intro.md
+++ b/docs/_pages/user_guide/examples/examples_force_intro.md
@@ -118,7 +118,7 @@ pivot_labels = ["Intrinsic only", "Centroid", "Axle at z=-0.5", "Axle at z=-1.0"
 for pivot, label in zip(pivot_points, pivot_labels):
     F, T = magpy.getFT(stator, cube, pivot=pivot)
 
-    print(f"{label}:" f"  Force:  {np.round(F, 1)} N" f"  Torque: {np.round(T, 1)} N*m")
+    print(f"{label}:  Force:  {np.round(F, 1)} N  Torque: {np.round(T, 1)} N*m")
 
 # Intrinsic only:
 #   Force:  [80.6 -0.   0. ] N
@@ -295,7 +295,6 @@ F0, T0 = magpy.getFT(loop, dipole, pivot=(0, 0, 0))
 
 # Backward (numerical), has opposite sign
 for meshing in [8, 40, 200, 1000]:
-
     # Set meshing parameter
     loop.meshing = meshing
 

--- a/docs/_pages/user_guide/examples/examples_vis_animations.md
+++ b/docs/_pages/user_guide/examples/examples_vis_animations.md
@@ -174,7 +174,6 @@ def create_frames(frames):
     images = []
     pl = init_plotter()
     for i in range(frames):
-
         # Modify object positions
         mag1.rotate_from_angax(360 / frames, axis="z")
         mag2.rotate_from_angax(-360 / frames, axis="z")
@@ -187,7 +186,7 @@ def create_frames(frames):
         pl.add_mesh(pv.Line(mag1.centroid, mag2.centroid), color="cyan")
 
         # Screenshot
-        print(f"Writing frame {i+1:3d}/{frames}")
+        print(f"Writing frame {i + 1:3d}/{frames}")
         ss = pl.screenshot(transparent_background=True, return_img=True)
         images.append(ss)
 
@@ -280,7 +279,7 @@ def create_frames(frames):
         )
 
         # Screenshot (requires kaleido package)
-        print(f"Writing frame {i+1:3d}/{frames}")
+        print(f"Writing frame {i + 1:3d}/{frames}")
         img = fig.to_image(format="png", width=500, height=500)
         images.append(img)
     return images

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,16 +146,11 @@ show-fixes = true
 extend-select = [
   "ARG",    # flake8-unused-arguments
   "B",      # flake8-bugbear
-  "BLE",    # flake8-blind-except
   "C4",     # flake8-comprehensions
-  "DTZ",    # flake8-datetimez
   "EM",     # flake8-errmsg
   "EXE",    # flake8-executable
-  "FA",     # flake8-future-annotations
-  "FLY",    # flynt
   "FURB",   # refurb
   "G",      # flake8-logging-format
-  "I",      # isort
   "ICN",    # flake8-import-conventions
   "ISC",    # flake8-implicit-str-concat
   "LOG",    # flake8-logging
@@ -163,7 +158,6 @@ extend-select = [
   "PD",     # pandas-vet
   "PERF",   # perflint
   "PGH",    # pygrep-hooks
-  "PIE",    # flake8-pie
   "PL",     # pylint
   "PT",     # flake8-pytest-style
   "PTH",    # flake8-use-pathlib
@@ -179,7 +173,6 @@ extend-select = [
   "TC",     # flake8-type-checking
   "TRY",    # tryceratops
   "UP",     # pyupgrade
-  "YTT",    # flake8-2020
 ]
 ignore = [
   "PLR09",    # Too many <...>


### PR DESCRIPTION
`copier update` from `2026.04.04` to `2026.08.14`.

Upstream:

- blacken-docs dropped; ruff-format now covers markdown, jupyter and pyproject code blocks
- ruff `extend-select` loses the groups Ruff 0.16 selects by default (`FA` aside, all verified to still fire)
- zizmor added to pre-commit, with `.github/zizmor.yml`
- workflows gain top-level `permissions: {}` plus per-job grants and `persist-credentials: false`
- `actions/attest-build-provenance` → `actions/attest` (same SLSA provenance with no predicate inputs)
- dependabot cooldown; Read the Docs interpreter 3.13 → 3.14

Kept ours where the project has diverged: the RTD `commands:` block, the disabled mypy hook, the pyvista headless-display and pypy OpenBLAS steps, and our test matrix.

Two drive-by fixes in the `checks` job: a duplicate `astral-sh/setup-uv` invocation and an `allow-prereleases` input handed to setup-uv, which has no such input — both from #954. `UV_PYTHON` is now pinned so a discovery mismatch can't silently test the same version twice.

Local pre-commit needs to be ≥ 4.6 / identify ≥ 2.6.19 for the new `pyproject` type tag; prek is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
