### PR TITLE
Add Agent Skills for Magpylib users and contributors

### DIFF
--- a/.agents/skills/agent-skill-authoring/SKILL.md
+++ b/.agents/skills/agent-skill-authoring/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: agent-skill-authoring
+description: >-
+  Design, write, or review repository Agent Skills and their bundled references.
+  Use when adding or revising SKILL.md files, choosing invocation behavior, or
+  improving skill discovery and progressive disclosure.
+license: BSD-3-Clause
+---
+
+# Agent Skill Authoring
+
+Create skills that change agent behavior predictably without loading irrelevant
+material into every request. Use `magpylib-skill-maintenance` as well when the
+target is Magpylib's package-distributed user skill.
+
+## Design
+
+1. Define the task branch the skill owns and a checkable completion condition.
+1. Confirm a skill is the right primitive: use always-on instructions for rules
+   that apply broadly, and a prompt for a single parameterized action.
+1. Choose model invocation only when autonomous discovery or cross-skill use is
+   valuable. Use `disable-model-invocation: true` for explicit utilities whose
+   invocation should remain a human choice.
+1. Write a concise description naming capabilities and genuine trigger branches.
+   The description is the discovery interface, not a summary of every section.
+1. Put ordered actions and universally needed rules in `SKILL.md`. Move
+   branch-specific reference, examples, scripts, and templates into nearby files
+   and link them only where needed.
+
+## Authoring rules
+
+- Match the frontmatter `name` to the containing directory.
+- Keep instructions executable, positive, and specific about observable done
+  conditions.
+- Prefer repository configuration and canonical docs over duplicated facts that
+  will become stale.
+- State tool or environment assumptions and provide a viable fallback.
+- Avoid hidden dependencies on unavailable skills, trackers, agents, or private
+  services.
+- Include provenance and licensing appropriate for shared repository content.
+
+## Validate
+
+Parse the YAML frontmatter, verify required fields and relative links, run the
+repository's formatting and spelling hooks, and test triggering with requests
+that should and should not activate the skill.
+
+## Sources
+
+The format and progressive-disclosure model follow the public
+[Agent Skills specification](https://agentskills.io). Invocation behavior is
+adapted for clients that support explicit model-invocation controls.

--- a/.agents/skills/codebase-design/SKILL.md
+++ b/.agents/skills/codebase-design/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: codebase-design
+description: >-
+  Design or improve module interfaces and architecture. Use when deciding where
+  behavior belongs, reducing a public surface, choosing dependency boundaries,
+  improving testability, or comparing alternative designs before implementation.
+license: BSD-3-Clause
+---
+
+# Codebase Design
+
+Design modules that hide substantial complexity behind a small, coherent
+interface. A module may be a function, class, package, or subsystem; judge it by
+what callers must understand, not by its physical size.
+
+## Design workflow
+
+1. Identify callers, required capabilities, invariants, failure modes, and
+   performance constraints.
+1. Locate the behavior and data that change together. Prefer one owning module
+   over policies repeated across callers.
+1. Sketch at least two materially different interfaces before committing to a
+   difficult-to-reverse design.
+1. Compare alternatives by caller complexity, hidden implementation detail,
+   dependency direction, testability, compatibility, and likely change patterns.
+1. Select the smallest interface that represents current requirements without
+   speculative extension points.
+1. Name the observable tests that can validate the interface independently of
+   its implementation.
+
+## Review questions
+
+- Does removing the module make its complexity reappear across callers? If not,
+  it may only be forwarding calls.
+- Are callers required to coordinate steps or know ordering that the module
+  could own?
+- Do parameters repeatedly travel together as one domain concept?
+- Does a proposed abstraction have more than one real implementation or source
+  of variation?
+- Can tests use the same interface as production callers?
+- Is compatibility preserved, or is the migration explicit and justified?
+
+Prefer dependency injection at genuine variation points, returned results over
+hidden side effects, and composition over inheritance that exposes irrelevant
+behavior. Do not optimize architectural purity at the expense of numerical
+clarity or a stable scientific API.
+
+## Sources
+
+The emphasis on deep modules follows John Ousterhout's _A Philosophy of Software
+Design_. The use of seams for testability follows Michael Feathers' _Working
+Effectively with Legacy Code_.

--- a/.agents/skills/diataxis-documentation/SKILL.md
+++ b/.agents/skills/diataxis-documentation/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: diataxis-documentation
+description: >-
+  Write or review Magpylib documentation using the Diataxis framework. Use when
+  changing tutorials, how-to guides, explanations, API reference, docstrings,
+  examples, or documentation navigation in this repository.
+license: BSD-3-Clause
+---
+
+# Diataxis Documentation
+
+Give each page one primary reader need. Use this skill together with
+`magpylib-development` for repository commands and local writing conventions.
+
+## Classify before writing
+
+- Tutorial: help a learner gain confidence by completing a guided experience.
+- How-to guide: help a competent user accomplish a specific practical task.
+- Reference: provide accurate, complete facts for lookup.
+- Explanation: build understanding of concepts, reasons, and trade-offs.
+
+Do not combine quadrants merely because their material concerns the same API.
+Put each fact in one canonical location, summarize it briefly elsewhere, and
+link to it.
+
+## Magpylib documentation map
+
+- Handwritten MyST pages live in `docs/_pages/`.
+- API pages are generated from NumPy-style public docstrings.
+- Images, videos, data, and web assets live in `docs/_static/`.
+- Navigation begins in `docs/index.md` and the pages it references.
+- Generated files in `docs/_autogen/` are build output; change their source
+  docstrings or Sphinx configuration instead of editing them directly.
+
+## Workflow
+
+1. Identify the target reader, their goal, and the Diataxis quadrant.
+1. Inspect the implementation, existing canonical docs, and neighboring pages.
+1. Choose the canonical location and update navigation when adding a page.
+1. Draft for one reader need, using runnable SI-unit examples where useful.
+1. Verify API names, defaults, shapes, units, and output against current code.
+1. Build the docs in nitpicky mode and repair relevant warnings or broken links.
+
+For tutorials, keep a meaningful result visible at each stage. For how-to
+guides, lead with the task and prerequisites. Keep reference neutral and
+complete. Use explanation for physical concepts, design rationale, and
+trade-offs rather than step-by-step instructions.
+
+## Local writing rules
+
+- Use MyST Markdown conventions in documentation and NumPy style in docstrings.
+- Use the SPOTIN vocabulary from `CONTRIBUTING.md` for axes and shapes.
+- Express examples in Magpylib v5 SI units.
+- Include only the code needed to demonstrate verified behavior.
+- Preserve one canonical home for tables, equations, and behavioral facts.
+- Use descriptive link text and connect new pages to existing navigation.
+
+Validate documentation changes with:
+
+```console
+uvx nox -s docs --non-interactive
+```
+
+## Sources
+
+The four-quadrant method is adapted from the public
+[Diataxis documentation framework](https://diataxis.fr/). Repository placement,
+formatting, and validation come from `docs/README.md`, `CONTRIBUTING.md`, and
+`noxfile.py`.

--- a/.agents/skills/domain-modeling/SKILL.md
+++ b/.agents/skills/domain-modeling/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: domain-modeling
+description: >-
+  Clarify domain concepts, terminology, invariants, and architectural decisions.
+  Use when names are overloaded, code and documentation disagree about a
+  concept, or a consequential design decision needs durable rationale.
+license: BSD-3-Clause
+---
+
+# Domain Modeling
+
+Make the project's language precise enough that code, tests, documentation, and
+discussion refer to the same concepts. In Magpylib, preserve established physics
+terminology and distinguish physical quantities from implementation
+representations.
+
+## Process
+
+1. Collect the terms, relationships, invariants, and concrete scenarios
+   involved.
+1. Compare their use across public APIs, implementation, tests, documentation,
+   issues, and relevant scientific sources.
+1. Surface overloaded or contradictory meanings and propose precise
+   alternatives.
+1. Stress-test the model with boundary cases and counterexamples.
+1. Confirm canonical terms and definitions with the user.
+1. Update the smallest existing canonical documentation location. Create a new
+   glossary only with user agreement and place it within the established docs
+   structure.
+
+Offer an architecture decision record when a design choice significantly affects
+the system and future contributors will need its rationale. Use an existing
+project convention when present; otherwise ask before introducing one. Record
+one decision per document together with its context, considered options,
+consequences, and status.
+
+## Boundaries
+
+A domain glossary describes concepts and language, not file layout or current
+implementation detail. A specification describes required behavior. An ADR
+records why a durable technical choice was made. Assign each fact to one of
+these artifact types and use cross-references where readers need the connection.
+
+## Sources
+
+The ubiquitous-language practice follows Eric Evans' _Domain-Driven Design_.
+Decision-record guidance follows the public
+[Architecture Decision Record collection](https://github.com/architecture-decision-record/architecture-decision-record).

--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: grill-me
+description:
+  Stress-test my current plan, design, or decision through a structured
+  interview.
+disable-model-invocation: true
+license: BSD-3-Clause
+---
+
+# Grill Me
+
+Run the `grilling` workflow on the plan, design, or decision in the current
+conversation. If none is identifiable, ask the user to name the subject in one
+sentence before starting the interview.

--- a/.agents/skills/grilling/SKILL.md
+++ b/.agents/skills/grilling/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: grilling
+description: >-
+  Interview the user to stress-test and clarify a plan, design, or decision. Use
+  when the user asks to be grilled or when consequential requirements remain
+  ambiguous and implementation should wait for explicit decisions.
+license: BSD-3-Clause
+---
+
+# Grilling
+
+Use disciplined Socratic questioning to expose assumptions and make the user's
+reasoning explicit. Research factual questions from the repository or primary
+sources; reserve questions for choices that require human judgment.
+
+## Process
+
+1. State the proposal, desired outcome, and known constraints.
+1. Ask the user to explain the evidence, assumptions, definitions, and expected
+   consequences behind the proposal.
+1. Test the reasoning with counterexamples, boundary cases, and credible
+   alternatives.
+1. Address one coherent topic at a time so answers can inform later questions.
+1. Explain why each question matters and state a recommendation when the
+   available evidence supports one.
+1. Revisit answers that conflict with established constraints or one another.
+1. Summarize decisions, assumptions, rejected alternatives, and remaining open
+   questions for confirmation.
+
+Do not ask the user for facts that can be established from code, documentation,
+tools, or authoritative external sources. Do not begin implementation until the
+user confirms the resulting understanding or explicitly asks to proceed despite
+listed uncertainties.
+
+## Result
+
+The user receives a confirmed account of the proposal, supporting reasons,
+assumptions, trade-offs, and unresolved questions.
+
+## Sources
+
+This method is based on the public tradition of Socratic questioning and
+critical-thinking prompts about clarification, evidence, assumptions,
+alternatives, and consequences.

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: handoff
+description:
+  Create a concise handoff so another agent session can continue the current
+  work.
+argument-hint: Describe the work that should continue after this conversation.
+disable-model-invocation: true
+license: BSD-3-Clause
+---
+
+# Handoff
+
+Write a self-contained Markdown handoff to the operating system's temporary
+directory, outside the repository. Tailor it to any focus supplied by the user.
+
+Include the objective, current state, decisions and rationale, unresolved
+questions, relevant files and symbols, commands and results, working-tree state,
+constraints, and concrete next actions. Add a short suggested-skills section
+using skills actually available in the destination workspace.
+
+Reference existing issues, plans, commits, and diffs rather than reproducing
+them. Exclude secrets, credentials, personal data, and irrelevant conversation.
+Report the resulting file path.

--- a/.agents/skills/magpylib-array-api-development/SKILL.md
+++ b/.agents/skills/magpylib-array-api-development/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: magpylib-array-api-development
+description:
+  Implement or review Magpylib Array API namespace dispatch, field-kernel ports,
+  capability declarations, and backend tests.
+license: BSD-3-Clause
+---
+
+# Magpylib Array API Development
+
+Add backend portability without changing established NumPy results, numerical
+accuracy, or performance unintentionally. Use `magpylib-development` for the
+general repository workflow and `primary-source-research` when behavior depends
+on a current standard or backend release.
+
+## Establish the contract
+
+Before editing the first kernel, establish these repository-level decisions:
+
+1. Target version: initially use Array API 2024.12, the newest version currently
+   implemented by `array-api-compat`. Recheck this when the compatibility
+   dependency or supported backend minimums change.
+1. Compatibility delivery: add `array-api-compat` as a runtime dependency unless
+   maintainers explicitly choose its documented vendoring option. Do not create
+   an ad hoc fallback. Add `array-api-strict` only to test dependencies, and add
+   `array-api-extra` only when accepted implementation or testing helpers
+   require it.
+1. Rollout: decide whether dispatch is experimental opt-in or always active and
+   identify the stable public boundary that owns that decision.
+1. Mixed inputs: choose rejection or document one owning input whose namespace
+   and device other inputs follow.
+1. Capability matrix: name every initially supported backend, device, dtype,
+   JIT, lazy, and autodiff combination and its CI coverage.
+
+Record these decisions in the implementing issue or pull request and user-facing
+documentation. Do not begin parallel kernel ports while they remain unresolved.
+
+For each change, state which capabilities it intends to support. Treat each of
+these as an independent claim:
+
+- use of standard Array API operations;
+- execution with each named array library;
+- preservation of a non-CPU device;
+- JAX execution under `jax.jit`;
+- lazy execution without materialization;
+- automatic differentiation;
+- numerical accuracy for each supported dtype.
+
+Do not infer one claim from another. Record unsupported combinations explicitly.
+Read [references/official-guidance.md](references/official-guidance.md) when
+choosing dependencies, dispatch semantics, or a backend test matrix. Consult
+[references/magpylib-array-api-work.md](references/magpylib-array-api-work.md)
+before reusing or superseding earlier Magpylib work.
+
+## Design the boundary
+
+1. Resolve the namespace once at the public or core computation boundary from
+   every relevant array input with `array_api_compat.array_namespace`. The
+   compatibility layer normalizes supported NumPy, CuPy, PyTorch, Dask, JAX, and
+   other arrays; it is not only a fallback for older NumPy.
+1. Define mixed-input behavior deliberately. Reject mixed non-NumPy namespaces
+   unless the API has a documented owning input whose namespace and device the
+   other inputs follow.
+1. Centralize namespace resolution, coercion, dtype promotion, device handling,
+   backend detection, and test assertions. Do not add per-kernel variants of the
+   same compatibility logic.
+1. Pass `xp` into internal kernels when dispatch has already occurred. Do not
+   repeatedly rediscover it or add an independent backend selector.
+1. Preserve ordinary NumPy behavior whenever all inputs are NumPy arrays. If an
+   opt-in gate is selected, test both enabled and disabled behavior.
+
+## Port a computation
+
+1. Capture the NumPy baseline with focused accuracy, shape, dtype, warning, and
+   timing checks.
+1. Add a failing test for the smallest capability being introduced.
+1. Replace array operations with operations from `xp`; retain `np` only at a
+   named and tested NumPy-only boundary.
+1. Use explicit `dtype=` and, where supported, `device=` for created arrays. Do
+   not rely on NumPy's default `float64` or integer width.
+1. Follow standard promotion rules. Avoid Python scalars changing promotion or
+   forcing values from device arrays.
+1. Avoid mutation, conversion to Python scalars, and value-dependent Python
+   control flow. These commonly break JAX JIT and lazy arrays even when eager
+   execution passes.
+1. Preserve the input namespace and device in array outputs. Never perform an
+   implicit GPU-to-CPU transfer.
+1. Isolate unavoidable compiled NumPy or SciPy calls behind one explicit
+   conversion boundary. Declare the resulting function CPU-only unless tested
+   native delegation provides wider support.
+1. Keep singularity handling, tolerances, broadcasting, and physical field
+   conventions identical unless a separately documented change is required.
+
+Start with a simple, purely array-based kernel. Treat complete elliptic
+integrals and Cylinder Segment control flow as dedicated algorithmic work rather
+than using them as the first migration slice.
+
+## Test each advertised capability
+
+- Run existing NumPy tests first and compare against independently established
+  results.
+- Use `array-api-strict` to detect non-standard operations and simulated device
+  assumptions. It is a test dependency, not a production backend.
+- Isolate the backend under test to the function being converted; compute
+  references with NumPy and compare through namespace-aware assertions.
+- Test JAX support inside `jax.jit`. An eager JAX pass does not establish JIT
+  support or differentiability.
+- When lazy support is claimed, ensure the test prohibits hidden computation or
+  persistence. Otherwise declare lazy execution unsupported.
+- Test real libraries and hardware for every documented backend/device pair;
+  strict conformance alone cannot establish GPU behavior.
+- Add explicit gradient tests before claiming autodiff support.
+- Exercise deliberate `float32` and `float64` cases. Do not let backend default
+  dtype settings stand in for precision testing.
+- Benchmark NumPy before and after each kernel conversion. Investigate material
+  regressions rather than accepting portability as justification.
+
+Run the focused backend test immediately after the first implementation edit,
+then the corresponding NumPy kernel tests. Widen to the full suite and lint only
+after the focused behavior is stable.
+
+## Document and finish
+
+Document capabilities per public function or coherent API group, including
+backend, CPU/GPU, dtype, JIT, lazy, and autodiff limitations. A capability must
+not be advertised as supported unless an automated test exercises it in CI on
+the relevant backend and device. Record manual hardware results as provisional
+evidence only; they do not establish published support.
+
+A completed slice has focused portable tests, unchanged NumPy accuracy,
+namespace and device assertions, an explicit capability declaration, and a
+recorded NumPy benchmark. Do not merge stale Array API branches wholesale;
+reapply their useful ideas to current kernels and tests.
+
+## Sources
+
+This workflow is derived solely from public specifications, official project
+documentation, public Magpylib issues and pull requests, and the repository's
+current source. Detailed links and applicability notes are in the bundled
+references.

--- a/.agents/skills/magpylib-array-api-development/references/magpylib-array-api-work.md
+++ b/.agents/skills/magpylib-array-api-development/references/magpylib-array-api-work.md
@@ -1,0 +1,84 @@
+# Magpylib Array API Work Inventory
+
+Public GitHub state checked 2026-08-27. Re-query GitHub before acting on status,
+mergeability, checks, or branch divergence. Old pull requests are design and
+test evidence, not authoritative versions of current kernels.
+
+## Direct work
+
+| Item                                                                                    | State at audit      | Scope                                                     |
+| --------------------------------------------------------------------------------------- | ------------------- | --------------------------------------------------------- |
+| [#792](https://github.com/magpylib/magpylib/issues/792)                                 | Open issue          | Original standard-support request and umbrella discussion |
+| [#844](https://github.com/magpylib/magpylib/pull/844)                                   | Open, conflicted PR | Initial aggregate core conversion                         |
+| [#849](https://github.com/magpylib/magpylib/pull/849)                                   | Open, conflicted PR | Circle core kernel                                        |
+| [#850](https://github.com/magpylib/magpylib/pull/850)                                   | Open, conflicted PR | Triangular Mesh core kernel                               |
+| [#851](https://github.com/magpylib/magpylib/pull/851)                                   | Open, conflicted PR | Sphere core kernel                                        |
+| [#852](https://github.com/magpylib/magpylib/pull/852)                                   | Open, conflicted PR | Triangle core kernel                                      |
+| [#853](https://github.com/magpylib/magpylib/pull/853)                                   | Open, conflicted PR | Cylinder Segment core kernel                              |
+| [#854](https://github.com/magpylib/magpylib/pull/854)                                   | Open, conflicted PR | Cuboid core kernel                                        |
+| [#855](https://github.com/magpylib/magpylib/pull/855)                                   | Open, conflicted PR | Tetrahedron core kernel                                   |
+| [#856](https://github.com/magpylib/magpylib/pull/856)                                   | Open, conflicted PR | Polyline core kernel                                      |
+| [#857](https://github.com/magpylib/magpylib/pull/857)                                   | Open, conflicted PR | Dipole core kernel                                        |
+| [#858](https://github.com/magpylib/magpylib/pull/858)                                   | Open, conflicted PR | Cylinder core kernel                                      |
+| [#859](https://github.com/magpylib/magpylib/pull/859)                                   | Closed PR           | Initial core-test submission, superseded by #860          |
+| [#860](https://github.com/magpylib/magpylib/pull/860)                                   | Open, conflicted PR | Backend-parametrized core tests                           |
+| [#861](https://github.com/magpylib/magpylib/pull/861)                                   | Open, conflicted PR | Combined utilities, kernels, and tests; stale at audit    |
+| [#866](https://github.com/magpylib/magpylib/issues/866)                                 | Closed issue        | NumFOCUS grant discussion                                 |
+| [NumFOCUS #46](https://github.com/numfocus/small-development-grant-proposals/issues/46) | Not selected        | Public four-stage implementation proposal                 |
+| [#981](https://github.com/magpylib/magpylib/issues/981)                                 | Open issue          | Performance and Array API implementation scope            |
+
+At the audit date, all thirteen open Array API pull requests reported
+`mergeable_state=dirty`, required review, and had zero checks. The combined
+prototype in #861 introduced compatibility helpers, strict/JAX/Dask tests,
+promotion logic, and lazy control-flow experiments. It also retained NumPy
+coupling, contained unfinished or duplicated Cylinder Segment work, and
+substantially predated current `main`.
+
+## Enabling and constraining work
+
+- [#726](https://github.com/magpylib/magpylib/issues/726): dtype and precision
+  policy directly controls portable creation, promotion, and tolerances.
+- [#883](https://github.com/magpylib/magpylib/issues/883): arbitrary batching
+  and broadcasting affect the computation boundary.
+- [#704](https://github.com/magpylib/magpylib/issues/704): functional-interface
+  design affects where namespace dispatch belongs.
+- [#916](https://github.com/magpylib/magpylib/pull/916): merged path-property
+  architecture deferred pure broadcasting and preserved the functional interface
+  partly for future JAX use.
+- [#937](https://github.com/magpylib/magpylib/pull/937): merged SciPy 1.17
+  Rotation adaptation changes an integration surface touched by old branches.
+- [#941](https://github.com/magpylib/magpylib/pull/941) and
+  [#945](https://github.com/magpylib/magpylib/pull/945): merged complete
+  elliptic-integral changes supersede overlapping code in old prototypes.
+- [#893](https://github.com/magpylib/magpylib/issues/893): proposed Dipole
+  far-field fallback introduces value-dependent control-flow and accuracy
+  concerns relevant to JIT and lazy execution.
+- [#795](https://github.com/magpylib/magpylib/pull/795): merged NumPy 2.0
+  support is relevant dependency history, not Array API dispatch support.
+
+## Motivation and exclusions
+
+- [#835](https://github.com/magpylib/magpylib/issues/835),
+  [#827](https://github.com/magpylib/magpylib/issues/827), and
+  [#579](https://github.com/magpylib/magpylib/issues/579) concern performance or
+  alternative compiled cores. They motivate backend work but do not implement
+  Array API dispatch.
+- [#867](https://github.com/magpylib/magpylib/issues/867) concerns rigid
+  transformations and may matter to a later object-level phase.
+- [#692](https://github.com/magpylib/magpylib/issues/692) concerns unit-array
+  interoperability, a related duck-array problem with a distinct contract.
+- [#732](https://github.com/magpylib/magpylib/issues/732) requested finite
+  element core tests and was closed as unnecessary. It is test-history context.
+- [#974](https://github.com/magpylib/magpylib/issues/974) uses “backend” for
+  display testing and is unrelated to numerical Array API backends.
+- Historical item `#668`, referenced from #579, returned HTTP 404 during the
+  audit. Do not infer its title, type, or outcome.
+
+## Recheck procedure
+
+Search the public repository across issues and pull requests for `array api`,
+`array-api`, `array_namespace`, `array-api-compat`, `array-api-strict`, `JAX`,
+`CuPy`, `PyTorch`, `Dask`, `GPU`, `backend`, `autodiff`, `device`, `dtype`,
+`broadcast`, and `batch`. Inspect comments, timelines, linked pull requests, and
+cross-references, then classify new results as direct, enabling, constraining,
+motivating, tangential, or unrelated.

--- a/.agents/skills/magpylib-array-api-development/references/official-guidance.md
+++ b/.agents/skills/magpylib-array-api-development/references/official-guidance.md
@@ -1,0 +1,86 @@
+# Official Array API Guidance
+
+Checked 2026-08-27. Recheck version-sensitive claims when a new standard is
+published, when `array-api-compat` or a supported backend minimum changes, and
+before changing dependency minimums or advertised capabilities.
+
+## Normative standard
+
+- [Python Array API standard 2025.12](https://data-apis.org/array-api/latest/)
+  is the latest published specification at the checked date. The written
+  specification is authoritative; its verification suite does not yet cover
+  every requirement.
+- [Future API evolution](https://data-apis.org/array-api/latest/future_API_evolution.html)
+  defines date-based versions and requires a compliant namespace to expose
+  `__array_api_version__`.
+- Arrays expose their namespace through `__array_namespace__(api_version=...)`.
+  Consumers should negotiate a version they support instead of assuming the
+  newest standard is implemented by every backend.
+- Magpylib's initial implementation target is 2024.12 because that is the newest
+  version implemented by `array-api-compat` at the checked date. The newer
+  specification remains useful for forward planning, not as the implementation
+  contract.
+- [Lazy versus eager execution](https://data-apis.org/array-api/latest/design_topics/lazy_eager.html)
+  explains why Python truth testing and scalar conversion can force execution or
+  fail for lazy implementations.
+- [Extension namespaces](https://data-apis.org/array-api/latest/extensions/index.html)
+  such as `linalg` and `fft` are optional coherent units. Feature-detect the
+  namespace before relying on one.
+
+## Consumer compatibility tools
+
+- [array-api-compat](https://data-apis.org/array-api-compat/) provides namespace
+  discovery and compatibility wrappers for NumPy, CuPy, PyTorch, Dask, JAX, and
+  other established libraries. It is suitable for runtime use by an
+  array-consuming library and officially supports installation as a dependency
+  or vendoring. Its wrappers implement Array API 2024.12 at the checked date.
+- [array-api-strict](https://data-apis.org/array-api-strict/) deliberately
+  exposes non-portable assumptions during testing. Do not require users to adopt
+  its array objects.
+- [array-api-extra](https://data-apis.org/array-api-extra/) provides portable
+  operations outside the standard and testing support for JAX JIT and lazy
+  execution. Each helper remains an additional dependency and capability
+  decision. Its
+  [`lazy_xp_function`](https://data-apis.org/array-api-extra/generated/array_api_extra.testing.lazy_xp_function.html)
+  test helper exercises JAX under JIT and guards Dask against unintended
+  computation.
+
+## Downstream implementation precedents
+
+- [SciPy's Array API developer guide](https://scipy.github.io/devdocs/dev/api-dev/array_api.html)
+  is the most complete public procedure for a scientific array consumer. It
+  resolves `xp` from all inputs, validates and coerces through centralized
+  helpers, converts around compiled calls explicitly, declares per-function
+  capabilities, and requires tests for every advertised capability.
+- SciPy tests NumPy, strict, PyTorch, JAX, and Dask on CPU and CuPy, PyTorch,
+  and JAX on available GPUs. JAX functions are tested under `jax.jit`; lazy Dask
+  tests prevent materialization. SciPy currently permits Dask to be declared
+  unsupported where structural barriers make support disproportionately costly.
+- [NumPy Array API compatibility](https://numpy.org/doc/stable/reference/array_api.html)
+  documents support in NumPy's main namespace. The separate `numpy.array_api`
+  module was removed in NumPy 2.0. At the checked date, NumPy 2.3 documents
+  compatibility with standard version 2024.12.
+- [NEP 56](https://numpy.org/neps/nep-0056-array-api-main-namespace.html)
+  explains the main-namespace design, predictable promotion, device-aware array
+  creation, and why a strict standalone array type is better suited to testing
+  than normal downstream use.
+- [Scikit-learn's Array API guide](https://scikit-learn.org/stable/modules/array_api.html)
+  demonstrates experimental opt-in dispatch, owning-input conversion policies,
+  namespace/device-preserving outputs, strict checks, and real GPU validation.
+
+## Implications for Magpylib
+
+1. Before porting kernels, choose and document the standard version, dependency
+   or vendoring strategy, rollout gate, mixed-input semantics, and CI-backed
+   capability matrix.
+1. Namespace dispatch belongs at a stable computation boundary, not in a global
+   mutable backend setting.
+1. If array arguments already identify namespace and device, separate `xp=` or
+   `device=` public keywords add ambiguity and should normally be avoided.
+1. Creation without an array input may require explicit keyword-only namespace,
+   device, and dtype parameters, but this is a separate API design decision.
+1. Calls into NumPy/SciPy compiled implementations are CPU boundaries. Device
+   transfer must fail clearly rather than happen silently.
+1. Array API syntax is only the common vocabulary. Backend availability,
+   accelerator execution, JIT, lazy evaluation, and autodiff require separate
+   implementation and evidence.

--- a/.agents/skills/magpylib-code-review/SKILL.md
+++ b/.agents/skills/magpylib-code-review/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: magpylib-code-review
+description: >-
+  Review Magpylib changes for correctness, regressions, scope, tests, and
+  repository conventions. Use when reviewing a branch, pull request, commit, or
+  working-tree diff in this repository.
+license: BSD-3-Clause
+---
+
+# Magpylib Code Review
+
+Review behavior and risk before style. Use `magpylib-development` for the
+repository's implementation and validation conventions.
+
+## Establish the review target
+
+1. Resolve the comparison point supplied by the user. For a branch or pull
+   request, compare against its merge base; for working-tree changes, include
+   staged and unstaged changes.
+1. Read the commit list and changed-file summary before individual hunks.
+1. Find the originating GitHub issue, pull request description, or stated user
+   request. If no specification exists, say so and review observable behavior
+   without inventing requirements.
+
+## Review criteria
+
+Inspect the complete diff using parallel read-only agents for independent areas
+when that improves coverage:
+
+- Correctness: wrong results, broken invariants, numerical instability,
+  singularities, shape errors, unit mistakes, and path or collection semantics.
+- Compatibility: public API, typing, warnings, optional dependencies, supported
+  Python versions, and serialized or displayed output.
+- Requirements: missing behavior, partial acceptance criteria, and scope creep.
+- Tests: meaningful regression coverage, independently derived expectations,
+  justified tolerances, and important scalar/vectorized or boundary cases.
+- Maintainability: unnecessary complexity, duplication, misleading names, and
+  changes made outside the abstraction that owns the behavior.
+- Documentation: current signatures, SI units, examples, links, and user-facing
+  behavior reflected in docs or docstrings.
+
+Treat `CONTRIBUTING.md`, `.github/CONTRIBUTING.md`, `pyproject.toml`, and nearby
+tests as authoritative. Tooling enforces formatting; do not report formatter
+preferences as review findings.
+
+## Verify findings
+
+Trace each suspected defect through the controlling code and callers. Run the
+narrowest test or reproducer that can distinguish a real problem from a concern
+when execution is practical. Do not claim a bug from pattern matching alone.
+
+## Report
+
+Lead with findings ordered by severity. For each finding, give a precise file
+location, the failure mode, its impact, and the smallest credible correction.
+Then list open questions and test gaps. If no defects are found, say so and
+state residual risks or validation not performed.
+
+## Sources
+
+This workflow is grounded in Magpylib's contribution guides. Its review criteria
+follow the public
+[Google Engineering Practices review guide](https://google.github.io/eng-practices/review/).

--- a/.agents/skills/magpylib-development/SKILL.md
+++ b/.agents/skills/magpylib-development/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: magpylib-development
+description: >-
+  Develop and maintain the Magpylib repository. Use when changing Python source,
+  tests, packaging, CI, or contributor tooling in this repository, or when
+  choosing the correct local validation command.
+license: BSD-3-Clause
+---
+
+# Magpylib Development
+
+Follow the repository's established Scientific Python workflow. Read the code
+nearest to the requested behavior and its focused tests before changing it.
+
+## Repository map
+
+- Public package: `src/magpylib/`
+- Internal implementation: `src/magpylib/_src/`
+- Tests: `tests/`
+- Sphinx and MyST documentation: `docs/`
+- Development sessions: `noxfile.py`
+- Tool configuration and dependency groups: `pyproject.toml`
+
+Keep public APIs in the public package namespaces. Preserve the existing split
+between public classes and helpers in `_src`, and update type information when a
+public signature changes.
+
+## Implementation workflow
+
+1. Identify the public or package-internal behavior that owns the change.
+1. Find the closest existing test and state the behavior it observes.
+1. For a bug fix or behavior change, add a focused regression test and witness
+   the intended failure before editing the implementation when practical.
+1. Make the smallest coherent change at the owning abstraction.
+1. Run the focused test immediately, then widen validation according to risk.
+1. Update user documentation and docstrings when the public contract changes.
+
+Do not rewrite unrelated code or weaken warnings, numerical tolerances, or test
+assertions merely to obtain a passing run. For numerical work, derive expected
+values independently from the implementation under test and include boundary,
+inside/outside, path, and array-shape cases where relevant.
+
+## Project conventions
+
+- Python support starts at 3.11.
+- Public code is typed; MyPy is strict for `magpylib.*`.
+- Public docstrings use NumPy style.
+- Source and test formatting is governed by the checked-in Ruff, Pylint, and
+  prek configuration.
+- Tests run with strict Pytest configuration and warnings treated as errors.
+- Follow the SPOTIN axis vocabulary documented in `CONTRIBUTING.md`.
+- Use SI units for Magpylib v5 code and examples.
+
+## Validation
+
+Start narrow and broaden only as the changed surface requires:
+
+```console
+uv run pytest tests/test_relevant_file.py -k relevant_behavior
+uv run pytest
+uvx nox -s lint
+uvx nox -s pylint
+uvx nox -s docs --non-interactive
+uvx nox -s build
+```
+
+Use `uvx nox` when Nox is not installed. A source change normally requires its
+focused tests and linting. A public API change also requires the relevant docs
+build. Packaging changes require the build session.
+
+## Sources
+
+This project workflow is derived from `.github/CONTRIBUTING.md`,
+`CONTRIBUTING.md`, `noxfile.py`, and `pyproject.toml`. Its general packaging and
+tooling practices follow the public
+[Scientific Python Development Guide](https://learn.scientific-python.org/development/)
+and the [scientific-python/cookie](https://github.com/scientific-python/cookie)
+template used to generate this repository.

--- a/.agents/skills/magpylib-skill-maintenance/SKILL.md
+++ b/.agents/skills/magpylib-skill-maintenance/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: magpylib-skill-maintenance
+description: >-
+  Create, review, or update Magpylib's package-distributed Agent Skill. Use when
+  changing src/magpylib/.agents/skills, adding skill references, validating
+  Agent Skills metadata, or checking that the skill ships in distributions.
+license: BSD-3-Clause
+---
+
+# Magpylib Skill Maintenance
+
+The user-facing `magpylib` skill is package data under
+`src/magpylib/.agents/skills/magpylib/`. It is versioned with the API it
+describes and discovered from an installed distribution by `library-skills`.
+
+Do not confuse it with repository development skills under `.agents/skills/`.
+Those guide contributors in this checkout and are not part of the installed
+Magpylib package.
+
+## Ground the change
+
+When the request names a specific correction, investigate that assertion and the
+neighboring guidance it affects. When the whole skill may be stale, build a
+complete checklist of its API names, parameters, defaults, units, shapes,
+examples, caveats, and file references. Independent read-only agents may verify
+separate checklist sections when available.
+
+Every technical claim must be supported by current package code, an executable
+check, or canonical documentation. Prefer executable checks for output shapes,
+path behavior, unit-sensitive examples, warnings, and exceptions.
+
+## Authoring rules
+
+- Keep `name: magpylib`; the directory and frontmatter name must match.
+- Make the description specific enough to trigger before stale pre-v5 knowledge
+  is used, especially for units and `polarization` versus `magnetization`.
+- Keep universally needed guidance in `SKILL.md`; place branch-specific detail
+  in `references/` and link it relatively.
+- Use paths valid in the installed package. Do not point users to
+  repository-only source, tests, or docs.
+- Keep examples minimal, executable, and in SI units.
+- Update or remove contradicted claims instead of preserving historical advice.
+
+Author the skill directly at its package path. Do not run `library-skills`
+installation from the repository root: a generated symlink can alter Hatch's
+sdist collection and omit the real packaged skill.
+
+## Validate
+
+Run the focused packaging tests and build both distribution formats:
+
+```console
+uv run pytest tests/test_package.py
+uvx nox -s build
+```
+
+Inspect the wheel and sdist archives to confirm `SKILL.md` and every linked
+reference are present at `magpylib/.agents/skills/magpylib/`. Also parse the
+frontmatter and verify all relative links resolve. A source-tree test alone is
+not sufficient evidence that package data ships.
+
+## Sources
+
+The format follows the public
+[Agent Skills specification](https://agentskills.io) and
+[library-skills](https://library-skills.io/) discovery convention. Package
+placement and the symlink caveat are grounded in this branch's introducing
+commit and `tests/test_package.py`.

--- a/.agents/skills/primary-source-research/SKILL.md
+++ b/.agents/skills/primary-source-research/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: primary-source-research
+description: >-
+  Research technical questions using authoritative primary sources. Use when a
+  task depends on current API behavior, specifications, upstream source code,
+  release history, or claims that should not rely on memory alone.
+license: BSD-3-Clause
+---
+
+# Primary-Source Research
+
+Investigate the question against sources that own the facts: official
+documentation, specifications, upstream repositories, release notes, and
+executable behavior. Use a read-only research subagent for an independent scope
+when available, but verify its material claims before relying on them.
+
+## Process
+
+1. Define the exact questions and what evidence would answer each one.
+1. Prefer primary sources; use secondary sources only to locate or contrast
+   authoritative material.
+1. Record versions, dates, and applicability constraints.
+1. Trace every non-obvious conclusion to a source or reproducible check.
+1. Reconcile contradictions explicitly instead of selecting the convenient
+   source.
+1. Return a concise synthesis separating established facts, inference, and
+   unresolved uncertainty.
+
+Create a repository artifact only when the user requests one or the findings
+must support later implementation. In that case, use an agreed project location
+and include source links beside the claims they support.

--- a/.agents/skills/resolving-merge-conflicts/SKILL.md
+++ b/.agents/skills/resolving-merge-conflicts/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: resolving-merge-conflicts
+description: >-
+  Resolve an in-progress Git merge, rebase, or cherry-pick conflict by
+  preserving the intended behavior of both sides. Use when conflict markers or
+  unmerged paths are present.
+license: BSD-3-Clause
+---
+
+# Resolving Merge Conflicts
+
+Inspect both changes before deciding what the merged file should contain.
+Preserve user work and obtain explicit approval before aborting or discarding a
+change.
+
+## Process
+
+1. Use `git status` to identify the active operation and every unmerged path.
+1. Read the conflicting commits and the surrounding code to understand what each
+   change was intended to do.
+1. Edit each file to keep one side, the other side, or a combined result. Remove
+   all conflict markers.
+1. Stage each resolved path with `git add` or `git rm` as appropriate.
+1. Review the staged diff and search the repository for remaining markers.
+1. Run focused tests for the affected behavior, followed by the relevant
+   repository checks.
+1. Continue the merge, rebase, or cherry-pick only after validation succeeds.
+
+If the changes are incompatible or the operation targets the wrong base, stop
+and explain the available Git options before modifying more files.
+
+## Sources
+
+The procedure follows Git's conflict markers and index workflow as documented by
+the public
+[GitHub command-line conflict guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line)
+and
+[rebase conflict guide](https://docs.github.com/en/get-started/using-git/resolving-merge-conflicts-after-a-git-rebase).

--- a/.agents/skills/scientific-python-template-update/SKILL.md
+++ b/.agents/skills/scientific-python-template-update/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: scientific-python-template-update
+description: >-
+  Update Magpylib from the scientific-python/cookie Copier template. Use when
+  running or reviewing a Copier update, changing .copier-answers.yml, or
+  reconciling generated template changes with repository customizations.
+license: BSD-3-Clause
+---
+
+# Scientific Python Template Update
+
+Magpylib tracks `gh:scientific-python/cookie` in `.copier-answers.yml`. Template
+updates are integration work: preserve intentional Magpylib customizations while
+accepting applicable upstream improvements.
+
+## Prepare
+
+1. Read `.copier-answers.yml` and the public template release notes.
+1. Record the current and target template revisions.
+1. Review the working tree and preserve any unrelated user changes before the
+   update begins.
+1. Require a clean working tree and use a dedicated update branch. Get explicit
+   approval before stashing, committing, switching branches, or running Copier
+   when the user has not already requested those operations.
+
+## Apply and reconcile
+
+Run `copier update` with the requested template revision and reuse the recorded
+answers unless the update intentionally changes them. Do not edit
+`.copier-answers.yml` manually; Copier documents that this makes later smart
+updates unreliable.
+
+Review every generated change and resolve inline conflict markers or `.rej`
+files according to the selected conflict mode. Compare the result with the
+pre-update commit to confirm that project metadata, dependencies, automation,
+documentation configuration, and Magpylib-specific behavior remain intentional.
+Use repository history when the purpose of an existing customization is unclear.
+
+## Validate
+
+Run the checks affected by the update, followed by the full repository gates:
+
+```console
+uvx nox -s lint
+uvx nox -s pylint
+uvx nox -s tests
+uvx nox -s docs --non-interactive
+uvx nox -s build
+```
+
+Review the final diff against the pre-update commit. Report accepted upstream
+changes, retained project customizations, deliberate departures, unresolved
+conflicts, and any validation that could not run.
+
+## Sources
+
+This workflow follows public
+[Copier update behavior](https://copier.readthedocs.io/en/stable/updating/) and
+Magpylib's recorded use of the `scientific-python/cookie` template.

--- a/.agents/skills/test-driven-development/SKILL.md
+++ b/.agents/skills/test-driven-development/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: test-driven-development
+description: >-
+  Apply test-driven development to Magpylib changes. Use when implementing a
+  feature or bug fix test-first, adding a regression test, or working through a
+  red-green-refactor cycle in this repository.
+license: BSD-3-Clause
+---
+
+# Test-Driven Development
+
+Develop one observable behavior at a time through a red-green-refactor cycle.
+Use this skill together with `magpylib-development` for repository commands and
+conventions.
+
+## Choose the test boundary
+
+Test behavior through the narrowest stable interface used by real callers. A
+public API is preferred, but a package-internal interface is appropriate when
+the task intentionally changes that contract. Avoid private implementation
+details, incidental call order, and snapshots that do not express a meaningful
+contract.
+
+For numerical behavior, obtain expected values independently: use an analytic
+result, symmetry, a trusted reference value, or a cross-interface consistency
+relation. Do not reproduce the implementation formula in the test.
+
+## Cycle
+
+1. State one behavior and the interface through which it is observed.
+1. Add the smallest test that expresses that behavior.
+1. Run only that test and confirm that it fails for the intended reason.
+1. Implement only the behavior required to satisfy that test.
+1. Rerun the same test until it passes without weakening the assertion.
+1. Refactor names, structure, or duplication while keeping the test green.
+1. Repeat for the next behavior, then run the containing test module and the
+   broader validation required by the changed surface.
+
+If the test unexpectedly passes before the implementation changes, prove that it
+can detect the defect before continuing. If it fails because of setup, imports,
+or unrelated state, repair the test until the failure demonstrates the missing
+behavior.
+
+## Magpylib test design
+
+- Match the organization and assertion style of the nearest tests.
+- Include array shape and scalar/vectorized behavior when changing field APIs.
+- Cover path and collection semantics when they affect the changed contract.
+- Treat warnings as part of the behavior; Pytest runs with warnings as errors.
+- Keep tolerances physically and numerically justified. Do not widen them to
+  hide an unexplained discrepancy.
+- Add optional-dependency cases only where the affected boundary requires them.
+
+## Completion
+
+The focused test has been witnessed failing for the intended reason and passing
+after the implementation. The containing module passes, relevant lint checks
+pass, and public behavior changes are reflected in docs or docstrings.
+
+## Sources
+
+This workflow follows the public red-green-refactor practice described by Kent
+Beck in _Test-Driven Development: By Example_, adapted to Magpylib's Pytest
+configuration and the public
+[Scientific Python testing guide](https://learn.scientific-python.org/development/guides/pytest/).

--- a/.agents/skills/wait-what/SKILL.md
+++ b/.agents/skills/wait-what/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: wait-what
+description:
+  Re-explain the last response because it was unclear or assumed too much
+  context.
+disable-model-invocation: true
+license: BSD-3-Clause
+---
+
+# Wait, What?
+
+Re-pitch the preceding explanation in plain language. Start with the missing
+context, define necessary terms, separate facts from recommendations, and give
+one concrete example. Keep established project terminology, but do not assume
+the reader followed earlier reasoning. End with the immediate decision or next
+step, not a repetition of the entire conversation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+- Magpylib now ships an official [Agent Skill](https://agentskills.io) at
+  `magpylib/.agents/skills/magpylib/`, so AI coding assistants get the current
+  API instead of the pre-v5 one they were trained on — SI units, `polarization`
+  over `magnetization`, output shapes, path semantics, and the `meshing`
+  requirement of `getFT()`. It travels inside the wheel and is therefore always
+  in sync with the installed version. Users pick it up with `uvx library-skills`
+  (see [library-skills.io](https://library-skills.io)), which symlinks it into
+  their project's `.agents/skills/`.
 - Extended the path system beyond `position`/`orientation` to object attributes
   ([#916](https://github.com/magpylib/magpylib/pull/916)). Physical properties
   such as `current`, `diameter`, `dimension`, `polarization`, `magnetization`,

--- a/src/magpylib/.agents/skills/magpylib/SKILL.md
+++ b/src/magpylib/.agents/skills/magpylib/SKILL.md
@@ -30,8 +30,8 @@ parameter names, and most pre-trained code reproduces the old API.
   `(s, p, o, *pixel, 3)` before squeezing. See
   [Field computation](#field-computation).
 - Never loop in Python over positions or parameters — use a path or the
-  functional interface. See
-  [references/position-paths.md](references/position-paths.md).
+  functional interface. Paths carry physical attributes too, not just motion:
+  see [Path-varying properties](#path-varying-properties).
 - Force and torque: `magpy.getFT(sources, targets)`, and every target except
   `Dipole` and `Sphere` needs `meshing` set. See
   [Force and torque](#force-and-torque).
@@ -79,12 +79,26 @@ Available classes:
 
 All magnets accept `polarization` (T) **or** `magnetization` (A/m). The two are
 codependent, kept in sync as J = µ₀·M, so set one and read either. Prefer
-`polarization` — datasheet remanence B_r is a polarization.
+`polarization`: a datasheet's remanence B_r is a polarization. Use B_r directly
+only when ignoring material response — a real magnet demagnetises itself, so the
+mean polarization sits a few percent below B_r (about 95% of it as a rule of
+thumb, exactly the J at the working point). For an inhomogeneous treatment see
+the `magpylib-material-response` package.
 
 Every source constructor takes `position`, `orientation`, its shape parameters,
 `meshing` (for force targets), and `style`. Shape parameters are given in the
 object's **local** coordinates; `position`/`orientation` place that local frame
-in the global one.
+in the global one. `obj.copy(**kwargs)` clones an object with overrides, which
+is how arrays of near-identical magnets are built.
+
+Two classes need more than a constructor call:
+
+- `magnet.TriangularMesh` builds a solid from a closed surface mesh, via
+  `from_pyvista()` (an STL or any PyVista `PolyData`), `from_ConvexHull()`,
+  `from_triangles()`, or `from_mesh()`. It validates closedness and orientation.
+- `misc.CustomSource(field_func=...)` wraps any callable
+  `field_func(field, observers) -> (n, 3)`, which is how measured or
+  interpolated field data joins a Magpylib scene.
 
 ## Field computation
 
@@ -104,8 +118,15 @@ B = magpy.getB(
 methods on every object, so `cube.getB(sensor)` and `sensor.getB(cube)` give the
 same array.
 
+`getJ` and `getM` describe the material, not a field in space: they return the
+body's own polarization/magnetization **inside** it and exactly zero everywhere
+outside. Inside a magnet the H-field opposes J (the demagnetising field), so
+`getB` inside is not µ₀·`getH` + J by inspection — it is smaller than J.
+
 `observers` is an array of positions with shape `(..., 3)`, a `Sensor`, a
-`Collection`, or a flat list of those.
+`Collection`, or a flat list of those. Note the asymmetry on the source side: a
+`Collection` passed as `sources` counts as **one** source and superposes its
+children, whereas `[child_a, child_b]` keeps a source axis of length 2.
 
 ```python
 import numpy as np
@@ -158,30 +179,71 @@ Together they form the object's **path**, and a field computation runs over the
 whole path at once.
 
 ```python
-from scipy.spatial.transform import Rotation as R
-
 cube.position = np.linspace((0, 0, 0.01), (0, 0, 0.05), 50)  # 50-step path
-cube.rotate(R.from_rotvec((0, 0, 90), degrees=True), anchor=(0, 0, 0))
+cube.rotate_from_angax(90, "z", anchor=(0, 0, 0))  # no scipy import needed
 ```
+
+Reach for the `rotate_from_*` helpers rather than building a `Rotation` by hand:
+`rotate_from_angax`, `rotate_from_rotvec`, `rotate_from_euler`,
+`rotate_from_quat`, `rotate_from_matrix`, `rotate_from_mrp`. They take the same
+`anchor` and `start` arguments as `rotate()`.
 
 `move()` and `rotate()` behave differently for scalar and vector input, and the
 default `start="auto"` means scalar input _transforms the existing path_ while
 vector input _appends to it_. This trips up nearly everyone; read
 [references/position-paths.md](references/position-paths.md) before writing
-multi-step motion, and note that physical attributes (`current`, `dimension`,
-`polarization`, `vertices`, …) can carry a path too.
+multi-step motion.
+
+## Path-varying properties
+
+A path is not restricted to motion. Physical attributes can vary along it too,
+so a current ramps, a coil deforms, or a magnet expands — computed in the same
+single vectorised call. `obj.path_properties` lists which attributes of a class
+support this.
+
+```python
+coil = magpy.current.Circle(
+    diameter=np.linspace(0.01, 0.02, 10),  # geometry ramps
+    current=np.linspace(1, 5, 10),  # excitation ramps
+    position=np.linspace((0, 0, 0), (0, 0, 0.02), 10),  # and it moves
+)
+B = magpy.getB(coil, (0, 0, 0.03))  # (10, 3)
+```
+
+This is the vectorised replacement for a Python loop over parameter values — AC
+or ramped currents, thermal expansion, deforming conductors, parameter sweeps.
+Note that a swept attribute is still **one object** observed at n settings, not
+n objects: the result has a path axis, not a source axis.
+
+Three rules govern it, and they are the part worth remembering:
+
+- **What you set is what is stored.** Attributes are independent (except
+  `position`/`orientation`, which stay synchronised with each other) and are
+  never silently expanded to match one another.
+- **Lengths reconcile only at computation time**, by edge-padding the shorter
+  attributes to the longest — the object is static beyond its own path — on a
+  temporary copy. Your attributes keep the lengths you gave them.
+- **Derived properties follow.** `dipole_moment`, `centroid`, and friends gain a
+  leading path axis when the attributes they are computed from vary.
+
+See [references/position-paths.md](references/position-paths.md) for
+end-slicing, mismatched lengths, and worked examples.
 
 ## Collections
 
 ```python
 array = magpy.Collection(magnet1, magnet2, sensor)
-array.rotate(R.from_rotvec((0, 0, 45), degrees=True), anchor=(0, 0, 0))
+array.rotate_from_angax(45, "z", anchor=(0, 0, 0))
 ```
 
 A `Collection` groups objects for common manipulation and spans a local frame
 for its children; moving it moves them while preserving relative placement. It
 is both a source (for `getB`) and a container. Access parts via `.sources`,
 `.observers`, `.collections`, or the `*_all` variants for nested collections.
+
+Subclassing `Collection` is the documented way to build a parametrised assembly
+— a magnet ring, a coil former — that behaves as one object with its own
+constructor arguments while keeping the full Magpylib API.
 
 ## Force and torque
 
@@ -236,4 +298,12 @@ subplots. Styling is per-object via `obj.style` or globally via
 - `misc.Triangle` is a single charged facet, not a closed body. For a solid mesh
   magnet use `magnet.TriangularMesh`, which validates closedness.
 - Field on a source's own vertices/edges returns 0, not `nan`.
+- `getJ()`/`getM()` return zero outside the body. They are not "the field" — for
+  that, use `getB()`/`getH()`.
+- A `Collection` as `sources` is one source, not many: `getB(coll, obs)` already
+  superposes its children, so summing the result again double-counts.
+- Setting one path property does not lengthen the others. A `current` of 3 steps
+  with a `position` of 2 computes over 3 steps, with the object parked at its
+  last position — no error, so check `path_properties` lengths when a result has
+  an unexpected first axis.
 - `magpy.mu_0` ≠ `4πe-7`. Use the constant when converting M ↔ J.

--- a/src/magpylib/.agents/skills/magpylib/SKILL.md
+++ b/src/magpylib/.agents/skills/magpylib/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: magpylib
+description: >-
+  Use when writing, reviewing, or debugging Python code that computes magnetic
+  fields, forces, or torques — magnets, coils, current loops, Halbach arrays,
+  field sensors, magnetic simulations — even when the user never says
+  "Magpylib". Covers source and sensor objects, getB/getH/getJ/getM and their
+  output shapes, positions/orientations/paths, collections, force and torque via
+  getFT, the functional interface, and show() visualisation. Magpylib v5+ takes
+  SI units (metres, tesla, amperes) and prefers `polarization` over
+  `magnetization`; code written from pre-v5 memory silently produces answers
+  that are wrong by factors of 1e3 to 1e9, so use this skill before writing any
+  Magpylib code rather than after the numbers look odd.
+license: BSD-3-Clause
+---
+
+# Magpylib
+
+Official skill, shipped inside the `magpylib` package and versioned with it.
+Prefer it over recalled API knowledge: the v4 → v5 transition changed units and
+parameter names, and most pre-trained code reproduces the old API.
+
+## Quick reference
+
+- Units are SI throughout: metres, tesla, amperes, degrees. See
+  [Units](#units-are-si-v5-and-later).
+- Magnets take `polarization` (T), not `magnetization` (A/m), unless the user
+  really means M. See [Sources](#sources).
+- Fields: `magpy.getB(sources, observers)`; output shape is
+  `(s, p, o, *pixel, 3)` before squeezing. See
+  [Field computation](#field-computation).
+- Never loop in Python over positions or parameters — use a path or the
+  functional interface. See
+  [references/position-paths.md](references/position-paths.md).
+- Force and torque: `magpy.getFT(sources, targets)`, and every target except
+  `Dipole` and `Sphere` needs `meshing` set. See
+  [Force and torque](#force-and-torque).
+- Read [Gotchas](#gotchas) when a result is off by a suspicious factor, has an
+  unexpected array shape, or a path did not behave as written.
+
+## Units are SI (v5 and later)
+
+| Quantity        | Parameter                           | v5 unit | v4 unit |
+| --------------- | ----------------------------------- | ------- | ------- |
+| Polarization J  | `polarization`, `getJ()`            | T       | —       |
+| Magnetization M | `magnetization`, `getM()`           | A/m     | mT      |
+| Current         | `current`                           | A       | A       |
+| Dipole moment   | `moment`                            | A·m²    | mT·mm³  |
+| B-field         | `getB()`                            | T       | mT      |
+| H-field         | `getH()`                            | A/m     | kA/m    |
+| Lengths         | `position`, `dimension`, `vertices` | m       | mm      |
+| Angles          | `angle`, `dimension` (cylinder φ)   | °       | °       |
+
+A 5 mm cube is `dimension=(0.005, 0.005, 0.005)`, not `(5, 5, 5)`. A typical
+NdFeB remanence of 1.2 T is `polarization=(0, 0, 1.2)`.
+
+`magpy.mu_0` is the vacuum permeability from `scipy.constants` — not
+`4 * np.pi * 1e-7`, since the 2019 SI redefinition.
+
+## Sources
+
+```python
+import magpylib as magpy
+
+cube = magpy.magnet.Cuboid(
+    dimension=(0.005, 0.005, 0.005),  # m
+    polarization=(0, 0, 1.2),  # T
+    position=(0, 0, 0.01),  # m
+)
+loop = magpy.current.Circle(diameter=0.02, current=10)  # m, A
+```
+
+Available classes:
+
+- `magpy.magnet`: `Cuboid`, `Cylinder`, `CylinderSegment`, `Sphere`,
+  `Tetrahedron`, `TriangularMesh`
+- `magpy.current`: `Circle`, `Polyline`, `TriangleSheet`, `TriangleStrip`
+- `magpy.misc`: `Dipole`, `Triangle`, `CustomSource`
+
+All magnets accept `polarization` (T) **or** `magnetization` (A/m). The two are
+codependent, kept in sync as J = µ₀·M, so set one and read either. Prefer
+`polarization` — datasheet remanence B_r is a polarization.
+
+Every source constructor takes `position`, `orientation`, its shape parameters,
+`meshing` (for force targets), and `style`. Shape parameters are given in the
+object's **local** coordinates; `position`/`orientation` place that local frame
+in the global one.
+
+## Field computation
+
+```python
+B = magpy.getB(
+    sources,
+    observers,
+    sumup=False,
+    squeeze=True,
+    pixel_agg=None,
+    output="ndarray",
+    in_out="auto",
+)
+```
+
+`getH`, `getJ`, and `getM` take the same arguments. All four also exist as
+methods on every object, so `cube.getB(sensor)` and `sensor.getB(cube)` give the
+same array.
+
+`observers` is an array of positions with shape `(..., 3)`, a `Sensor`, a
+`Collection`, or a flat list of those.
+
+```python
+import numpy as np
+
+grid = np.mgrid[-0.02:0.02:20j, 0:1:1j, -0.02:0.02:20j].T.reshape(-1, 3)
+B = magpy.getB(cube, grid)  # shape (400, 3)
+```
+
+Output shape before squeezing is `(s, p, o, *pixel_shape, 3)` — sources, path
+length, observers, sensor pixel shape, field components. With `squeeze=True`
+(default) every length-1 axis disappears, which is why a single source at a
+single position returns plain `(3,)`. Pass `squeeze=False` whenever downstream
+code indexes axes positionally.
+
+- `sumup=True` sums the field of all sources into one array.
+- `pixel_agg="mean"` (any NumPy aggregator name) reduces over pixels, and is
+  what lets observers with different pixel shapes be mixed in one call.
+- `output="dataframe"` returns a tidy pandas DataFrame instead of an ndarray.
+- `in_out` declares whether observers sit inside or outside magnet bodies
+  (`"auto"`, `"inside"`, `"outside"`). Setting it skips a per-observer test, but
+  it only affects `Tetrahedron` and `TriangularMesh` — Magpylib warns and
+  ignores it elsewhere.
+
+**One call, many inputs.** Magpylib vectorises everything it is handed. A Python
+loop over `getB` is the single most common performance mistake — it is routinely
+100× slower than passing a path or an observer array. See
+[references/field-computation.md](references/field-computation.md) for the
+functional interface (`magpy.func.*`), which computes many parameter sets at
+once without creating objects.
+
+## Observers and sensors
+
+```python
+sensor = magpy.Sensor(
+    position=(0, 0, 0.01),
+    pixel=[(0, 0, 0), (0.001, 0, 0)],  # local coordinates, m
+    handedness="right",
+)
+```
+
+A sensor reports the field **in its own frame**: rotate the sensor and the
+returned vector components rotate with it. That is the point of sensors — for
+raw global-frame values, pass position arrays instead.
+
+## Position, orientation, and paths
+
+`position` is a point `(x, y, z)` or a sequence of points; `orientation` is a
+`scipy.spatial.transform.Rotation` (never Euler tuples) or `None` for identity.
+Together they form the object's **path**, and a field computation runs over the
+whole path at once.
+
+```python
+from scipy.spatial.transform import Rotation as R
+
+cube.position = np.linspace((0, 0, 0.01), (0, 0, 0.05), 50)  # 50-step path
+cube.rotate(R.from_rotvec((0, 0, 90), degrees=True), anchor=(0, 0, 0))
+```
+
+`move()` and `rotate()` behave differently for scalar and vector input, and the
+default `start="auto"` means scalar input _transforms the existing path_ while
+vector input _appends to it_. This trips up nearly everyone; read
+[references/position-paths.md](references/position-paths.md) before writing
+multi-step motion, and note that physical attributes (`current`, `dimension`,
+`polarization`, `vertices`, …) can carry a path too.
+
+## Collections
+
+```python
+array = magpy.Collection(magnet1, magnet2, sensor)
+array.rotate(R.from_rotvec((0, 0, 45), degrees=True), anchor=(0, 0, 0))
+```
+
+A `Collection` groups objects for common manipulation and spans a local frame
+for its children; moving it moves them while preserving relative placement. It
+is both a source (for `getB`) and a container. Access parts via `.sources`,
+`.observers`, `.collections`, or the `*_all` variants for nested collections.
+
+## Force and torque
+
+```python
+loop = magpy.current.Circle(diameter=0.02, current=10, meshing=40)
+F, T = magpy.getFT(cube, loop, pivot="centroid")
+```
+
+- Numerical, not analytical: targets are discretised, so results depend on
+  `meshing`. Every target except `Dipole` and `Sphere` **must** have `meshing`
+  set, as an integer target number of mesh cells.
+- Output shape is `(s, p, t, 3)` for force and torque, in N and N·m.
+- Torque needs a pivot. `pivot="centroid"` (default) is right for a free body;
+  `pivot=None` gives nonphysical results.
+- **Scale invariance does not hold for forces.** Field results are invariant if
+  every length uses the same unit, but force and torque are not — pass true SI
+  metres.
+
+See [references/force-torque.md](references/force-torque.md) for meshing
+convergence, `eps`, and `return_mesh`.
+
+## Visualisation
+
+```python
+magpy.show(cube, sensor, backend="plotly")
+```
+
+`show()` accepts any number of objects, `backend` (`"matplotlib"`, `"plotly"`,
+`"pyvista"`, or a registered third-party backend), `animation=True` for paths,
+`return_fig=True` to get the figure instead of displaying, and `row`/`col` for
+subplots. Styling is per-object via `obj.style` or globally via
+`magpy.defaults`. See
+[references/visualization.md](references/visualization.md).
+
+## Gotchas
+
+- **v4 code is silently wrong, not broken.**
+  `Cuboid(magnetization=(0, 0, 1000), dimension=(5, 5, 5))` is valid v5 — it
+  means 1000 A/m and a 5 metre cube. Nothing raises; the answer is off by ~1e9.
+  If input looks like millimetres, convert rather than run it.
+- `magnetization` in v4 meant _polarization_. A v4 script's
+  `magnetization=(0, 0, 1000)` (mT) becomes `polarization=(0, 0, 1.0)` (T).
+- `orientation` is a scipy `Rotation`. Passing a tuple of angles raises.
+- `rotate()` with vector input **appends** to the path by default; use `start=0`
+  to transform the existing path instead.
+- `squeeze=True` changes the output rank based on input. Code that indexes
+  `B[:, 0]` breaks the moment a second source or a path appears.
+- `getFT` without `meshing` on a magnet or current target raises — `Dipole` and
+  `Sphere` are the only exceptions.
+- The functional interface moved in v5.2: `getB("Cuboid", ...)` and `getB_dict`
+  are gone, replaced by `magpy.func.cuboid_field(...)` and friends.
+- `misc.Triangle` is a single charged facet, not a closed body. For a solid mesh
+  magnet use `magnet.TriangularMesh`, which validates closedness.
+- Field on a source's own vertices/edges returns 0, not `nan`.
+- `magpy.mu_0` ≠ `4πe-7`. Use the constant when converting M ↔ J.

--- a/src/magpylib/.agents/skills/magpylib/references/field-computation.md
+++ b/src/magpylib/.agents/skills/magpylib/references/field-computation.md
@@ -1,0 +1,102 @@
+# Field computation
+
+Read this when output shapes matter, when many parameter sets must be evaluated,
+or when a computation is too slow.
+
+## Output shape
+
+`getB`/`getH`/`getJ`/`getM` return `(s, p, o, o1, o2, ..., 3)`:
+
+| Axis        | Meaning                                         |
+| ----------- | ----------------------------------------------- |
+| `s`         | number of sources                               |
+| `p`         | path length (longest path among the objects)    |
+| `o`         | number of observers                             |
+| `o1, o2, …` | sensor pixel shape, or the observer array shape |
+| `3`         | field components (x, y, z)                      |
+
+With `squeeze=True` (the default) every axis of length 1 is dropped. A single
+source, no path, one observer therefore yields `(3,)`, while adding a second
+source silently changes the rank to `(2, 3)`.
+
+Pass `squeeze=False` in library code, then index explicitly:
+
+```python
+B = magpy.getB(sources, observers, squeeze=False)  # always 5+ dims
+b_first_source = B[0]
+```
+
+## Observers
+
+Any of these work as `observers`:
+
+- an array-like of shape `(..., 3)` — positions in global coordinates
+- a `Sensor` — the field is returned in the sensor's own frame
+- a `Collection` containing observers
+- a flat list mixing the above
+
+Sensors with **different** pixel shapes cannot be broadcast into one array; pass
+`pixel_agg="mean"` (or any NumPy aggregator name) to reduce each sensor's pixels
+first, which makes the shapes compatible.
+
+## sumup and output
+
+```python
+B = magpy.getB([magnet_a, magnet_b], grid, sumup=True)  # superposition
+df = magpy.getB(sources, sensors, output="dataframe")  # tidy pandas frame
+```
+
+`sumup=True` collapses the source axis by summing — the physically meaningful
+superposition of several sources. `output="dataframe"` is convenient for
+plotting libraries and for `groupby` over sources/sensors/path indices.
+
+## The functional interface
+
+`magpy.func.*` computes fields for many parameter sets without creating objects.
+Use it when the parameters vary, not just the positions — sweeping dimensions,
+polarizations, or currents.
+
+```python
+import numpy as np
+import magpylib as magpy
+
+n = 100_000
+B = magpy.func.cuboid_field(
+    field="B",
+    observers=np.random.rand(n, 3),
+    dimensions=np.random.rand(n, 3),
+    polarizations=np.tile((0, 0, 1.0), (n, 1)),
+)  # (100000, 3)
+```
+
+Available: `circle_field`, `polyline_field`, `cuboid_field`, `cylinder_field`,
+`cylinder_segment_field`, `sphere_field`, `tetrahedron_field`, `dipole_field`,
+`triangle_charge_field`, `triangle_current_field`.
+
+Every function takes `field` (`"B"` or `"H"`), `observers`, its shape and
+excitation parameters, and optional `positions`, `orientations`, `squeeze`.
+Scalar inputs are tiled to the longest input length. Output is `(i, 3)`.
+
+This replaced the v4-era string dispatch: `getB("Cuboid", ...)` and `getB_dict`
+no longer exist.
+
+## Performance
+
+Magpylib vectorises over sources, path steps, observers and pixels in one pass.
+The rule is one `getB` call per experiment:
+
+```python
+# Slow: one call per position
+for z in heights:
+    B.append(magpy.getB(cube, (0, 0, z)))
+
+# Fast: one call, all positions
+B = magpy.getB(cube, [(0, 0, z) for z in heights])
+```
+
+The same applies to moving sources — set a path rather than repositioning in a
+loop (see [position-paths.md](position-paths.md)).
+
+If observers sit inside `Tetrahedron` or `TriangularMesh` bodies and their
+location is known, `in_out="inside"` / `"outside"` skips the per-observer
+containment test.

--- a/src/magpylib/.agents/skills/magpylib/references/field-computation.md
+++ b/src/magpylib/.agents/skills/magpylib/references/field-computation.md
@@ -39,6 +39,19 @@ Sensors with **different** pixel shapes cannot be broadcast into one array; pass
 `pixel_agg="mean"` (or any NumPy aggregator name) to reduce each sensor's pixels
 first, which makes the shapes compatible.
 
+On the source side, a `Collection` behaves as a **single** source — it
+superposes its children internally and contributes one entry to the `s` axis.
+Pass a list of the children instead when the per-source breakdown is wanted:
+
+```python
+magpy.getB(coll, obs).shape  # (3,) — already summed
+magpy.getB(list(coll.sources_all), obs).shape  # (2, 3) — per source
+```
+
+Multiple sources and multiple observers produce **all combinations**, and
+similar sources are grouped and vectorised internally, so one call with many
+inputs beats many calls.
+
 ## sumup and output
 
 ```python

--- a/src/magpylib/.agents/skills/magpylib/references/force-torque.md
+++ b/src/magpylib/.agents/skills/magpylib/references/force-torque.md
@@ -1,0 +1,83 @@
+# Force and torque
+
+Read this when computing `getFT` — holding force, magnetic bearings, actuator
+torque, floating-magnet equilibria — or when force results look mesh-dependent.
+
+```python
+F, T = magpy.getFT(
+    sources,
+    targets,
+    pivot="centroid",
+    eps=1e-5,
+    squeeze=True,
+    meshreport=False,
+    return_mesh=False,
+)
+```
+
+`F` is in newtons, `T` in newton-metres, both shaped `(s, p, t, 3)` — sources,
+path, targets, components — before squeezing.
+
+## Meshing is mandatory
+
+Unlike field computation, force is numerical: each target is discretised and the
+force integral summed over cells. Every target **except `Dipole` and `Sphere`**
+must have `meshing` set, or `getFT` raises `ValueError`.
+
+```python
+loop = magpy.current.Circle(diameter=0.02, current=10, meshing=40)
+cube = magpy.magnet.Cuboid(
+    dimension=(0.01, 0.01, 0.01), polarization=(0, 0, 1.2), meshing=1000
+)
+```
+
+`meshing` is an integer _target_ cell count; the mesher aims for uniform,
+aspect-ratio-1 cells and will not hit the number exactly. Pass `meshreport=True`
+to print the realised cell count per target, and `return_mesh=True` to get the
+mesh dictionaries (`"pts"`, `"moments"` for magnets, `"cvecs"` for currents)
+instead of F and T.
+
+**Always run a convergence check** — double `meshing` until the result stops
+moving:
+
+```python
+for n in (100, 400, 1600, 6400):
+    cube.meshing = n
+    F, _ = magpy.getFT(source, cube)
+    print(n, F)
+```
+
+## Scale invariance does NOT hold
+
+Field computation is scale invariant: a 1 mm magnet at 1 mm distance gives the
+same field as a 1 m magnet at 1 m, so any consistent length unit works. **Force
+and torque break this.** Inputs must be true SI metres or the newtons are
+meaningless.
+
+## Pivot
+
+Torque is defined about a pivot, and the force contributes
+`T_F = F × (r_pivot − r_position)`:
+
+- `pivot="centroid"` (default) — the target's barycenter, correct for a freely
+  floating body.
+- array-like `(3,)` — the same pivot point for every target, e.g. a shaft axis.
+- one pivot per target — an array with one row per target.
+- `pivot=None` — no pivot; results are nonphysical, use only when you know why.
+
+## eps
+
+`eps` is the finite-difference step used for the field gradient on magnet
+targets. The default `1e-5` suits metre-scale problems; a good value is roughly
+`1e-6 ×` the characteristic source size. Too large smears the gradient, too
+small loses precision to floating-point cancellation. It is unused for current
+targets.
+
+## Sanity checks
+
+- Newton's third law: `getFT(a, b)` and `getFT(b, a)` should give opposite
+  forces. A mismatch usually means one target is under-meshed.
+- A target must be a magnet, a current, or a `Dipole`; `CustomSource` cannot be
+  a target.
+- Forces between touching or overlapping bodies are unreliable — the analytical
+  field diverges at surfaces.

--- a/src/magpylib/.agents/skills/magpylib/references/position-paths.md
+++ b/src/magpylib/.agents/skills/magpylib/references/position-paths.md
@@ -46,6 +46,22 @@ Pass an explicit `start=0` to overwrite instead of append.
 about its own `position`, an array-like `(3,)` rotates it about that global
 point — which is how you build orbits and Halbach arrangements.
 
+Prefer the convenience constructors over assembling a `Rotation` yourself; they
+take the same `anchor` and `start`:
+
+| Method                           | Input                        |
+| -------------------------------- | ---------------------------- |
+| `rotate_from_angax(angle, axis)` | angle (°) about a named axis |
+| `rotate_from_rotvec(rotvec)`     | rotation vector              |
+| `rotate_from_euler(angles, seq)` | Euler angles                 |
+| `rotate_from_quat(quat)`         | quaternion                   |
+| `rotate_from_matrix(matrix)`     | rotation matrix              |
+| `rotate_from_mrp(mrp)`           | modified Rodrigues params    |
+
+Each accepts vector input as well, so
+`sensor.rotate_from_angax(np.linspace(0, 360, 37), "z", start=0)` writes a full
+37-step spin over an existing path.
+
 ```python
 # 8 magnets evenly placed on a circle, each rotated about the origin
 magnets = []
@@ -63,20 +79,73 @@ Chained calls compose, and `reset_path()` restores `position=(0, 0, 0)` and
 
 Beyond position and orientation, physical attributes can vary along the path:
 `current`, `diameter`, `dimension`, `polarization`, `magnetization`, `moment`,
-`vertices`. Ask an object which of its attributes support this with
-`obj.path_properties`.
+`vertices`. Ask an object which of its attributes support this — the answer is
+per class:
 
 ```python
-coil = magpy.current.Circle(
-    diameter=np.linspace(0.01, 0.05, 10),  # geometry ramps
-    current=np.linspace(1, 10, 10),  # excitation ramps
-)
+loop = magpy.current.Circle(current=1, diameter=0.01)
+loop.path_properties  # ('position', 'orientation', 'current', 'diameter')
 ```
 
-This models AC or ramped currents, deforming geometry, and thermal expansion
-without a Python loop. Attributes are independent — setting one to a path does
-not lengthen the others; shorter ones are edge-padded to the longest at
-computation time.
+A sinusoidal drive is then one object, not forty:
+
+```python
+t = np.linspace(0, 1, 40)
+coil = magpy.current.Circle(diameter=0.02, current=5 * np.sin(2 * np.pi * t))
+B = magpy.getB(coil, (0, 0, 0.01))  # (40, 3) in one vectorised call
+```
+
+Geometry works the same way — a cube expanding from 10 mm to 11 mm is a path
+over `dimension`, and `vertices` lets a conductor deform:
+
+```python
+side = np.linspace(0.010, 0.011, 20)
+cube = magpy.magnet.Cuboid(
+    dimension=np.column_stack([side, side, side]),
+    polarization=(0, 0, 1),
+)
+cube.dimension.shape  # (20, 3)
+cube.dipole_moment.shape  # (20, 3) — derived properties gain the path axis
+```
+
+### Storage and reconciliation
+
+`position` and `orientation` are special in exactly one respect: they stay
+eagerly synchronised with each other, because geometric consistency is always
+required. **Every other path property is independent, and what you set is what
+is stored** — an attribute keeps the shape it was given and is never expanded to
+match the others.
+
+```python
+cube = magpy.magnet.Cuboid(dimension=(0.01, 0.01, 0.01), polarization=(0, 0, 1))
+cube.position = [(0, 0, z) for z in np.linspace(0, 0.04, 5)]
+np.shape(cube.position)  # (5, 3) — a path
+cube.dimension  # [0.01 0.01 0.01] — untouched
+```
+
+Lengths are reconciled only when they must be — at field, force, and display
+time — on a temporary copy, by two rules:
+
+- **Edge-padding**: when a step beyond an attribute's own length is needed, its
+  last entry is repeated. The object is _static_ beyond its path.
+- **End-slicing**: when a path is automatically shortened, the **end** is kept.
+
+So mismatched lengths inside one object are legal and quiet:
+
+```python
+loop = magpy.current.Circle(current=[1, 2, 3], diameter=0.01)
+loop.position = [(0, 0, 0), (0, 0, 0.01)]  # only 2 steps
+
+magpy.getB(loop, (0, 0, 0.02)).shape  # (3, 3) — runs over 3 steps
+len(loop.position)  # still 2 — padding never rewrote the attribute
+```
+
+The third step reuses the final position while the current keeps changing. This
+is a feature for combining a long excitation with a short motion, and a trap
+when the mismatch was unintentional: nothing raises, so a wrong path length
+shows up only as an unexpected leading axis. The same edge-padding applies
+_between_ objects — when sources of different path lengths are combined, the
+shorter ones are treated as static beyond their end.
 
 ## Frames
 

--- a/src/magpylib/.agents/skills/magpylib/references/position-paths.md
+++ b/src/magpylib/.agents/skills/magpylib/references/position-paths.md
@@ -1,0 +1,87 @@
+# Position, orientation, and paths
+
+Read this before writing any motion — rotation about a point, a swept
+trajectory, a parameter ramp — or when a path came out with the wrong length.
+
+## The path
+
+`position` (shape `(3,)` or `(p, 3)`, metres) and `orientation` (a scipy
+`Rotation` of length 1 or `p`) together define an object's path. Magpylib keeps
+the two the same length. A field computation evaluates every path step at once,
+so paths are the vectorised way to model motion.
+
+```python
+import numpy as np
+import magpylib as magpy
+from scipy.spatial.transform import Rotation as R
+
+cube = magpy.magnet.Cuboid(dimension=(0.01, 0.01, 0.01), polarization=(0, 0, 1))
+cube.position = np.linspace((0, 0, 0.02), (0, 0, 0.10), 50)
+B = magpy.getB(cube, (0, 0, 0))  # (50, 3) — one call, 50 steps
+```
+
+`orientation` must be a `scipy.spatial.transform.Rotation`. A tuple of Euler
+angles raises `MagpylibBadUserInput`.
+
+## move() and rotate()
+
+```python
+obj.move(displacement, start="auto")
+obj.rotate(rotation, anchor=None, start="auto")
+```
+
+The behaviour depends on whether the input is scalar or vector, and this is the
+most common source of surprise:
+
+| Input                          | `start="auto"` means | Effect                                 |
+| ------------------------------ | -------------------- | -------------------------------------- |
+| scalar (one vector / rotation) | `start=0`            | transforms the **whole existing path** |
+| vector (n vectors / rotations) | `start=len(path)`    | **appends** n new steps to the path    |
+
+So `obj.move((0, 0, 0.01))` shifts an existing 50-step path bodily, while
+`obj.move(np.linspace((0, 0, 0), (0, 0, 0.01), 10))` grows the path by 10 steps.
+Pass an explicit `start=0` to overwrite instead of append.
+
+`anchor` is the pivot for rotation: `anchor=None` (default) spins the object
+about its own `position`, an array-like `(3,)` rotates it about that global
+point — which is how you build orbits and Halbach arrangements.
+
+```python
+# 8 magnets evenly placed on a circle, each rotated about the origin
+magnets = []
+for i in range(8):
+    m = magpy.magnet.Cuboid(dimension=(0.01, 0.01, 0.01), polarization=(0, 0, 1))
+    m.position = (0.05, 0, 0)
+    m.rotate(R.from_rotvec((0, 0, i * 45), degrees=True), anchor=(0, 0, 0))
+    magnets.append(m)
+```
+
+Chained calls compose, and `reset_path()` restores `position=(0, 0, 0)` and
+`orientation=None`.
+
+## Path-varying attributes
+
+Beyond position and orientation, physical attributes can vary along the path:
+`current`, `diameter`, `dimension`, `polarization`, `magnetization`, `moment`,
+`vertices`. Ask an object which of its attributes support this with
+`obj.path_properties`.
+
+```python
+coil = magpy.current.Circle(
+    diameter=np.linspace(0.01, 0.05, 10),  # geometry ramps
+    current=np.linspace(1, 10, 10),  # excitation ramps
+)
+```
+
+This models AC or ramped currents, deforming geometry, and thermal expansion
+without a Python loop. Attributes are independent — setting one to a path does
+not lengthen the others; shorter ones are edge-padded to the longest at
+computation time.
+
+## Frames
+
+Shape parameters (`dimension`, `vertices`, sensor `pixel`) are always in the
+object's **local** frame. `position`/`orientation` place that frame in the
+global one. A `Collection` spans its own frame for its children: moving the
+collection moves all children while preserving their relative placement, and
+children remain individually addressable afterwards.

--- a/src/magpylib/.agents/skills/magpylib/references/visualization.md
+++ b/src/magpylib/.agents/skills/magpylib/references/visualization.md
@@ -42,10 +42,25 @@ magpy.defaults.display.backend = "plotly"  # session-wide
 magpy.show(cube, backend="pyvista")  # one call
 ```
 
+All three animate and do subplots; they differ in what else they can draw:
+
+| Capability                              | matplotlib | plotly | pyvista |
+| --------------------------------------- | ---------- | ------ | ------- |
+| `supports_animation`                    | yes        | yes    | yes     |
+| `supports_subplots`                     | yes        | yes    | yes     |
+| `supports_colorgradient`                | **no**     | yes    | yes     |
+| `supports_animation_output` (gif / mp4) | no         | no     | **yes** |
+| `supports_native_traces` (`model3d`)    | yes        | yes    | **no**  |
+
 Rough guidance: matplotlib for static figures in papers and docs, plotly for
-interactive notebook work, pyvista for large meshes and high-quality 3D. Note
-that matplotlib's 3D compositing has no real depth sorting, so overlapping
-bodies can render misleadingly — prefer plotly or pyvista for dense scenes.
+interactive notebook work, pyvista for large meshes, saved animations, and
+high-quality 3D. Matplotlib's 3D compositing has no real depth sorting, so
+overlapping bodies can render misleadingly — prefer plotly or pyvista for dense
+scenes.
+
+A backend handed something it never declared support for warns and falls back
+rather than producing silently wrong output — custom `style.model3d` traces sent
+to pyvista, for instance.
 
 Third-party backends register at runtime with
 `magpy.register_backend(name, show_func, **capabilities)`, or ship in a package
@@ -60,8 +75,9 @@ magpy.show(cube, animation=True)
 ```
 
 `animation=True` plays the object path; `animation=<seconds>` sets the duration.
-Not every backend supports animation — matplotlib does not. Check
-`magpy.defaults.display.animation` for frame-rate and looping options.
+All three built-in backends animate, but only pyvista can write the animation to
+a file (gif or mp4). Check `magpy.defaults.display.animation` for frame-rate and
+looping options.
 
 ## Subplots
 
@@ -95,3 +111,14 @@ cube.style.opacity = 0.5  # or afterwards, by attribute
 Global defaults live under `magpy.defaults.display.style`, and anything left
 unset on an object defers to them. `magpy.defaults.reset()` restores factory
 settings — useful between test cases, since defaults are process-wide state.
+
+## Custom 3D models
+
+`obj.style.model3d` carries extra geometry drawn in place of, or alongside, the
+default body — a dashed outline on a `CustomSource`, a coil former, a housing.
+Build traces with the helpers in `magpy.graphics.model3d`: `make_Cuboid`,
+`make_Prism`, `make_Pyramid`, `make_Ellipsoid`, `make_CylinderSegment`,
+`make_Tetrahedron`, `make_TriangularMesh`, `make_Arrow`; or pass a
+backend-native trace via `magpy.graphics.Trace3d`. Set
+`style.model3d.showdefault = False` to replace the default representation rather
+than add to it. Pyvista does not consume these (see the capability table above).

--- a/src/magpylib/.agents/skills/magpylib/references/visualization.md
+++ b/src/magpylib/.agents/skills/magpylib/references/visualization.md
@@ -1,0 +1,97 @@
+# Visualisation
+
+Read this when producing figures, animating paths, building subplots, or styling
+objects.
+
+## show()
+
+```python
+magpy.show(
+    *objects,
+    backend=None,
+    canvas=None,
+    animation=False,
+    zoom=0,
+    markers=None,
+    return_fig=False,
+    row=None,
+    col=None,
+    style=None,
+)
+```
+
+`show()` takes any number of sources, sensors, and collections. It is also a
+method on every object (`cube.show()`), and `magpy.show(cube, sensor)` draws
+them in one scene.
+
+- `return_fig=True` returns the backend figure instead of displaying it — use
+  this in scripts, tests, and docs builds rather than relying on a display.
+- `canvas` draws into an existing figure/axes/plotter, which is how Magpylib
+  scenes get embedded in a larger dashboard.
+- `zoom` widens (positive) or tightens the automatic bounds.
+- `markers` adds plain position markers for reference points.
+
+## Backends
+
+Built in: `"matplotlib"`, `"plotly"`, `"pyvista"` (see
+`magpy.SUPPORTED_PLOTTING_BACKENDS`). The default is
+`magpy.defaults.display.backend`, itself `"auto"`, which picks by context.
+
+```python
+magpy.defaults.display.backend = "plotly"  # session-wide
+magpy.show(cube, backend="pyvista")  # one call
+```
+
+Rough guidance: matplotlib for static figures in papers and docs, plotly for
+interactive notebook work, pyvista for large meshes and high-quality 3D. Note
+that matplotlib's 3D compositing has no real depth sorting, so overlapping
+bodies can render misleadingly — prefer plotly or pyvista for dense scenes.
+
+Third-party backends register at runtime with
+`magpy.register_backend(name, show_func, **capabilities)`, or ship in a package
+under the `magpylib.backends` entry-point group, after which the name is
+accepted anywhere a built-in one is.
+
+## Animation
+
+```python
+cube.position = np.linspace((0, 0, 0.02), (0, 0, 0.1), 50)
+magpy.show(cube, animation=True)
+```
+
+`animation=True` plays the object path; `animation=<seconds>` sets the duration.
+Not every backend supports animation — matplotlib does not. Check
+`magpy.defaults.display.animation` for frame-rate and looping options.
+
+## Subplots
+
+```python
+with magpy.show_context(cube, sensor, backend="plotly") as sc:
+    sc.show(col=1)  # 3D scene
+    sc.show(col=2, output="Bx")  # field plot of the same objects
+```
+
+`show_context()` collects several `show()` calls into one figure, with `row` and
+`col` placing each panel. `output` selects what a panel draws: `"model3d"` (the
+default) or field components such as `"Bx"`, `"Hz"`, or `"B"` for magnitude,
+plotted over the path.
+
+## Styling
+
+Every object carries a `style` tree, and any style leaf can be set at
+construction with a `style_`-prefixed keyword:
+
+```python
+cube = magpy.magnet.Cuboid(
+    dimension=(0.01, 0.01, 0.01),
+    polarization=(0, 0, 1),
+    style_label="rotor magnet",
+    style_color="crimson",
+    style_magnetization_show=True,
+)
+cube.style.opacity = 0.5  # or afterwards, by attribute
+```
+
+Global defaults live under `magpy.defaults.display.style`, and anything left
+unset on an object defers to them. `magpy.defaults.reset()` restores factory
+settings — useful between test cases, since defaults are process-wide state.

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,9 +1,13 @@
 import importlib.metadata
 import os
+import re
+from pathlib import Path
 
 import pytest
 
 import magpylib as m
+
+SKILL_DIR = Path(m.__file__).parent / ".agents" / "skills" / "magpylib"
 
 
 @pytest.mark.skipif(
@@ -16,3 +20,47 @@ import magpylib as m
 )
 def test_version() -> None:
     assert importlib.metadata.version("magpylib") == m.__version__
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    """Read the SKILL.md YAML frontmatter without depending on a YAML parser."""
+    assert text.startswith("---\n"), "SKILL.md must open with YAML frontmatter"
+    block = text.split("---\n", 2)[1]
+    fields: dict[str, list[str]] = {}
+    key = None
+    for line in block.splitlines():
+        if match := re.match(r"^([a-z][\w-]*):\s*(.*)$", line):
+            key = match.group(1)
+            value = match.group(2)
+            fields[key] = [] if value in {">-", ">", "|", "|-"} else [value]
+        elif key is not None and line.startswith("  "):
+            fields[key].append(line.strip())
+    return {k: " ".join(v) for k, v in fields.items()}
+
+
+def test_agent_skill_is_packaged() -> None:
+    """The Agent Skill ships inside the package, next to the code it describes."""
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_agent_skill_frontmatter() -> None:
+    """Frontmatter follows the Agent Skills spec (https://agentskills.io)."""
+    fields = _frontmatter((SKILL_DIR / "SKILL.md").read_text(encoding="utf-8"))
+
+    name = fields.get("name", "")
+    assert name == SKILL_DIR.name, "name must match the parent directory name"
+    assert re.fullmatch(r"[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?", name)
+    assert "--" not in name
+
+    description = fields.get("description", "")
+    assert description, "description is required"
+    assert len(description) <= 1024, "description exceeds the 1024 character limit"
+
+
+def test_agent_skill_links_resolve() -> None:
+    """Relative links out of SKILL.md point at files that are shipped too."""
+    text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    targets = re.findall(r"\]\((?!https?://|#)([^)]+)\)", text)
+    assert targets, "expected SKILL.md to reference its files in references/"
+    missing = [t for t in targets if not (SKILL_DIR / t).is_file()]
+    assert not missing, f"broken relative links in SKILL.md: {missing}"


### PR DESCRIPTION
## Summary

This PR adds Agent Skills for both Magpylib users and repository contributors.

- Ships a versioned `magpylib` user skill inside the package at `src/magpylib/.agents/skills/magpylib/`, installed as `magpylib/.agents/skills/magpylib/` in wheels and sdists.
- Adds 16 repository development skills under `.agents/skills/` for implementation, review, testing, documentation, research, design, maintenance, and contributor workflows.
- Adds a dedicated Array API development skill grounded in the public Array API specification, official SciPy, NumPy, scikit-learn, and data-apis guidance, plus a dated audit of related Magpylib issues and pull requests.

## Why

Assistants can otherwise generate plausible Magpylib code from pre-v5 assumptions: millimetres instead of metres, millitesla instead of tesla, or `magnetization` where v5 expects `polarization`. These mistakes often execute successfully while producing results wrong by factors of 1e3 to 1e9.

The packaged user skill is version-pinned to the installed Magpylib release. The repository skills separately encode contributor workflows and project-specific validation without shipping that development-only context to end users.

## Packaged user skill

The 309-line `SKILL.md` covers units, sources, field computation and output shapes, sensors, paths, path-varying properties, collections, force and torque, visualization, and common silent failure modes.

Four progressively disclosed references cover:

- field computation;
- position and property paths;
- force and torque;
- visualization.

Three package tests verify that the skill is included, its frontmatter meets the Agent Skills specification, and all relative references resolve.

Users can discover and install it with `uvx library-skills` from [library-skills.io](https://library-skills.io).

## Repository contributor skills

The repository-local suite covers:

- Magpylib development and code review;
- test-driven development;
- Diataxis documentation;
- primary-source research;
- codebase design and domain modeling;
- merge-conflict resolution and Scientific Python Copier updates;
- package-skill maintenance and Agent Skill authoring;
- handoff, clarification, and grilling workflows.

These files remain under `.agents/skills/` and are not package data.

## Array API development skill

The dedicated workflow defines:

- Array API 2024.12 as the initial implementation target supported by `array-api-compat` at the audit date;
- dependency or vendoring, rollout, mixed-input, and capability-matrix decisions required before parallel kernel ports;
- namespace, dtype, device, promotion, mutation, control-flow, and compiled-code boundaries;
- independent evidence requirements for backend execution, GPU preservation, JAX JIT, lazy evaluation, autodiff, precision, and NumPy performance;
- automated CI coverage as a prerequisite for advertising support;
- a public-source inventory of every direct and adjacent Magpylib Array API issue and pull request checked on 2026-08-27.

The inventory records that all 13 open direct Array API PRs were conflicted and had zero checks at the audit date. They are treated as design evidence rather than merge-ready implementations.

## Verification

- Every packaged API claim was checked against the current source, docstrings, documentation examples, or executable behavior.
- `skills-ref validate`: valid packaged skill.
- Wheel and sdist inspection: all packaged skill files are present.
- Scratch installation: `uvx library-skills scan` discovers the installed skill and `install` links it correctly.
- Package work: full suite passed with 1388 passed and 1 skipped.
- Repository skills: YAML/frontmatter parsing, relative-link checks, contamination scans, editor diagnostics, and repository hooks passed.
- `uvx nox -s lint`: passed.

## Repository-root installation caveat

Do not run `library-skills install` at the repository root. Its generated symlink points back into `src/magpylib`; Hatch can then record the skill under the symlink in the sdist while omitting the real package path. Install from a separate consumer project when testing discovery.