### PR TITLE
Rework the docs figure rendering and build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,10 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/_autogen/
+# figures written during the docs build, see docs/_ext/magpydocs.py
+docs/_static/scenes/
+docs/_static/figures/
+docs/_static/static_viewer.html
 
 # PyBuilder
 .pybuilder/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,11 +9,16 @@ build:
     python: "3.14"
   apt_packages:
     - libgl1-mesa-dev # pyvista/VTK needs OpenGL libs
+    - xvfb # conf.py starts it, without a display VTK warns into every page
   commands:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
     - uv sync --group docs
     - uv run sphinx-apidoc -f -T -e -E -M -o docs/_autogen src/magpylib
-    - uv run python -m sphinx -T -b html -d docs/_build/doctrees -D language=en
-      docs $READTHEDOCS_OUTPUT/html
+    # a fixed -j, never auto: sphinx reads auto off the host's core count,
+    # which ignores what the container is actually allotted. Each read worker
+    # drives a notebook kernel carrying pyvista and VTK, ~0.5GB a lane, so the
+    # count has to stay a number we picked against the 7GB build budget.
+    - uv run python -m sphinx -T -j4 -b html -d docs/_build/doctrees -D
+      language=en docs $READTHEDOCS_OUTPUT/html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,9 @@
   namespace, a misspelled `units...` argument to `show()` now raises `TypeError`
   instead of warning, matching how the other namespaces (`animation...`,
   `style...`) already behaved.
+- Reworked the docs build (theme-aware figures, on-demand Pyvista scenes,
+  parallel notebooks) and fixed Pyvista face colors breaking web scene exports
+  ([#988](https://github.com/magpylib/magpylib/pull/988)).
 
 ## [5.2.3] 2026-05-15
 

--- a/docs/_ext/kernel_startup.py
+++ b/docs/_ext/kernel_startup.py
@@ -1,0 +1,10 @@
+"""Register the docs renderers in every notebook kernel.
+
+``conf.py`` copies this into an ipython profile it points the kernels at, so it
+runs before a page's first cell but *inside* the shell. Importing it earlier
+than that - from ``sitecustomize``, say - is measurably wrong: matplotlib then
+resolves its backend before ipython can offer the inline one, picks the
+platform's gui backend instead, and the first ``plt.show()`` blocks forever.
+"""
+
+import magpydocs  # noqa: F401

--- a/docs/_ext/magpydocs.py
+++ b/docs/_ext/magpydocs.py
@@ -1,0 +1,376 @@
+"""Helpers that run inside the notebook kernel rather than in sphinx.
+
+myst-nb executes every page in a kernel that inherits this build's environment
+- which is where the variables used here come from, see ``conf.py`` - and runs
+it with the page's own directory as the working directory, the same assumption
+the pages already make when they read data files out of ``_static``.
+
+Importing this module does two things to the figures the pages produce:
+
+* pyvista scenes are rendered the way the pyvista documentation renders them, a
+  static screenshot in the page plus the scene as a small ``.vtksz`` file that a
+  shared viewer loads only when a reader asks for it. Inlining the viewer with
+  every scene instead - what pyvista's own ``html`` backend does - costs about
+  1 MB per figure, against 9 KB for the scene alone.
+* pyvista screenshots and matplotlib figures are written twice, once for each
+  theme, and the page carries both urls. ``webcode/figures.js`` picks one,
+  so a reader fetches a single variant and it follows the theme toggle.
+
+Pages keep calling ``magpy.show(...)`` unchanged; ``PYVISTA_JUPYTER_BACKEND``
+points pyvista here, and matplotlib arrives through a display formatter.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import itertools
+import os
+import re
+import shutil
+import warnings
+from pathlib import Path
+
+from IPython.display import HTML
+
+BACKEND = "magpylib-docs"
+SCENES = "scenes"
+FIGURES = "figures"
+VIEWER = "static_viewer.html"
+
+#: A scene heavier than this stays a plain screenshot. Interactive scenes are
+#: only fetched on demand, but they are still build output that has to be
+#: stored and served, and geometry-heavy scenes run to tens of megabytes.
+MAX_SCENE_BYTES = 5_000_000
+
+#: The theme's dark palette, for the dark twin of every figure. A scene takes
+#: the colour of the panel it sits in, a matplotlib figure is drawn on
+#: transparency and only needs its ink lightened.
+DARK_PANEL = "#222832"  # --pst-color-on-background
+DARK_INK = "#ced6dd"  # --pst-color-text-base
+DARK_GRID = "#48566b"  # --pst-color-border
+
+#: Background for the dark scene, top and bottom of the gradient. Deliberately
+#: a slate rather than the page colour: a scene is mostly background, so
+#: painting it the colour of the page turns the figure into a black box, and
+#: anything drawn in a dark colour disappears into it. This mirrors what the
+#: light scene does on a white page - a shaded card the objects sit on.
+DARK_SCENE_TOP = "#3b4453"
+DARK_SCENE_BOTTOM = "#242b36"
+
+#: distinguishes the tab controls of two identical scenes on one page
+_ELEMENTS = itertools.count()
+
+
+def _renders_html() -> bool:
+    """Whether this build can use what we emit.
+
+    text/html only outranks the image mime types for an html build, and the
+    urls written here assume the page keeps its source tree depth, which
+    dirhtml does not. Anywhere else, hand back to the native output.
+    """
+    return os.environ.get("MAGPYLIB_DOCS_BUILDER") == "html"
+
+
+def _static() -> Path:
+    """Absolute path of the docs ``_static`` directory."""
+    return Path(os.environ["MAGPYLIB_DOCS_STATIC"])
+
+
+def _static_url() -> str:
+    """``_static`` as seen from the page being executed.
+
+    The built page sits at the same depth under the html output directory, so
+    the same relative url works there.
+    """
+    return os.path.relpath(_static(), Path.cwd()).replace(os.sep, "/")
+
+
+def _folder(name: str) -> Path:
+    path = _static() / name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _themed_img(folder: str, name: str, ext: str, alt: str, style: str) -> str:
+    """An image that follows the theme toggle.
+
+    The ``src`` is left to ``webcode/figures.js`` so a reader only ever
+    fetches the variant their theme calls for; the aspect ratio holds the space
+    while it arrives, and noscript keeps the light one working without
+    javascript.
+    """
+    url = f"{_static_url()}/{folder}/{name}"
+    return (
+        f'<img class="magpy-themed" alt="{alt}" style="{style}" '
+        f'data-light="{url}.{ext}" data-dark="{url}-dark.{ext}">'
+        f'<noscript><img src="{url}.{ext}" alt="{alt}"></noscript>'
+    )
+
+
+def _install_viewer(static: Path) -> None:
+    """Copy trame's standalone viewer next to the scenes, once per build."""
+    from trame_vtk.tools.vtksz2html import HTML_VIEWER_PATH  # noqa: PLC0415
+
+    target = static / VIEWER
+    if not target.exists():
+        shutil.copy(HTML_VIEWER_PATH, target)
+
+
+def _tabs(name: str, element: str, body: str, shape: str, interactive: bool) -> str:
+    """The screenshot, and the scene behind a second tab if there is one.
+
+    The markup is sphinx-design's, whose stylesheet every page already loads,
+    so the tabs match the ones written by hand elsewhere in the docs.
+    """
+    if not interactive:
+        return f'<div class="magpy-scene">{body}</div>'
+    # the viewer resolves fileURL against its own location in _static, while
+    # the viewer itself is addressed from the page
+    viewer = f"{_static_url()}/{VIEWER}?fileURL={SCENES}/{name}"
+    return (
+        f'<div class="sd-tab-set magpy-scene" data-viewer="{viewer}.vtksz" '
+        f'data-viewer-dark="{viewer}-dark.vtksz">'
+        f'<input checked="checked" id="{element}-static" name="{element}" type="radio">'
+        f'<label class="sd-tab-label" for="{element}-static">Static Scene</label>'
+        f'<div class="sd-tab-content">{body}</div>'
+        f'<input id="{element}-interactive" name="{element}" type="radio">'
+        f'<label class="sd-tab-label" for="{element}-interactive">Interactive Scene</label>'
+        f'<div class="sd-tab-content">'
+        f'<div class="magpy-scene-viewer" style="aspect-ratio: {shape}"></div>'
+        f"</div>"
+        f"</div>"
+    )
+
+
+def _show_scene(plotter, screenshot=None, **kwargs):  # noqa: ARG001
+    """Render one plotter as a screenshot plus an on-demand interactive scene."""
+    # magpylib renders animations by opening a gif/movie on the plotter and
+    # embeds the result itself; pyvista routes the plotter here afterwards all
+    # the same, and exporting it would write every frame to disk for nothing.
+    # off_screen cannot be used to spot these - pyvista forces it on for every
+    # plotter in a notebook - so key off the writer, as pyvista's scraper does.
+    animation = (
+        getattr(plotter, "_gif_filename", None) is not None
+        or getattr(plotter, "mwriter", None) is not None
+    )
+    if animation or not _renders_html():
+        from pyvista.jupyter.notebook import show_static_image  # noqa: PLC0415
+
+        return show_static_image(plotter, screenshot)
+
+    # the plotter is handed over mid-show and has not rendered yet;
+    # screenshotting it before that segfaults, as pyvista's own handler notes
+    plotter.render()
+
+    payload = plotter.export_vtksz(filename=None)
+    name = hashlib.sha256(payload).hexdigest()[:16]
+
+    scenes = _folder(SCENES)
+    image = plotter.screenshot(scenes / f"{name}.png", return_img=True)
+    interactive = len(payload) <= MAX_SCENE_BYTES
+
+    # The dark twin keeps the gradient that gives the light scene its depth. A
+    # screenshot reuses the last render, so the new background needs one of its
+    # own, and the plotter is handed back as it arrived - a page is free to
+    # show the same plotter again.
+    # captured off the renderers: background_color reports only the bottom of
+    # a gradient, and magpylib's scenes are gradients
+    saved = [
+        (r.GetBackground(), r.GetBackground2(), bool(r.GetGradientBackground()))
+        for r in plotter.renderers
+    ]
+    try:
+        plotter.set_background(DARK_SCENE_BOTTOM, top=DARK_SCENE_TOP)
+        plotter.render()
+        plotter.screenshot(scenes / f"{name}-dark.png")
+        if interactive:
+            # the scene carries its own background, so the viewer needs the
+            # dark export too, or the interactive tab lights up on a dark page
+            (scenes / f"{name}.vtksz").write_bytes(payload)
+            (scenes / f"{name}-dark.vtksz").write_bytes(
+                plotter.export_vtksz(filename=None)
+            )
+            _install_viewer(_static())
+    finally:
+        for renderer, (bottom, top, gradient) in zip(
+            plotter.renderers, saved, strict=True
+        ):
+            renderer.SetBackground(bottom)
+            renderer.SetBackground2(top)
+            renderer.SetGradientBackground(gradient)
+        plotter.render()
+
+    height, width = image.shape[:2]
+
+    shape = f"{width} / {height}"
+    body = _themed_img(SCENES, name, "png", "3d scene", f"aspect-ratio: {shape}")
+    # the file name is a content hash, so two identical scenes on one page
+    # would share their radio ids and drive each other
+    element = f"{name}-{next(_ELEMENTS)}"
+    return HTML(_tabs(name, element, body, shape, interactive=interactive))
+
+
+def _save_svg(fig) -> bytes:
+    buffer = io.BytesIO()
+    # bbox_inches matches what the inline backend does, transparency lets the
+    # page - light or dark - show through. Layout warnings raised by this
+    # render are ours, not the page's: they would surface as stderr blocks in
+    # the docs, which the single inline render this replaces never produced.
+    with warnings.catch_warnings():
+        # not filtered by module: matplotlib raises these through
+        # warn_external, which attributes them to this file
+        warnings.simplefilter("ignore", UserWarning)
+        # no Date in the metadata: the file name is a content hash, and a
+        # timestamp would give the same figure a new name on every save
+        fig.savefig(
+            buffer,
+            format="svg",
+            transparent=True,
+            bbox_inches="tight",
+            metadata={"Date": None},
+        )
+    return buffer.getvalue()
+
+
+def _svg_size(payload: bytes) -> tuple[float, float]:
+    """Width and height of an svg in css pixels, for the aspect ratio."""
+    head = payload[:400].decode("utf8", errors="replace")
+    width = re.search(r'width="([\d.]+)pt"', head)
+    height = re.search(r'height="([\d.]+)pt"', head)
+    if not (width and height):
+        # consumed as css pixels: a bare ratio here would lay the figure out
+        # four pixels wide
+        return (640.0, 480.0)
+    return (float(width.group(1)) * 4 / 3, float(height.group(1)) * 4 / 3)
+
+
+def _darken(fig) -> None:
+    """Lighten a figure's ink so it reads on the dark page.
+
+    Applied to a copy of the figure - mutating the original would change what a
+    second display of it renders, and the file names are content hashes.
+    """
+    fig.patch.set_alpha(0)
+    if fig._suptitle is not None:
+        fig._suptitle.set_color(DARK_INK)
+    for ax in fig.axes:
+        ax.patch.set_alpha(0)
+        ax.tick_params(colors=DARK_INK, which="both")
+        for spine in ax.spines.values():
+            spine.set_color(DARK_GRID)
+        for text in (ax.title, *ax.texts, *ax.get_xticklabels(), *ax.get_yticklabels()):
+            text.set_color(DARK_INK)
+        legend = ax.get_legend()
+        if legend is not None:
+            legend.get_frame().set_facecolor(DARK_PANEL)
+            legend.get_frame().set_edgecolor(DARK_GRID)
+            for text in legend.get_texts():
+                text.set_color(DARK_INK)
+        for name in ("xaxis", "yaxis", "zaxis"):
+            axis = getattr(ax, name, None)
+            if axis is None:
+                continue
+            axis.label.set_color(DARK_INK)
+            # 3d axes draw their own panes and grid, out of reach of spines
+            pane = getattr(axis, "pane", None)
+            if pane is not None:
+                pane.set_facecolor(DARK_PANEL)
+                pane.set_edgecolor(DARK_GRID)
+                pane.set_alpha(1)
+            info = getattr(axis, "_axinfo", None)
+            if info and "grid" in info:
+                info["grid"]["color"] = DARK_GRID
+        for text in getattr(ax, "get_zticklabels", list)():
+            text.set_color(DARK_INK)
+
+
+def _drop_inline_figure_output() -> None:
+    """Stop the inline backend rendering a figure we are about to render.
+
+    text/html outranks the image mime types in myst-nb, so the inline output
+    would be ignored anyway - it would just cost another render per figure.
+    Done lazily, because magpylib configures the inline backend on import,
+    which is after this module is loaded.
+    """
+    from IPython import get_ipython  # noqa: PLC0415
+    from matplotlib.figure import Figure  # noqa: PLC0415
+
+    shell = get_ipython()
+    if shell is None:  # pragma: no cover - not running under a kernel
+        return
+    if not _renders_html():
+        return
+    for mime in ("image/png", "image/svg+xml", "image/jpeg", "application/pdf"):
+        shell.display_formatter.formatters[mime].type_printers.pop(Figure, None)
+
+
+def _dark_twin(fig):
+    """A darkened copy of a figure, or None if it cannot be copied.
+
+    A pickle round-trip is matplotlib's own way of copying a figure. The copy
+    is registered with pyplot like any other figure, so the caller has to close
+    it: left open, the next cell's flush would display it as an output of its
+    own. Darkening the original instead is not an option - it would change what
+    a second display of that figure renders.
+    """
+    import pickle  # noqa: PLC0415
+
+    try:
+        twin = pickle.loads(pickle.dumps(fig))
+    except Exception:  # noqa: BLE001 - any unpicklable artist
+        return None
+    # unpickling re-registers the copy with pyplot, so it is displayed in its
+    # own right unless it is both marked and closed: marked, because a twin
+    # handed back here would be given a twin of its own, and so on
+    twin._magpydocs_twin = True
+    _darken(twin)
+    return twin
+
+
+def _show_figure(fig):
+    """Write a matplotlib figure twice and hand the page both urls."""
+    if not _renders_html():
+        return None  # the inline backend's own image output stands
+    if getattr(fig, "_magpydocs_twin", False):
+        return None  # a dark twin of ours, on its way out
+
+    _drop_inline_figure_output()
+    figures = _folder(FIGURES)
+    light = _save_svg(fig)
+    name = hashlib.sha256(light).hexdigest()[:16]
+    (figures / f"{name}.svg").write_bytes(light)
+
+    width, height = _svg_size(light)
+    style = f"width: {width:.0f}px; max-width: 100%; aspect-ratio: {width:.0f} / {height:.0f}"
+
+    twin = _dark_twin(fig)
+    if twin is None:
+        # nothing to swap to, so the light figure stands on its own
+        return f'<img src="{_static_url()}/{FIGURES}/{name}.svg" alt="figure" style="{style}">'
+
+    import matplotlib.pyplot as plt  # noqa: PLC0415
+
+    try:
+        (figures / f"{name}-dark.svg").write_bytes(_save_svg(twin))
+    finally:
+        plt.close(twin)
+    return _themed_img(FIGURES, name, "svg", "figure", style)
+
+
+def register() -> None:
+    """Point pyvista and matplotlib at the renderers above."""
+    import pyvista as pv  # noqa: PLC0415
+
+    pv.register_jupyter_backend(BACKEND, _show_scene, override=True)
+
+    # A formatter registered against Figure would not survive: magpylib calls
+    # set_matplotlib_formats on import, and IPython implements that by dropping
+    # every registered Figure printer, ours included. A _repr_html_ on the
+    # class is looked up separately, so it stands.
+    from matplotlib.figure import Figure  # noqa: PLC0415
+
+    Figure._repr_html_ = _show_figure
+
+
+register()

--- a/docs/_pages/user_guide/examples/examples_vis_pv_streamlines.md
+++ b/docs/_pages/user_guide/examples/examples_vis_pv_streamlines.md
@@ -41,7 +41,7 @@ strl = grid.streamlines_from_source(
     seed,
     vectors="B",
     max_step_length=0.1,
-    max_time=.02,
+    max_length=.02,
     integration_direction="both",
 )
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -37,3 +37,50 @@ Target the logo text
     font-weight: bold;
     font-size: 1.6em;
 }
+
+
+/*
+Dark mode paints a light panel behind notebook html outputs, on the assumption
+that they are light-only - the same theme rule the image fix above works around.
+Plotly figures follow the page theme themselves (webcode/plotlySync.js), so for
+those the panel is just a bezel. Kept narrow on purpose: dataframes and other
+html outputs still want it.
+*/
+/* Plotly outputs - the figure, and the script-only one holding its config and
+   (since plotly 7) the inlined bundle, which the panel renders as a bare strip
+   above the figure. Both are tagged by webcode/plotlySync.js rather than
+   matched with :has(): re-evaluating a :has() over a multi-megabyte script, in
+   a page plotly keeps mutating, costs enough style invalidation to lock the
+   browser up. `body` is in the selector only to outweigh the theme's rule. */
+html[data-theme=dark] body .bd-content div.cell_output div.text_html.magpy-plotly-output,
+/* and pyvista scenes, which carry their own screenshot and toggle */
+html[data-theme=dark] .bd-content div.cell_output div.text_html:has(div.magpy-scene),
+/* and matplotlib figures, which now arrive as html rather than as an image */
+html[data-theme=dark] .bd-content div.cell_output div.text_html:has(img.magpy-themed) {
+    background: none;
+    padding: 0;
+}
+
+
+/*
+Pyvista scenes rendered by docs/_ext/magpydocs.py: a screenshot, and the scene
+itself behind sphinx-design tabs, see webcode/figures.js.
+*/
+.magpy-scene img,
+.magpy-scene .magpy-scene-viewer {
+    width: 100%;
+}
+
+/* the light twin is what shows without javascript */
+.magpy-themed:not([src]) {
+    visibility: hidden;
+}
+
+/* the viewer fills the box the panel reserves from the screenshot's shape, so
+   switching tabs does not move the page */
+.magpy-scene iframe {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}

--- a/docs/_static/webcode/figures.js
+++ b/docs/_static/webcode/figures.js
@@ -1,0 +1,78 @@
+/*
+Figures written by docs/_ext/magpydocs.py.
+
+Each one comes in two variants, one per theme, and carries both urls rather
+than a src: picking one here means a reader fetches a single variant, and it
+follows the theme toggle. Pyvista scenes additionally carry the scene itself,
+which trame's standalone viewer loads into the Interactive Scene tab the first
+time a reader opens it - on demand, so the megabyte of viewer is not fetched by
+everyone who scrolls past a figure. The scene carries its own background, so
+each theme has its own export to load.
+*/
+(function () {
+    "use strict";
+
+    function isDark() {
+        return document.documentElement.dataset.theme === "dark";
+    }
+
+    function sceneUrl(scene) {
+        return (isDark() && scene.dataset.viewerDark) || scene.dataset.viewer;
+    }
+
+    function applyImages() {
+        var dark = isDark();
+        document.querySelectorAll("img.magpy-themed").forEach(function (image) {
+            var wanted = dark ? image.dataset.dark : image.dataset.light;
+            if (wanted && image.getAttribute("src") !== wanted) {
+                image.setAttribute("src", wanted);
+            }
+        });
+    }
+
+    function applyScenes() {
+        document.querySelectorAll(".magpy-scene").forEach(function (scene) {
+            var frame = scene.querySelector(".magpy-scene-viewer iframe");
+            var wanted = sceneUrl(scene);
+            if (frame && frame.getAttribute("src") !== wanted) {
+                frame.setAttribute("src", wanted);
+            }
+        });
+    }
+
+    function apply() {
+        applyImages();
+        applyScenes();
+    }
+
+    document.addEventListener("change", function (event) {
+        var input = event.target;
+        if (!input.id || !input.id.endsWith("-interactive") || !input.checked) {
+            return;
+        }
+        var scene = input.closest(".magpy-scene");
+        var panel = scene && scene.querySelector(".magpy-scene-viewer");
+        if (!panel || panel.firstChild) {
+            return;
+        }
+        var frame = document.createElement("iframe");
+        frame.src = sceneUrl(scene);
+        // the panel already carries the screenshot's aspect ratio, so the
+        // viewer lands in exactly the box the static tab occupied
+        panel.appendChild(frame);
+    });
+
+    function start() {
+        apply();
+        new MutationObserver(apply).observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ["data-theme"],
+        });
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", start);
+    } else {
+        start();
+    }
+})();

--- a/docs/_static/webcode/plotlySync.js
+++ b/docs/_static/webcode/plotlySync.js
@@ -1,0 +1,209 @@
+/*
+Keep embedded plotly figures in sync with the page they sit on.
+
+Size: a figure is drawn at whatever width its container has at draw time, and
+`responsive: true` only re-draws on a *window* resize event. A figure drawn
+while the layout is still settling therefore stays clipped on the right until
+the reader resizes the browser by hand.
+
+Theme: the theme has no dark-mode story for embedded figures
+(pydata/pydata-sphinx-theme#1248, closed as not planned), so a figure keeps the
+light template it was exported with and glares out of a dark page. Recolor from
+the theme's own CSS variables, and hand the figure back to its embedded template
+- by resetting the very same properties to null - on the way back to light.
+
+Both end up in a single relayout per figure, so a theme switch that also moves
+the layout costs one redraw rather than two. A figure is held back until that
+first relayout has painted, so a dark page never flashes a light figure.
+*/
+(function () {
+    "use strict";
+
+    // 3d scenes and 2d axes are keyed scene/scene2/..., xaxis/xaxis2/...
+    var SCENE = /^scene\d*$/;
+    var AXIS = /^[xy]axis\d*$/;
+    var SWEEPS = 10;
+    var SWEEP_MS = 500;
+    var SETTLE_MS = 150;
+
+    var watched = new WeakSet();
+
+    // plotly 7 puts Plotly on the window; older notebook renderers loaded it
+    // through require.js and stashed it on window._Plotly.
+    function getPlotly() {
+        return window.Plotly || window._Plotly;
+    }
+
+    function cssVar(name, fallback) {
+        var style = window.getComputedStyle(document.documentElement);
+        return style.getPropertyValue(name).trim() || fallback;
+    }
+
+    // null resets a property to the value in the figure's own template
+    function themeUpdate(gd, dark) {
+        var page = dark ? cssVar("--pst-color-background", "#14181e") : null;
+        var pane = dark ? cssVar("--pst-color-on-background", "#222832") : null;
+        var text = dark ? cssVar("--pst-color-text-base", "#ced6dd") : null;
+        var line = dark ? cssVar("--pst-color-border", "#48566b") : null;
+
+        var update = {
+            paper_bgcolor: page,
+            plot_bgcolor: pane,
+            "font.color": text,
+            "legend.bgcolor": dark ? "rgba(0,0,0,0)" : null,
+        };
+        // the animation slider rail is hard-coded in plotly's defaults rather
+        // than taken from the template, so it stays near-white on its own
+        (gd._fullLayout.sliders || []).forEach(function (_, i) {
+            var at = "sliders[" + i + "].";
+            update[at + "bgcolor"] = dark
+                ? cssVar("--pst-color-surface", "#29313d")
+                : null;
+            update[at + "activebgcolor"] = line;
+            update[at + "bordercolor"] = line;
+            update[at + "tickcolor"] = text;
+        });
+        Object.keys(gd._fullLayout).forEach(function (key) {
+            if (SCENE.test(key)) {
+                ["xaxis", "yaxis", "zaxis"].forEach(function (axis) {
+                    var at = key + "." + axis + ".";
+                    update[at + "backgroundcolor"] = pane;
+                    update[at + "gridcolor"] = line;
+                    update[at + "zerolinecolor"] = line;
+                    update[at + "color"] = text;
+                });
+            } else if (AXIS.test(key)) {
+                update[key + ".gridcolor"] = line;
+                update[key + ".zerolinecolor"] = line;
+                update[key + ".linecolor"] = line;
+                update[key + ".color"] = text;
+            }
+        });
+        return update;
+    }
+
+    function sync(gd) {
+        var plotly = getPlotly();
+        var width = gd.clientWidth;
+        if (!plotly || !gd._fullLayout || !width) {
+            return; // not drawn yet
+        }
+        if (gd._magpySyncing) {
+            // recorded as applied only once it has been: a theme change
+            // arriving mid-relayout is picked up when that relayout lands
+            return;
+        }
+        var wanted =
+            document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+        // figures are exported with the light template
+        var recolor = (gd._pstTheme || "light") !== wanted;
+        var refit = Math.abs(gd._fullLayout.width - width) > 1;
+        gd._pstTheme = wanted;
+        if (!recolor && !refit) {
+            return;
+        }
+        var update = recolor ? themeUpdate(gd, wanted === "dark") : {};
+        if (refit) {
+            // what Plotly.Plots.resize does internally, folded into the same
+            // relayout so the two never redraw the figure one after the other
+            delete gd.layout.width;
+            delete gd.layout.height;
+            update.autosize = true;
+        }
+        gd._magpySyncing = true;
+        var done = function () {
+            gd._magpySyncing = false;
+            sync(gd); // in case the theme moved while this was painting
+        };
+        plotly.relayout(gd, update).then(done, done);
+    }
+
+    function watch(gd) {
+        if (watched.has(gd)) {
+            return;
+        }
+        watched.add(gd);
+        if (typeof ResizeObserver === "undefined") {
+            return;
+        }
+        var box = gd.parentElement || gd;
+        var lastWidth = 0;
+        var timer = null;
+        new ResizeObserver(function () {
+            // resizing the figure resizes the box too - only react to width
+            // changes that come from the outside
+            var width = box.clientWidth;
+            if (!width || width === lastWidth) {
+                return;
+            }
+            lastWidth = width;
+            // one reflow arrives as a burst of callbacks, redraw once
+            clearTimeout(timer);
+            timer = setTimeout(function () {
+                sync(gd);
+            }, SETTLE_MS);
+        }).observe(box);
+    }
+
+    // The stylesheet drops the theme's light panel behind plotly's outputs by
+    // class rather than by :has(), which would have to be re-evaluated as
+    // plotly mutates the page.
+    function tagOutput(el) {
+        var output = el.closest && el.closest(".cell_output div.text_html");
+        if (output) {
+            output.classList.add("magpy-plotly-output");
+        }
+    }
+
+    function tagScriptOnlyOutputs() {
+        document.querySelectorAll(".cell_output div.text_html").forEach(function (out) {
+            var children = out.children;
+            if (!children.length) {
+                return;
+            }
+            for (var i = 0; i < children.length; i++) {
+                if (children[i].tagName !== "SCRIPT") {
+                    return;
+                }
+            }
+            out.classList.add("magpy-plotly-output");
+        });
+    }
+
+    function adopt(gd) {
+        tagOutput(gd);
+        if (!watched.has(gd)) {
+            watch(gd);
+        }
+        sync(gd);
+    }
+
+    function sweep() {
+        document.querySelectorAll(".plotly-graph-div").forEach(adopt);
+    }
+
+    function start() {
+        tagScriptOnlyOutputs();
+        sweep();
+        // a figure is only findable once plotly has classed it, which can
+        // land well after DOMContentLoaded
+        var sweeps = 0;
+        var timer = setInterval(function () {
+            sweep();
+            if (++sweeps >= SWEEPS) {
+                clearInterval(timer);
+            }
+        }, SWEEP_MS);
+
+        new MutationObserver(sweep).observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ["data-theme"],
+        });
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", start);
+    } else {
+        start();
+    }
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,29 @@ if platform.system() == "Linux":
         os.system(f"{xvfb} :99 -screen 0 1024x768x24 >/dev/null 2>&1 &")
         os.environ["DISPLAY"] = ":99"
 os.environ["PYVISTA_OFF_SCREEN"] = "true"
-os.environ["PYVISTA_USE_IPYVTK"] = "true"
+# The notebook kernels myst-nb starts inherit this environment: PYTHONPATH puts
+# the docs helpers on their import path, an ipython profile of our own imports
+# them once the shell is up, and the rest tells them where to write figures and
+# which pyvista backend to use - pinning a backend also keeps pyvista from
+# warning, in every pyvista cell, that trame is missing. The profile is
+# generated rather than tracked, so kernels leave their history and pid files
+# in the build directory instead of the source tree.
+_docs_dir = Path(__file__).parent
+_ext_dir = _docs_dir / "_ext"
+_startup_dir = _docs_dir / "_build" / "ipython" / "profile_default" / "startup"
+_startup_dir.mkdir(parents=True, exist_ok=True)
+shutil.copy(_ext_dir / "kernel_startup.py", _startup_dir / "00-magpylib-docs.py")
+os.environ["IPYTHONDIR"] = str(_startup_dir.parents[1])
+os.environ["MAGPYLIB_DOCS_STATIC"] = str(_docs_dir / "_static")
+os.environ["PYTHONPATH"] = os.pathsep.join(
+    p for p in (str(_ext_dir), os.environ.get("PYTHONPATH", "")) if p
+)
+os.environ["PYVISTA_JUPYTER_BACKEND"] = "magpylib-docs"
+# Pin plotly's renderer for the same reason: left to auto-detect it emits a
+# widget mime type when ipywidgets is installed - which pyvista[jupyter] pulls
+# in - and myst-nb renders nothing for it, so every plotly figure vanishes
+# from the page without a warning.
+os.environ["PLOTLY_RENDERER"] = "notebook"
 os.environ["MAGPYLIB_MPL_SVG"] = "true"
 
 # Location of Sphinx files
@@ -22,14 +44,57 @@ sys.path.insert(0, str(Path("./../").resolve()))  ##Add the folder one level abo
 ###)
 
 
-# from sphinx_gallery.sorting import FileNameSortKey
+def _record_builder(app):
+    """Tell the notebook kernels which builder they are feeding.
 
-# pio.renderers.default = "sphinx_gallery"
+    Only an html build renders the text/html figures magpydocs emits; any other
+    builder must keep matplotlib's own image output. This runs on
+    builder-inited - inside setup() the builder does not exist yet - which is
+    still before any notebook is executed.
+    """
+    os.environ["MAGPYLIB_DOCS_BUILDER"] = app.builder.name
+
+
+def _balance_read_order(app, env, docnames):
+    """Spread the executed pages evenly over a parallel build's workers.
+
+    ``sphinx-build -j`` slices this list into contiguous chunks, one per
+    worker, and every notebook lives under ``_pages/user_guide``. Left in the
+    alphabetical order sphinx hands us, the chunks covering that directory get
+    all of the executing and the rest return almost immediately - at ``-j4``
+    two of the six chunks hold no notebook at all, and the build waits on the
+    one holding twelve. Interleaving the executed pages with the cheap ones
+    gives every chunk a comparable share.
+
+    A notebook is recognised the way myst-nb recognises one, by the kernelspec
+    its front matter carries. Only the read order changes, which nothing in the
+    output depends on, and a serial build skips this entirely.
+    """
+    if app.parallel <= 1:
+        return
+    heavy, light = [], []
+    for docname in docnames:
+        head = Path(env.doc2path(docname)).read_text(encoding="utf8", errors="replace")[
+            :2000
+        ]
+        (heavy if "kernelspec" in head else light).append(docname)
+    # each group is spread over the whole range, so sorting on the key merges
+    # them in proportion however lopsided the split is
+    total = len(docnames)
+    order = {}
+    for group in (heavy, light):
+        step = total / len(group) if group else 1
+        order.update({d: i * step for i, d in enumerate(group)})
+    docnames.sort(key=order.__getitem__)
 
 
 def setup(app):
+    app.connect("builder-inited", _record_builder)
+    app.connect("env-before-read-docs", _balance_read_order)
     app.add_css_file("css/stylesheet.css")
     app.add_js_file("webcode/summaryOpen.js")
+    app.add_js_file("webcode/plotlySync.js")
+    app.add_js_file("webcode/figures.js")
 
 
 ###    sphinx.ext.apidoc.main(
@@ -66,13 +131,13 @@ needs_sphinx = "7.2"
 extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
     "sphinx.ext.coverage",
     "sphinx.ext.autosummary",
     "sphinx.ext.ifconfig",
-    "matplotlib.sphinxext.plot_directive",
     "sphinx_copybutton",
     "myst_nb",
-    "sphinx_thebe",
     "sphinx_favicon",
     "sphinx_design",
     "sphinxcontrib.bibtex",
@@ -339,7 +404,6 @@ copybutton_prompt_is_regexp = True
 
 html_js_files = [
     "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js",
-    # "https://unpkg.com/thebe@latest/lib/index.js",
 ]
 
 suppress_warnings = [
@@ -353,27 +417,28 @@ favicons = [
 ]
 
 
+# Kept broad on purpose. Docstrings describe types in prose - "array-like,
+# shape (n,3), default None" - which napoleon hands to the python domain one
+# comma-separated token at a time, so a build without this reports some 4700
+# missing targets, of which only a few hundred name a type that exists.
+# Narrowing it is a docstring job, not a config one. napoleon_preprocess_types
+# with type aliases is not the answer either: it cuts the links intersphinx
+# does resolve from 1386 to 216.
 nitpick_ignore_regex = [(r"py:.*", r".*")]
 
+# Types named in docstrings and signatures link to the project that defines
+# them. Sphinx 9 caches the downloaded inventories, so this costs one fetch per
+# project per build at most.
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
+    "pandas": ("https://pandas.pydata.org/docs", None),
+    "pyvista": ("https://docs.pyvista.org", None),
+    "plotly": ("https://plotly.com/python-api-reference", None),
+}
 
-# sphinx gallery settings
-# sphinx_gallery_conf = {
-#     # convert rst to md for ipynb
-#     # "pypandoc": True,
-#     # path to your example scripts
-#     "examples_dirs": "../examples",
-#     # path to where to save gallery generated output
-#     "gallery_dirs": "auto_examples",
-#     # Remove the "Download all examples" button from the top level gallery
-#     "download_all_examples": False,
-#     # # Remove sphinx configuration comments from code blocks
-#     # "remove_config_comments": True,
-#     # # Sort gallery example by file name instead of number of lines (default)
-#     # "within_subsection_order": FileNameSortKey,
-#     # Modules for which function level galleries are created.  In
-#     "doc_module": "pyvista",
-#     "image_scrapers": ("pyvista", "matplotlib"),
-# }
 
 # import pyvista
 # pyvista.BUILDING_GALLERY = True

--- a/noxfile.py
+++ b/noxfile.py
@@ -73,6 +73,9 @@ def docs(session: nox.Session) -> None:
     shared_args = (
         "-n",  # nitpicky mode
         "-T",  # full tracebacks
+        # execute the notebooks in parallel - they are read, and so run, by one
+        # forked worker per core. conf.py evens out how they are shared.
+        "-j=auto",
         f"-b={args.builder}",
         "docs",
         args.output or f"docs/_build/{args.builder}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,18 +65,16 @@ dev = [
 
 docs = [
   "pydata-sphinx-theme",
-  "sphinx>=7.0,<8.0",
+  "sphinx >=8.2", # pydata-sphinx-theme 0.20 dropped sphinx <=8.1
   "sphinx-design",
-  "sphinx-thebe",
   "sphinx-favicon",
-  "sphinx-gallery",
   "sphinx-copybutton",
   "myst-nb",
   "pandas",
   "numpy-stl",
-  "pyvista",
+  "pyvista[jupyter] >=0.48", # trame ships the scene exporter and the viewer
   "magpylib-material-response",
-  "plotly>=5.16,<6.0", # see https://github.com/executablebooks/myst-nb/issues/667
+  "plotly>=7.0", # see https://github.com/executablebooks/myst-nb/issues/667
   "kaleido==0.2.1", # ulterior versions don't ship chrome,
   "sphinxcontrib-bibtex>=2.6",
 ]

--- a/src/magpylib/_src/display/backend_pyvista.py
+++ b/src/magpylib/_src/display/backend_pyvista.py
@@ -99,9 +99,13 @@ def mesh3d_to_pyvista(trace):
     }
     if facecolor is not None:
         # pylint: disable=unsupported-assignment-operation
-        mesh.cell_data["colors"] = [
-            Color(c, default_color=(0, 0, 0)).int_rgb for c in facecolor
-        ]
+        # uint8, or numpy stores the rgb triples as int64: vtk keeps that
+        # dtype through to the scene export, where it becomes a BigInt64Array
+        # that webgl viewers cannot read - the scene then breaks at this actor
+        mesh.cell_data["colors"] = np.array(
+            [Color(c, default_color=(0, 0, 0)).int_rgb for c in facecolor],
+            dtype=np.uint8,
+        )
         trace_pv.update(
             {
                 "scalars": "colors",

--- a/src/magpylib/_src/utility.py
+++ b/src/magpylib/_src/utility.py
@@ -381,6 +381,9 @@ def is_notebook() -> bool:  # pragma: no cover
     """Check if execution is within a IPython environment"""
     # pylint: disable=import-outside-toplevel
     try:
+        # ipython 9.17 hands out get_ipython through a module __getattr__, so
+        # pylint no longer finds the name by reading the module
+        # pylint: disable-next=no-name-in-module
         from IPython import get_ipython  # noqa: PLC0415
 
         shell = get_ipython().__class__.__name__

--- a/tests/test_display_pyvista.py
+++ b/tests/test_display_pyvista.py
@@ -193,3 +193,25 @@ def test_pyvista_skips_the_title_on_a_subplot_grid():
         title="MY TITLE",
     )
     assert "title" not in plotter.renderer.actors
+
+
+def test_face_colors_stay_uint8():
+    """Face colors must reach vtk as unsigned bytes.
+
+    Handed a list of int triples, numpy makes an int64 array and vtk keeps
+    that dtype into `export_vtksz`, where it becomes a BigInt64Array. Webgl
+    viewers cannot read one, so the exported scene breaks at this actor and
+    everything queued behind it - later actors, the orientation marker - is
+    never drawn, while the desktop render looks perfectly fine.
+    """
+    plotter = magpy.show(magpy.Sensor(), backend="pyvista", return_fig=True)
+
+    colored = [
+        actor.mapper.dataset
+        for actor in plotter.renderer.actors.values()
+        if getattr(getattr(actor, "mapper", None), "dataset", None) is not None
+        and "colors" in actor.mapper.dataset.cell_data
+    ]
+    assert colored, "the sensor is drawn with per-face colors"
+    for dataset in colored:
+        assert dataset.cell_data["colors"].dtype == np.uint8


### PR DESCRIPTION

<img width="1503" height="833" alt="image" src="https://github.com/user-attachments/assets/db0dad27-e666-4c76-baec-74c739278589" />

<img width="1412" height="786" alt="image" src="https://github.com/user-attachments/assets/f263bcb0-689f-4089-8c48-a8b7ef881130" />

Docs figures now follow the light/dark theme toggle, 3D scenes load on demand instead of shipping a viewer with every figure, and the notebooks execute in parallel — a full local docs build goes from **83s to 18s**.

## Theme-aware figures

Pyvista scenes and matplotlib figures are written once per theme, and `webcode/figures.js` picks the variant the reader's theme calls for, so each reader only fetches one of them. Plotly figures are recolored from the theme's own CSS variables by `webcode/plotlySync.js`, which also refits figures that used to sit clipped on the right when they were drawn before the page layout had settled.

## Lighter 3D scenes

A pyvista scene renders as a static screenshot, with the interactive version fetched only when a reader opens the *Interactive Scene* tab — roughly 9 KB per scene, against the ~1 MB that pyvista's own `html` backend inlines into every figure. Read the Docs also gains Xvfb and the OpenGL libraries, so VTK and trame stop writing warnings into every pyvista cell.

## Parallel notebook execution

Notebooks run during Sphinx's read phase, and every extension we load declares `parallel_read_safe`, so `-j` spreads them across one forked worker per core.

Sphinx chunks pages alphabetically and all of our notebooks live under `_pages/user_guide`, so left alone they pile onto a couple of workers while the rest finish immediately — `_balance_read_order` interleaves them with the cheap pages. Read the Docs gets a fixed `-j4` rather than `auto`, because `auto` resolves to the host's core count and ignores what the container is actually allotted.

## Also in here

- **A library fix, not just docs.** `mesh3d_to_pyvista` built an int64 cell array, which VTK carried into `export_vtksz` as a `BigInt64Array` that WebGL cannot read. The scene broke at that actor and everything queued behind it never drew. Desktop rendering was unaffected, which is why it went unnoticed.
- Docs moved onto Sphinx 9 and Plotly 7, with Plotly's renderer pinned so myst-nb keeps rendering its figures.
- One unrelated pylint fix, needed for a green run: IPython 9.17 (released 2026-08-28) resolves `get_ipython` through a module `__getattr__`, which pylint reads as the name being absent. `main` fails the same way on any run from now on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
