### PR TITLE
Add the Array API development skill

### DIFF
--- a/.agents/skills/magpylib-array-api-development/SKILL.md
+++ b/.agents/skills/magpylib-array-api-development/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: magpylib-array-api-development
+description: >-
+  Implement or review Magpylib Array API namespace dispatch, field-kernel ports,
+  capability declarations, and backend tests. Use when converting a core field
+  kernel to an `xp` namespace, choosing an Array API dependency or standard
+  version, adding backend-parametrized tests, or reviewing an Array API pull
+  request in this repository.
+license: BSD-3-Clause
+---
+
+# Magpylib Array API Development
+
+Add backend portability without changing established NumPy results, numerical
+accuracy, or performance unintentionally. Use `magpylib-development` for the
+general repository workflow and `primary-source-research` when behavior depends
+on a current standard or backend release.
+
+## Establish the contract
+
+Before editing the first kernel, establish these repository-level decisions:
+
+1. Target version: choose the standard version to implement. Current tooling
+   implements 2025.12: `array-api-compat` 1.14.0 sets `__array_api_version__` to
+   `2025.12` for every wrapped namespace, `array-api-strict` 2.6 defaults to it,
+   and NumPy 2.5 reports it. Take this from the compatibility changelog and the
+   installed `__array_api_version__`; project landing pages lag by months.
+   Implementing an older revision is a legitimate conservative choice, but then
+   pin it in tests with
+   `array_api_strict.set_array_api_strict_flags(api_version=...)`, because the
+   default follows the newest revision.
+1. Compatibility delivery: choose whether `array-api-compat` is a runtime
+   dependency or vendored through its documented option; a runtime dependency is
+   the recommended default. Do not create an ad hoc fallback. Keep
+   `array-api-strict` to test dependencies only. `array-api-extra` is not
+   optional under this workflow: its `testing` assertions, `at`, and
+   `apply_where` are required below, so add it as a test and runtime dependency
+   or replace those rules deliberately.
+1. Rollout: decide whether dispatch is experimental opt-in or always active and
+   identify the stable public boundary that owns that decision.
+1. Mixed inputs: choose rejection or document one owning input whose namespace
+   and device other inputs follow.
+1. Capability matrix: name every initially supported backend, device, dtype,
+   JIT, lazy, and autodiff combination and its CI coverage.
+
+Record these decisions in the implementing issue or pull request and user-facing
+documentation. Do not begin parallel kernel ports while they remain unresolved.
+
+For each change, state which capabilities it intends to support. Treat each of
+these as an independent claim:
+
+- use of standard Array API operations;
+- execution with each named array library;
+- preservation of a non-CPU device;
+- JAX execution under `jax.jit`;
+- lazy execution without materialization;
+- automatic differentiation;
+- numerical accuracy for each supported dtype.
+
+Do not infer one claim from another. Record unsupported combinations explicitly.
+Read [references/official-guidance.md](references/official-guidance.md) when
+choosing dependencies, dispatch semantics, or a backend test matrix. Consult
+[references/magpylib-array-api-work.md](references/magpylib-array-api-work.md)
+before reusing or superseding earlier Magpylib work; issue #981 is the current
+design source for measured cost, scope, and sequencing in this repository.
+
+## Design the boundary
+
+Current state: the core functions accept a foreign array, coerce it to host, and
+return NumPy with no error or warning, and an `array_api_strict` input fails on
+array iteration. Raising an explicit error for non-NumPy input is an improvement
+worth making before, and independently of, any kernel port.
+
+1. Resolve the namespace once at the public or core computation boundary from
+   every relevant array input with `array_api_compat.array_namespace`. The
+   compatibility layer normalizes supported NumPy, CuPy, PyTorch, Dask, JAX, and
+   other arrays; it is not only a fallback for older NumPy.
+1. Define mixed-input behavior deliberately. Reject mixed non-NumPy namespaces
+   unless the API has a documented owning input whose namespace and device the
+   other inputs follow.
+1. Centralize namespace resolution, coercion, dtype promotion, device handling,
+   backend detection, and test assertions. Do not add per-kernel variants of the
+   same compatibility logic.
+1. Pass `xp` into internal kernels when dispatch has already occurred. Do not
+   repeatedly rediscover it or add an independent backend selector.
+   `_cel_iter_scalarvector(..., xp=, any_=)` in
+   `src/magpylib/_src/fields/special_cel.py` is the established form of this
+   seam in this repository; follow it rather than inventing a second one.
+1. Preserve ordinary NumPy behavior whenever all inputs are NumPy arrays. If an
+   opt-in gate is selected, test both enabled and disabled behavior.
+
+## Port a computation
+
+1. Capture the NumPy baseline with focused accuracy, shape, dtype, warning, and
+   timing checks.
+1. Add a failing test for the smallest capability being introduced.
+1. Replace array operations with operations from `xp`; retain `np` only at a
+   named and tested NumPy-only boundary.
+1. Convert indexed assignment with `array_api_extra.at`, as
+   `xpx.at(arr)[idx].set(value)`. This is the most common single operation in
+   the port: `_src/fields/` holds 389 indexed assignments, of which 160 are
+   plain slice or integer targets that convert mechanically and 229 are mask or
+   fancy-index targets. Use `array_api_extra.apply_where` for value-dependent
+   branches, and `array_api_extra.lazy_apply` only where a Python callback is
+   unavoidable.
+1. Use explicit `dtype=` and, where supported, `device=` for created arrays. Do
+   not rely on NumPy's default `float64` or integer width.
+1. Follow standard promotion rules. Avoid Python scalars changing promotion or
+   forcing values from device arrays.
+1. Avoid mutation, conversion to Python scalars, and value-dependent Python
+   control flow. These commonly break JAX JIT and lazy arrays even when eager
+   execution passes.
+1. Where an iteration count is data-dependent, keep the eager early exit and
+   degrade only lazy backends to a fixed trip count. The Bulirsch `cel` loop
+   converges in two to five iterations depending on geometry, so a worst-case
+   fixed count costs six to sixteen times more work on the elliptic kernels, and
+   is worst in the far field that users sweep over.
+1. Preserve the input namespace and device in array outputs. Never perform an
+   implicit GPU-to-CPU transfer.
+1. Isolate unavoidable compiled NumPy or SciPy calls behind one explicit
+   conversion boundary. Declare the resulting function CPU-only unless tested
+   native delegation provides wider support.
+1. Keep singularity handling, tolerances, broadcasting, and physical field
+   conventions identical unless a separately documented change is required.
+
+Start with a simple, purely array-based kernel. Sequence the rest by the kind of
+indexed assignment rather than by raw count: `field_BH_cylinder_segment.py` has
+the largest total but converts mostly mechanically, while `special_el3.py` is
+almost entirely data-dependent mask assignment and is the genuinely hard file.
+Treat it and the complete elliptic integrals as dedicated algorithmic work
+rather than as an early migration slice.
+
+## Test each advertised capability
+
+- Run existing NumPy tests first and compare against independently established
+  results.
+- Use `array-api-strict` to detect non-standard operations and simulated device
+  assumptions. Disable its `boolean_indexing` and `data_dependent_shapes` flags
+  to surface the mask-indexing patterns that will not port. It is a test
+  dependency, not a production backend.
+- Isolate the backend under test to the function being converted; compute
+  references with NumPy, then convert them into the namespace under test before
+  comparing. Use `array_api_extra.testing` (`assert_close`, `assert_close_nulp`,
+  `assert_equal`, `assert_less`) rather than `numpy.testing`, which forces the
+  comparison onto NumPy and defeats the purpose of the conversion. These
+  assertions check namespace, dtype, shape, and device by default, so a raw
+  NumPy reference passed as `desired` fails on namespace mismatch rather than on
+  values.
+- Test JAX support inside `jax.jit`. An eager JAX pass does not establish JIT
+  support or differentiability.
+- When lazy support is claimed, tag the function with
+  `array_api_extra.testing.lazy_xp_function` and call `patch_lazy_xp_functions`
+  from the test or a fixture; the tag does nothing without it. It jits the
+  function under JAX and raises when Dask materializes the graph. Otherwise
+  declare lazy execution unsupported.
+- Test real libraries and hardware for every documented backend/device pair;
+  strict conformance alone cannot establish GPU behavior.
+- Add explicit gradient tests before claiming autodiff support.
+- Exercise deliberate `float32` and `float64` cases. Do not let backend default
+  dtype settings stand in for precision testing.
+- Benchmark NumPy before and after each kernel conversion. Investigate material
+  regressions rather than accepting portability as justification. Rewriting
+  masks as `apply_where` or `at` can regress the default NumPy users, who are
+  the majority; a NumPy-path performance check in CI is worth adding before the
+  first kernel PR.
+
+Run the focused backend test immediately after the first implementation edit,
+then the corresponding NumPy kernel tests. Widen to the full suite and lint only
+after the focused behavior is stable.
+
+## Document and finish
+
+Document capabilities per public function or coherent API group, including
+backend, CPU/GPU, dtype, JIT, lazy, and autodiff limitations. A capability must
+not be advertised as supported unless an automated test exercises it in CI on
+the relevant backend and device. CI currently runs CPU only, on Ubuntu, Windows,
+and macOS, so GPU support cannot be advertised until a GPU runner exists. Manual
+hardware results belong in a separate provisional tier that is labeled as such
+in the documentation; they do not establish published support, and they are not
+a reason to weaken the CI rule.
+
+A completed slice has focused portable tests, unchanged NumPy accuracy,
+namespace and device assertions, an explicit capability declaration, and a
+recorded NumPy benchmark. Do not merge stale Array API branches wholesale;
+reapply their useful ideas to current kernels and tests.
+
+## Sources
+
+This workflow is derived solely from public specifications, official project
+documentation, public Magpylib issues and pull requests, and the repository's
+current source. Detailed links and applicability notes are in the bundled
+references.

--- a/.agents/skills/magpylib-array-api-development/references/magpylib-array-api-work.md
+++ b/.agents/skills/magpylib-array-api-development/references/magpylib-array-api-work.md
@@ -1,0 +1,89 @@
+# Magpylib Array API Work Inventory
+
+Public GitHub state checked 2026-08-27; pull-request states re-checked
+2026-08-31. Re-query GitHub before acting on status, mergeability, checks, or
+branch divergence. Old pull requests are design and test evidence, not
+authoritative versions of current kernels.
+
+## Direct work
+
+| Item                                                                                    | State                       | Scope                                                     |
+| --------------------------------------------------------------------------------------- | --------------------------- | --------------------------------------------------------- |
+| [#792](https://github.com/magpylib/magpylib/issues/792)                                 | Open issue                  | Original standard-support request and umbrella discussion |
+| [#844](https://github.com/magpylib/magpylib/pull/844)                                   | Closed unmerged, 2026-08-30 | Initial aggregate core conversion                         |
+| [#849](https://github.com/magpylib/magpylib/pull/849)                                   | Open, conflicted PR         | Circle core kernel                                        |
+| [#850](https://github.com/magpylib/magpylib/pull/850)                                   | Open, conflicted PR         | Triangular Mesh core kernel                               |
+| [#851](https://github.com/magpylib/magpylib/pull/851)                                   | Open, conflicted PR         | Sphere core kernel                                        |
+| [#852](https://github.com/magpylib/magpylib/pull/852)                                   | Open, conflicted PR         | Triangle core kernel                                      |
+| [#853](https://github.com/magpylib/magpylib/pull/853)                                   | Open, conflicted PR         | Cylinder Segment core kernel                              |
+| [#854](https://github.com/magpylib/magpylib/pull/854)                                   | Open, conflicted PR         | Cuboid core kernel                                        |
+| [#855](https://github.com/magpylib/magpylib/pull/855)                                   | Open, conflicted PR         | Tetrahedron core kernel                                   |
+| [#856](https://github.com/magpylib/magpylib/pull/856)                                   | Open, conflicted PR         | Polyline core kernel                                      |
+| [#857](https://github.com/magpylib/magpylib/pull/857)                                   | Open, conflicted PR         | Dipole core kernel                                        |
+| [#858](https://github.com/magpylib/magpylib/pull/858)                                   | Open, conflicted PR         | Cylinder core kernel                                      |
+| [#859](https://github.com/magpylib/magpylib/pull/859)                                   | Closed PR                   | Initial core-test submission, superseded by #860          |
+| [#860](https://github.com/magpylib/magpylib/pull/860)                                   | Open, conflicted PR         | Backend-parametrized core tests                           |
+| [#861](https://github.com/magpylib/magpylib/pull/861)                                   | Open, conflicted PR         | Combined utilities, kernels, and tests; stale at audit    |
+| [#866](https://github.com/magpylib/magpylib/issues/866)                                 | Closed issue                | NumFOCUS grant discussion                                 |
+| [NumFOCUS #46](https://github.com/numfocus/small-development-grant-proposals/issues/46) | Not selected                | Public four-stage implementation proposal                 |
+| [#981](https://github.com/magpylib/magpylib/issues/981)                                 | Open issue                  | Measured baseline and migration sequencing; design source |
+
+At the audit date, all thirteen open Array API pull requests reported
+`mergeable_state=dirty`, required review, and had zero checks. #844 has since
+been closed unmerged (2026-08-30), leaving twelve. The combined prototype in
+#861 introduced compatibility helpers, strict/JAX/Dask tests, promotion logic,
+and lazy control-flow experiments. It also retained NumPy coupling, contained
+unfinished or duplicated Cylinder Segment work, and substantially predated
+current `main`.
+
+Read #981 before planning a slice; it is the current design source for scope and
+sequencing.
+
+## Enabling and constraining work
+
+- [#726](https://github.com/magpylib/magpylib/issues/726): dtype and precision
+  policy directly controls portable creation, promotion, and tolerances.
+- [#883](https://github.com/magpylib/magpylib/issues/883): arbitrary batching
+  and broadcasting affect the computation boundary.
+- [#704](https://github.com/magpylib/magpylib/issues/704): functional-interface
+  design affects where namespace dispatch belongs.
+- [#916](https://github.com/magpylib/magpylib/pull/916): merged path-property
+  architecture deferred pure broadcasting and preserved the functional interface
+  partly for future JAX use.
+- [#937](https://github.com/magpylib/magpylib/pull/937): merged SciPy 1.17
+  Rotation adaptation changes an integration surface touched by old branches.
+- [#941](https://github.com/magpylib/magpylib/pull/941) and
+  [#945](https://github.com/magpylib/magpylib/pull/945): merged complete
+  elliptic-integral changes supersede overlapping code in old prototypes.
+- [#893](https://github.com/magpylib/magpylib/issues/893): proposed Dipole
+  far-field fallback introduces value-dependent control-flow and accuracy
+  concerns relevant to JIT and lazy execution.
+- [#795](https://github.com/magpylib/magpylib/pull/795): merged NumPy 2.0
+  support is relevant dependency history, not Array API dispatch support.
+
+## Motivation and exclusions
+
+- [#835](https://github.com/magpylib/magpylib/issues/835),
+  [#827](https://github.com/magpylib/magpylib/issues/827), and
+  [#579](https://github.com/magpylib/magpylib/issues/579) concern performance or
+  alternative compiled cores. They motivate backend work but do not implement
+  Array API dispatch.
+- [#867](https://github.com/magpylib/magpylib/issues/867) concerns rigid
+  transformations and may matter to a later object-level phase.
+- [#692](https://github.com/magpylib/magpylib/issues/692) concerns unit-array
+  interoperability, a related duck-array problem with a distinct contract.
+- [#732](https://github.com/magpylib/magpylib/issues/732) requested finite
+  element core tests and was closed as unnecessary. It is test-history context.
+- [#974](https://github.com/magpylib/magpylib/issues/974) uses “backend” for
+  display testing and is unrelated to numerical Array API backends.
+- Historical item `#668`, referenced from #579, returned HTTP 404 during the
+  audit. Do not infer its title, type, or outcome.
+
+## Recheck procedure
+
+Search the public repository across issues and pull requests for `array api`,
+`array-api`, `array_namespace`, `array-api-compat`, `array-api-strict`, `JAX`,
+`CuPy`, `PyTorch`, `Dask`, `GPU`, `backend`, `autodiff`, `device`, `dtype`,
+`broadcast`, and `batch`. Inspect comments, timelines, linked pull requests, and
+cross-references, then classify new results as direct, enabling, constraining,
+motivating, tangential, or unrelated.

--- a/.agents/skills/magpylib-array-api-development/references/official-guidance.md
+++ b/.agents/skills/magpylib-array-api-development/references/official-guidance.md
@@ -1,0 +1,108 @@
+# Official Array API Guidance
+
+Checked 2026-08-27; version claims re-verified 2026-08-31 against installed
+packages and upstream changelogs. Recheck version-sensitive claims when a new
+standard is published, when `array-api-compat` or a supported backend minimum
+changes, and before changing dependency minimums or advertised capabilities.
+Verify a version from a changelog or an installed `__array_api_version__`, not
+from a project landing page: several landing pages were months out of date at
+the checked date.
+
+## Normative standard
+
+- [Python Array API standard 2025.12](https://data-apis.org/array-api/latest/)
+  is the latest published specification at the checked date. The written
+  specification is authoritative; its verification suite does not yet cover
+  every requirement.
+- [Future API evolution](https://data-apis.org/array-api/latest/future_API_evolution.html)
+  defines date-based versions and requires a compliant namespace to expose
+  `__array_api_version__`.
+- Arrays expose their namespace through `__array_namespace__(api_version=...)`.
+  Consumers should negotiate a version they support instead of assuming the
+  newest standard is implemented by every backend.
+- 2025.12 is the revision that current tooling implements. `array-api-compat`
+  1.14.0 (2026-02-26) targets it and sets `__array_api_version__` to `2025.12`
+  for every wrapped namespace, `array-api-strict` 2.6 defaults to it, and NumPy
+  2.5 reports it. Implementing an older revision is a maintainer decision,
+  recorded in the implementing issue and pinned in tests through
+  `array_api_strict.set_array_api_strict_flags(api_version=...)`.
+- [Lazy versus eager execution](https://data-apis.org/array-api/latest/design_topics/lazy_eager.html)
+  explains why Python truth testing and scalar conversion can force execution or
+  fail for lazy implementations.
+- [Extension namespaces](https://data-apis.org/array-api/latest/extensions/index.html)
+  such as `linalg` and `fft` are optional coherent units. Feature-detect the
+  namespace before relying on one.
+
+## Consumer compatibility tools
+
+- [array-api-compat](https://data-apis.org/array-api-compat/) provides namespace
+  discovery and compatibility wrappers for NumPy, CuPy, PyTorch, Dask, JAX, and
+  other established libraries. It is suitable for runtime use by an
+  array-consuming library and officially supports installation as a dependency
+  or vendoring. Its wrappers implement Array API 2025.12 from 1.14.0 onward; the
+  project landing page still claims 2024.12 and is stale.
+- [array-api-strict](https://data-apis.org/array-api-strict/) deliberately
+  exposes non-portable assumptions during testing. Do not require users to adopt
+  its array objects. Its `boolean_indexing` and `data_dependent_shapes` flags,
+  and its `api_version` flag, are set through `set_array_api_strict_flags(...)`.
+- [array-api-extra](https://data-apis.org/array-api-extra/) provides portable
+  operations outside the standard and testing support for JAX JIT and lazy
+  execution. `at` supplies out-of-place indexed assignment, `apply_where`
+  supplies value-dependent branches that survive the JIT, and `lazy_apply` wraps
+  an unavoidable Python callback. Its
+  [`lazy_xp_function`](https://data-apis.org/array-api-extra/generated/array_api_extra.testing.lazy_xp_function.html)
+  test helper exercises JAX under JIT and guards Dask against unintended
+  computation, and takes effect only when the test or a fixture calls
+  `patch_lazy_xp_functions`. Its
+  [`testing`](https://data-apis.org/array-api-extra/api-testing.html) module
+  provides `assert_close`, `assert_close_nulp`, `assert_equal` and `assert_less`
+  as namespace-aware replacements for the `numpy.testing` assertions; they check
+  namespace, dtype, shape and device by default, so both arguments must already
+  be in the namespace under test.
+
+## Downstream implementation precedents
+
+- [SciPy's Array API developer guide](https://scipy.github.io/devdocs/dev/api-dev/array_api.html)
+  is the most complete public procedure for a scientific array consumer. It
+  resolves `xp` from all inputs, validates and coerces through centralized
+  helpers, converts around compiled calls explicitly, declares per-function
+  capabilities, and requires tests for every advertised capability.
+- SciPy tests NumPy, strict, PyTorch, JAX, and Dask on CPU and CuPy, PyTorch,
+  and JAX on available GPUs. JAX functions are tested under `jax.jit`; lazy Dask
+  tests prevent materialization. SciPy currently permits Dask to be declared
+  unsupported where structural barriers make support disproportionately costly.
+- SciPy has merged Array API support for `scipy.spatial.transform.Rotation`
+  ([scipy#23249](https://github.com/scipy/scipy/pull/23249)), which removes the
+  object-level blocker recorded in Magpylib #792. It landed in SciPy 1.17, which
+  is this repository's declared minimum, so `Rotation` is no longer
+  automatically a NumPy-only boundary.
+- [NumPy Array API compatibility](https://numpy.org/doc/stable/reference/array_api.html)
+  documents support in NumPy's main namespace. The separate `numpy.array_api`
+  module was removed in NumPy 2.0. At the checked date NumPy 2.5 reports
+  `__array_api_version__` of `2025.12`, while that documentation page still
+  states 2024.12.
+- [NEP 56](https://numpy.org/neps/nep-0056-array-api-main-namespace.html)
+  explains the main-namespace design, predictable promotion, device-aware array
+  creation, and why a strict standalone array type is better suited to testing
+  than normal downstream use.
+- [Scikit-learn's Array API guide](https://scikit-learn.org/stable/modules/array_api.html)
+  demonstrates experimental opt-in dispatch, owning-input conversion policies,
+  namespace/device-preserving outputs, strict checks, and real GPU validation.
+
+## Implications for Magpylib
+
+1. Before porting kernels, choose and document the standard version, dependency
+   or vendoring strategy, rollout gate, mixed-input semantics, and CI-backed
+   capability matrix.
+1. Namespace dispatch belongs at a stable computation boundary, not in a global
+   mutable backend setting.
+1. If array arguments already identify namespace and device, separate `xp=` or
+   `device=` public keywords add ambiguity and should normally be avoided.
+1. Creation without an array input may require explicit keyword-only namespace,
+   device, and dtype parameters, but this is a separate API design decision.
+1. Calls into NumPy/SciPy compiled implementations are CPU boundaries. Device
+   transfer must fail clearly rather than happen silently. Check each SciPy
+   surface individually: `Rotation` is no longer one of them.
+1. Array API syntax is only the common vocabulary. Backend availability,
+   accelerator execution, JIT, lazy evaluation, and autodiff require separate
+   implementation and evidence.


### PR DESCRIPTION
Split out of #984. Just the Array API skill now — `magpylib-development` and `primary-source-research` moved down to #993, where everything else can reference them too.

A 192-line `SKILL.md` and two references: current official guidance (108 lines) and an inventory of prior Magpylib Array API work (89 lines). Both carry their own recheck procedure, because version claims and PR status go stale fast.

The skill covers three things.

**The five decisions to settle before parallel kernel ports start:** standard version, dependency delivery, rollout gate, mixed-input semantics, CI-backed capability matrix. All five are posed as questions with a recommended default. Merging this shouldn't ratify a maintainer decision by merge instead of by discussion — the answers belong in the implementing issue.

**The port procedure:** resolve the namespace once at one boundary, explicit dtype and device, standard promotion, what breaks under JIT and lazy backends, and where compiled NumPy/SciPy calls have to be fenced off.

**Evidence per capability.** Backend execution, GPU, JAX JIT, lazy, autodiff, precision and NumPy performance are separate claims, and none of them implies another.

The repo-specific parts come from #981: `xpx.at` for the 389 indexed assignments in `_src/fields/`, `special_el3.py` being the hard file rather than `field_BH_cylinder_segment.py`, the `xp`/`any_` seam already sitting in `special_cel.py`, and the 6–16× lazy penalty on the elliptic kernels.

Why this one first: it's the prerequisite for reorganising #792. Its own rule — don't start parallel kernel ports while the contract is unresolved — is what the twelve open Array API PRs should be triaged against, so it needs a merged home to point at.
