### PR TITLE
Add Magpylib-specific contributor skills

### DIFF
--- a/.agents/skills/agent-skill-authoring/SKILL.md
+++ b/.agents/skills/agent-skill-authoring/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: agent-skill-authoring
+description: >-
+  Design, write, or review repository Agent Skills and their bundled references.
+  Use when adding or revising SKILL.md files, choosing invocation behavior, or
+  improving skill discovery and progressive disclosure.
+license: BSD-3-Clause
+---
+
+# Agent Skill Authoring
+
+Create skills that change agent behavior predictably without loading irrelevant
+material into every request. Use `magpylib-skill-maintenance` as well when the
+target is Magpylib's package-distributed user skill.
+
+## Design
+
+1. Define the task branch the skill owns and a checkable completion condition.
+1. Confirm a skill is the right primitive: use always-on instructions for rules
+   that apply broadly, and a prompt for a single parameterized action.
+1. Choose model invocation only when autonomous discovery or cross-skill use is
+   valuable. Use `disable-model-invocation: true` for explicit utilities whose
+   invocation should remain a human choice.
+1. Write a concise description naming capabilities and genuine trigger branches.
+   The description is the discovery interface, not a summary of every section.
+1. Put ordered actions and universally needed rules in `SKILL.md`. Move
+   branch-specific reference, examples, scripts, and templates into nearby files
+   and link them only where needed.
+
+## Authoring rules
+
+- Match the frontmatter `name` to the containing directory.
+- Keep instructions executable, positive, and specific about observable done
+  conditions.
+- Prefer repository configuration and canonical docs over duplicated facts that
+  will become stale.
+- State tool or environment assumptions and provide a viable fallback.
+- Avoid hidden dependencies on unavailable skills, trackers, agents, or private
+  services.
+- Include provenance and licensing appropriate for shared repository content.
+
+## Validate
+
+Parse the YAML frontmatter, verify required fields and relative links, run the
+repository's formatting and spelling hooks, and test triggering with requests
+that should and should not activate the skill.
+
+## Sources
+
+The format and progressive-disclosure model follow the public
+[Agent Skills specification](https://agentskills.io). Invocation behavior is
+adapted for clients that support explicit model-invocation controls.

--- a/.agents/skills/magpylib-code-review/SKILL.md
+++ b/.agents/skills/magpylib-code-review/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: magpylib-code-review
+description: >-
+  Review Magpylib changes for correctness, regressions, scope, tests, and
+  repository conventions. Use when reviewing a branch, pull request, commit, or
+  working-tree diff in this repository.
+license: BSD-3-Clause
+---
+
+# Magpylib Code Review
+
+Review behavior and risk before style. Use `magpylib-development` for the
+repository's implementation and validation conventions.
+
+## Establish the review target
+
+1. Resolve the comparison point supplied by the user. For a branch or pull
+   request, compare against its merge base; for working-tree changes, include
+   staged and unstaged changes.
+1. Read the commit list and changed-file summary before individual hunks.
+1. Find the originating GitHub issue, pull request description, or stated user
+   request. If no specification exists, say so and review observable behavior
+   without inventing requirements.
+
+## Review criteria
+
+Inspect the complete diff using parallel read-only agents for independent areas
+when that improves coverage:
+
+- Correctness: wrong results, broken invariants, numerical instability,
+  singularities, shape errors, unit mistakes, and path or collection semantics.
+- Compatibility: public API, typing, warnings, optional dependencies, supported
+  Python versions, and serialized or displayed output.
+- Requirements: missing behavior, partial acceptance criteria, and scope creep.
+- Tests: meaningful regression coverage, independently derived expectations,
+  justified tolerances, and important scalar/vectorized or boundary cases.
+- Maintainability: unnecessary complexity, duplication, misleading names, and
+  changes made outside the abstraction that owns the behavior.
+- Documentation: current signatures, SI units, examples, links, and user-facing
+  behavior reflected in docs or docstrings.
+
+Treat `CONTRIBUTING.md`, `.github/CONTRIBUTING.md`, `pyproject.toml`, and nearby
+tests as authoritative. Tooling enforces formatting; do not report formatter
+preferences as review findings.
+
+## Verify findings
+
+Trace each suspected defect through the controlling code and callers. Run the
+narrowest test or reproducer that can distinguish a real problem from a concern
+when execution is practical. Do not claim a bug from pattern matching alone.
+
+## Report
+
+Lead with findings ordered by severity. For each finding, give a precise file
+location, the failure mode, its impact, and the smallest credible correction.
+Then list open questions and test gaps. If no defects are found, say so and
+state residual risks or validation not performed.
+
+## Sources
+
+This workflow is grounded in Magpylib's contribution guides. Its review criteria
+follow the public
+[Google Engineering Practices review guide](https://google.github.io/eng-practices/review/).

--- a/.agents/skills/magpylib-skill-maintenance/SKILL.md
+++ b/.agents/skills/magpylib-skill-maintenance/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: magpylib-skill-maintenance
+description: >-
+  Create, review, or update Magpylib's package-distributed Agent Skill. Use when
+  changing src/magpylib/.agents/skills, adding skill references, validating
+  Agent Skills metadata, or checking that the skill ships in distributions.
+license: BSD-3-Clause
+---
+
+# Magpylib Skill Maintenance
+
+The user-facing `magpylib` skill is package data under
+`src/magpylib/.agents/skills/magpylib/`. It is versioned with the API it
+describes and discovered from an installed distribution by `library-skills`.
+
+Do not confuse it with repository development skills under `.agents/skills/`.
+Those guide contributors in this checkout and are not part of the installed
+Magpylib package.
+
+## Ground the change
+
+When the request names a specific correction, investigate that assertion and the
+neighboring guidance it affects. When the whole skill may be stale, build a
+complete checklist of its API names, parameters, defaults, units, shapes,
+examples, caveats, and file references. Independent read-only agents may verify
+separate checklist sections when available.
+
+Every technical claim must be supported by current package code, an executable
+check, or canonical documentation. Prefer executable checks for output shapes,
+path behavior, unit-sensitive examples, warnings, and exceptions.
+
+## Authoring rules
+
+- Keep `name: magpylib`; the directory and frontmatter name must match.
+- Make the description specific enough to trigger before stale pre-v5 knowledge
+  is used, especially for units and `polarization` versus `magnetization`.
+- Keep universally needed guidance in `SKILL.md`; place branch-specific detail
+  in `references/` and link it relatively.
+- Use paths valid in the installed package. Do not point users to
+  repository-only source, tests, or docs.
+- Keep examples minimal, executable, and in SI units.
+- Update or remove contradicted claims instead of preserving historical advice.
+
+Author the skill directly at its package path. Do not run `library-skills`
+installation from the repository root: a generated symlink can alter Hatch's
+sdist collection and omit the real packaged skill.
+
+## Validate
+
+Run the focused packaging tests and build both distribution formats:
+
+```console
+uv run pytest tests/test_package.py
+uvx nox -s build
+```
+
+Inspect the wheel and sdist archives to confirm `SKILL.md` and every linked
+reference are present at `magpylib/.agents/skills/magpylib/`. Also parse the
+frontmatter and verify all relative links resolve. A source-tree test alone is
+not sufficient evidence that package data ships.
+
+## Sources
+
+The format follows the public
+[Agent Skills specification](https://agentskills.io) and
+[library-skills](https://library-skills.io/) discovery convention. Package
+placement and the symlink caveat are grounded in this branch's introducing
+commit and `tests/test_package.py`.

--- a/.agents/skills/magpylib-skill-maintenance/SKILL.md
+++ b/.agents/skills/magpylib-skill-maintenance/SKILL.md
@@ -47,17 +47,19 @@ sdist collection and omit the real packaged skill.
 
 ## Validate
 
-Run the focused packaging tests and build both distribution formats:
+Build both distribution formats first, then run the focused packaging tests:
 
 ```console
-uv run pytest tests/test_package.py
 uvx nox -s build
+uv run pytest tests/test_package.py
 ```
 
-Inspect the wheel and sdist archives to confirm `SKILL.md` and every linked
-reference are present at `magpylib/.agents/skills/magpylib/`. Also parse the
-frontmatter and verify all relative links resolve. A source-tree test alone is
-not sufficient evidence that package data ships.
+The order matters. `test_agent_skill_ships_in_distributions` opens the wheel and
+sdist left in `dist/` and asserts that `SKILL.md` and every linked reference are
+present at `magpylib/.agents/skills/magpylib/`; with no artifacts to inspect it
+skips. Every other test in that file resolves through `magpylib.__file__`, which
+is the source tree under an editable install, so it checks the frontmatter and
+relative links but cannot show that package data ships.
 
 ## Sources
 

--- a/.agents/skills/scientific-python-template-update/SKILL.md
+++ b/.agents/skills/scientific-python-template-update/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: scientific-python-template-update
+description: >-
+  Update Magpylib from the scientific-python/cookie Copier template. Use when
+  running or reviewing a Copier update, changing .copier-answers.yml, or
+  reconciling generated template changes with repository customizations.
+license: BSD-3-Clause
+---
+
+# Scientific Python Template Update
+
+Magpylib tracks `gh:scientific-python/cookie` in `.copier-answers.yml`. Template
+updates are integration work: preserve intentional Magpylib customizations while
+accepting applicable upstream improvements.
+
+## Prepare
+
+1. Read `.copier-answers.yml` and the public template release notes.
+1. Record the current and target template revisions.
+1. Review the working tree and preserve any unrelated user changes before the
+   update begins.
+1. Require a clean working tree and use a dedicated update branch. Get explicit
+   approval before stashing, committing, switching branches, or running Copier
+   when the user has not already requested those operations.
+
+## Apply and reconcile
+
+Run `copier update` with the requested template revision and reuse the recorded
+answers unless the update intentionally changes them. Do not edit
+`.copier-answers.yml` manually; Copier documents that this makes later smart
+updates unreliable.
+
+Review every generated change and resolve inline conflict markers or `.rej`
+files according to the selected conflict mode. Compare the result with the
+pre-update commit to confirm that project metadata, dependencies, automation,
+documentation configuration, and Magpylib-specific behavior remain intentional.
+Use repository history when the purpose of an existing customization is unclear.
+
+## Validate
+
+Run the checks affected by the update, followed by the full repository gates:
+
+```console
+uvx nox -s lint
+uvx nox -s pylint
+uvx nox -s tests
+uvx nox -s docs --non-interactive
+uvx nox -s build
+```
+
+Review the final diff against the pre-update commit. Report accepted upstream
+changes, retained project customizations, deliberate departures, unresolved
+conflicts, and any validation that could not run.
+
+## Sources
+
+This workflow follows public
+[Copier update behavior](https://copier.readthedocs.io/en/stable/updating/) and
+Magpylib's recorded use of the `scientific-python/cookie` template.


### PR DESCRIPTION
Split out of #984. Sits on #992, so the diff here is just the four skills.

- `magpylib-code-review` — project review checklist
- `magpylib-skill-maintenance` — keeping the packaged user skill in sync with the API
- `agent-skill-authoring` — referenced by the above, travels with it
- `scientific-python-template-update` — the Copier/cookie update this repo already does

These four are project property: three name Magpylib outright, and the fourth encodes a workflow we already run. Anything that's general engineering practice rather than project policy is in #991, so it can be argued about without holding this up.

It's based on #992 rather than #989 because `magpylib-skill-maintenance` documents the packaged skill's path and validation steps, and those only exist once #992 lands.

Not package data — these stay in `.agents/skills/` and never ship in a wheel.
