### PR TITLE
Add general engineering and workflow skills

### DIFF
--- a/.agents/skills/codebase-design/SKILL.md
+++ b/.agents/skills/codebase-design/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: codebase-design
+description: >-
+  Design or improve module interfaces and architecture. Use when deciding where
+  behavior belongs, reducing a public surface, choosing dependency boundaries,
+  improving testability, or comparing alternative designs before implementation.
+license: BSD-3-Clause
+---
+
+# Codebase Design
+
+Design modules that hide substantial complexity behind a small, coherent
+interface. A module may be a function, class, package, or subsystem; judge it by
+what callers must understand, not by its physical size.
+
+## Design workflow
+
+1. Identify callers, required capabilities, invariants, failure modes, and
+   performance constraints.
+1. Locate the behavior and data that change together. Prefer one owning module
+   over policies repeated across callers.
+1. Sketch at least two materially different interfaces before committing to a
+   difficult-to-reverse design.
+1. Compare alternatives by caller complexity, hidden implementation detail,
+   dependency direction, testability, compatibility, and likely change patterns.
+1. Select the smallest interface that represents current requirements without
+   speculative extension points.
+1. Name the observable tests that can validate the interface independently of
+   its implementation.
+
+## Review questions
+
+- Does removing the module make its complexity reappear across callers? If not,
+  it may only be forwarding calls.
+- Are callers required to coordinate steps or know ordering that the module
+  could own?
+- Do parameters repeatedly travel together as one domain concept?
+- Does a proposed abstraction have more than one real implementation or source
+  of variation?
+- Can tests use the same interface as production callers?
+- Is compatibility preserved, or is the migration explicit and justified?
+
+Prefer dependency injection at genuine variation points, returned results over
+hidden side effects, and composition over inheritance that exposes irrelevant
+behavior. Do not optimize architectural purity at the expense of numerical
+clarity or a stable scientific API.
+
+## Sources
+
+The emphasis on deep modules follows John Ousterhout's _A Philosophy of Software
+Design_. The use of seams for testability follows Michael Feathers' _Working
+Effectively with Legacy Code_.

--- a/.agents/skills/diataxis-documentation/SKILL.md
+++ b/.agents/skills/diataxis-documentation/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: diataxis-documentation
+description: >-
+  Write or review Magpylib documentation using the Diataxis framework. Use when
+  changing tutorials, how-to guides, explanations, API reference, docstrings,
+  examples, or documentation navigation in this repository.
+license: BSD-3-Clause
+---
+
+# Diataxis Documentation
+
+Give each page one primary reader need. Use this skill together with
+`magpylib-development` for repository commands and local writing conventions.
+
+## Classify before writing
+
+- Tutorial: help a learner gain confidence by completing a guided experience.
+- How-to guide: help a competent user accomplish a specific practical task.
+- Reference: provide accurate, complete facts for lookup.
+- Explanation: build understanding of concepts, reasons, and trade-offs.
+
+Do not combine quadrants merely because their material concerns the same API.
+Put each fact in one canonical location, summarize it briefly elsewhere, and
+link to it.
+
+## Magpylib documentation map
+
+- Handwritten MyST pages live in `docs/_pages/`.
+- API pages are generated from NumPy-style public docstrings.
+- Images, videos, data, and web assets live in `docs/_static/`.
+- Navigation begins in `docs/index.md` and the pages it references.
+- Generated files in `docs/_autogen/` are build output; change their source
+  docstrings or Sphinx configuration instead of editing them directly.
+
+## Workflow
+
+1. Identify the target reader, their goal, and the Diataxis quadrant.
+1. Inspect the implementation, existing canonical docs, and neighboring pages.
+1. Choose the canonical location and update navigation when adding a page.
+1. Draft for one reader need, using runnable SI-unit examples where useful.
+1. Verify API names, defaults, shapes, units, and output against current code.
+1. Build the docs in nitpicky mode and repair relevant warnings or broken links.
+
+For tutorials, keep a meaningful result visible at each stage. For how-to
+guides, lead with the task and prerequisites. Keep reference neutral and
+complete. Use explanation for physical concepts, design rationale, and
+trade-offs rather than step-by-step instructions.
+
+## Local writing rules
+
+- Use MyST Markdown conventions in documentation and NumPy style in docstrings.
+- Use the SPOTIN vocabulary from `CONTRIBUTING.md` for axes and shapes.
+- Express examples in Magpylib v5 SI units.
+- Include only the code needed to demonstrate verified behavior.
+- Preserve one canonical home for tables, equations, and behavioral facts.
+- Use descriptive link text and connect new pages to existing navigation.
+
+Validate documentation changes with:
+
+```console
+uvx nox -s docs --non-interactive
+```
+
+## Sources
+
+The four-quadrant method is adapted from the public
+[Diataxis documentation framework](https://diataxis.fr/). Repository placement,
+formatting, and validation come from `docs/README.md`, `CONTRIBUTING.md`, and
+`noxfile.py`.

--- a/.agents/skills/domain-modeling/SKILL.md
+++ b/.agents/skills/domain-modeling/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: domain-modeling
+description: >-
+  Clarify domain concepts, terminology, invariants, and architectural decisions.
+  Use when names are overloaded, code and documentation disagree about a
+  concept, or a consequential design decision needs durable rationale.
+license: BSD-3-Clause
+---
+
+# Domain Modeling
+
+Make the project's language precise enough that code, tests, documentation, and
+discussion refer to the same concepts. In Magpylib, preserve established physics
+terminology and distinguish physical quantities from implementation
+representations.
+
+## Process
+
+1. Collect the terms, relationships, invariants, and concrete scenarios
+   involved.
+1. Compare their use across public APIs, implementation, tests, documentation,
+   issues, and relevant scientific sources.
+1. Surface overloaded or contradictory meanings and propose precise
+   alternatives.
+1. Stress-test the model with boundary cases and counterexamples.
+1. Confirm canonical terms and definitions with the user.
+1. Update the smallest existing canonical documentation location. Create a new
+   glossary only with user agreement and place it within the established docs
+   structure.
+
+Offer an architecture decision record when a design choice significantly affects
+the system and future contributors will need its rationale. Use an existing
+project convention when present; otherwise ask before introducing one. Record
+one decision per document together with its context, considered options,
+consequences, and status.
+
+## Boundaries
+
+A domain glossary describes concepts and language, not file layout or current
+implementation detail. A specification describes required behavior. An ADR
+records why a durable technical choice was made. Assign each fact to one of
+these artifact types and use cross-references where readers need the connection.
+
+## Sources
+
+The ubiquitous-language practice follows Eric Evans' _Domain-Driven Design_.
+Decision-record guidance follows the public
+[Architecture Decision Record collection](https://github.com/architecture-decision-record/architecture-decision-record).

--- a/.agents/skills/grill-me/SKILL.md
+++ b/.agents/skills/grill-me/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: grill-me
+description:
+  Stress-test my current plan, design, or decision through a structured
+  interview.
+disable-model-invocation: true
+license: BSD-3-Clause
+---
+
+# Grill Me
+
+Run the `grilling` workflow on the plan, design, or decision in the current
+conversation. If none is identifiable, ask the user to name the subject in one
+sentence before starting the interview.

--- a/.agents/skills/grilling/SKILL.md
+++ b/.agents/skills/grilling/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: grilling
+description: >-
+  Interview the user to stress-test and clarify a plan, design, or decision. Use
+  when the user asks to be grilled or when consequential requirements remain
+  ambiguous and implementation should wait for explicit decisions.
+license: BSD-3-Clause
+---
+
+# Grilling
+
+Use disciplined Socratic questioning to expose assumptions and make the user's
+reasoning explicit. Research factual questions from the repository or primary
+sources; reserve questions for choices that require human judgment.
+
+## Process
+
+1. State the proposal, desired outcome, and known constraints.
+1. Ask the user to explain the evidence, assumptions, definitions, and expected
+   consequences behind the proposal.
+1. Test the reasoning with counterexamples, boundary cases, and credible
+   alternatives.
+1. Address one coherent topic at a time so answers can inform later questions.
+1. Explain why each question matters and state a recommendation when the
+   available evidence supports one.
+1. Revisit answers that conflict with established constraints or one another.
+1. Summarize decisions, assumptions, rejected alternatives, and remaining open
+   questions for confirmation.
+
+Do not ask the user for facts that can be established from code, documentation,
+tools, or authoritative external sources. Do not begin implementation until the
+user confirms the resulting understanding or explicitly asks to proceed despite
+listed uncertainties.
+
+## Result
+
+The user receives a confirmed account of the proposal, supporting reasons,
+assumptions, trade-offs, and unresolved questions.
+
+## Sources
+
+This method is based on the public tradition of Socratic questioning and
+critical-thinking prompts about clarification, evidence, assumptions,
+alternatives, and consequences.

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: handoff
+description:
+  Create a concise handoff so another agent session can continue the current
+  work.
+argument-hint: Describe the work that should continue after this conversation.
+disable-model-invocation: true
+license: BSD-3-Clause
+---
+
+# Handoff
+
+Write a self-contained Markdown handoff to the operating system's temporary
+directory, outside the repository. Tailor it to any focus supplied by the user.
+
+Include the objective, current state, decisions and rationale, unresolved
+questions, relevant files and symbols, commands and results, working-tree state,
+constraints, and concrete next actions. Add a short suggested-skills section
+using skills actually available in the destination workspace.
+
+Reference existing issues, plans, commits, and diffs rather than reproducing
+them. Exclude secrets, credentials, personal data, and irrelevant conversation.
+Report the resulting file path.

--- a/.agents/skills/resolving-merge-conflicts/SKILL.md
+++ b/.agents/skills/resolving-merge-conflicts/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: resolving-merge-conflicts
+description: >-
+  Resolve an in-progress Git merge, rebase, or cherry-pick conflict by
+  preserving the intended behavior of both sides. Use when conflict markers or
+  unmerged paths are present.
+license: BSD-3-Clause
+---
+
+# Resolving Merge Conflicts
+
+Inspect both changes before deciding what the merged file should contain.
+Preserve user work and obtain explicit approval before aborting or discarding a
+change.
+
+## Process
+
+1. Use `git status` to identify the active operation and every unmerged path.
+1. Read the conflicting commits and the surrounding code to understand what each
+   change was intended to do.
+1. Edit each file to keep one side, the other side, or a combined result. Remove
+   all conflict markers.
+1. Stage each resolved path with `git add` or `git rm` as appropriate.
+1. Review the staged diff and search the repository for remaining markers.
+1. Run focused tests for the affected behavior, followed by the relevant
+   repository checks.
+1. Continue the merge, rebase, or cherry-pick only after validation succeeds.
+
+If the changes are incompatible or the operation targets the wrong base, stop
+and explain the available Git options before modifying more files.
+
+## Sources
+
+The procedure follows Git's conflict markers and index workflow as documented by
+the public
+[GitHub command-line conflict guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line)
+and
+[rebase conflict guide](https://docs.github.com/en/get-started/using-git/resolving-merge-conflicts-after-a-git-rebase).

--- a/.agents/skills/test-driven-development/SKILL.md
+++ b/.agents/skills/test-driven-development/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: test-driven-development
+description: >-
+  Apply test-driven development to Magpylib changes. Use when implementing a
+  feature or bug fix test-first, adding a regression test, or working through a
+  red-green-refactor cycle in this repository.
+license: BSD-3-Clause
+---
+
+# Test-Driven Development
+
+Develop one observable behavior at a time through a red-green-refactor cycle.
+Use this skill together with `magpylib-development` for repository commands and
+conventions.
+
+## Choose the test boundary
+
+Test behavior through the narrowest stable interface used by real callers. A
+public API is preferred, but a package-internal interface is appropriate when
+the task intentionally changes that contract. Avoid private implementation
+details, incidental call order, and snapshots that do not express a meaningful
+contract.
+
+For numerical behavior, obtain expected values independently: use an analytic
+result, symmetry, a trusted reference value, or a cross-interface consistency
+relation. Do not reproduce the implementation formula in the test.
+
+## Cycle
+
+1. State one behavior and the interface through which it is observed.
+1. Add the smallest test that expresses that behavior.
+1. Run only that test and confirm that it fails for the intended reason.
+1. Implement only the behavior required to satisfy that test.
+1. Rerun the same test until it passes without weakening the assertion.
+1. Refactor names, structure, or duplication while keeping the test green.
+1. Repeat for the next behavior, then run the containing test module and the
+   broader validation required by the changed surface.
+
+If the test unexpectedly passes before the implementation changes, prove that it
+can detect the defect before continuing. If it fails because of setup, imports,
+or unrelated state, repair the test until the failure demonstrates the missing
+behavior.
+
+## Magpylib test design
+
+- Match the organization and assertion style of the nearest tests.
+- Include array shape and scalar/vectorized behavior when changing field APIs.
+- Cover path and collection semantics when they affect the changed contract.
+- Treat warnings as part of the behavior; Pytest runs with warnings as errors.
+- Keep tolerances physically and numerically justified. Do not widen them to
+  hide an unexplained discrepancy.
+- Add optional-dependency cases only where the affected boundary requires them.
+
+## Completion
+
+The focused test has been witnessed failing for the intended reason and passing
+after the implementation. The containing module passes, relevant lint checks
+pass, and public behavior changes are reflected in docs or docstrings.
+
+## Sources
+
+This workflow follows the public red-green-refactor practice described by Kent
+Beck in _Test-Driven Development: By Example_, adapted to Magpylib's Pytest
+configuration and the public
+[Scientific Python testing guide](https://learn.scientific-python.org/development/guides/pytest/).

--- a/.agents/skills/wait-what/SKILL.md
+++ b/.agents/skills/wait-what/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: wait-what
+description:
+  Re-explain the last response because it was unclear or assumed too much
+  context.
+disable-model-invocation: true
+license: BSD-3-Clause
+---
+
+# Wait, What?
+
+Re-pitch the preceding explanation in plain language. Start with the missing
+context, define necessary terms, separate facts from recommendations, and give
+one concrete example. Keep established project terminology, but do not assume
+the reader followed earlier reasoning. End with the immediate decision or next
+step, not a repetition of the entire conversation.


### PR DESCRIPTION
Split out of #984. Top of the stack, on #990.

`codebase-design`, `diataxis-documentation`, `domain-modeling`, `grilling`, `grill-me`, `handoff`, `resolving-merge-conflicts`, `test-driven-development`, `wait-what`.

None of these name Magpylib. They're general engineering practice and conversational workflow, and committing them makes them policy that every contributor inherits — a different question from "should the repo document how to port a kernel", so it gets its own PR. For comparison, ruff ships four repo skills and dask one, all project-specific.

Two of these are arguably in the wrong PR: `diataxis-documentation` and `test-driven-development` both reference `docs/_pages/`, the SPOTIN convention and SI units, so they're really project skills. Happy to move them into #990.

Worth knowing when reviewing:

- `grill-me` and `wait-what` are `disable-model-invocation: true`, so they only run when someone asks for them.
- `grill-me` delegates to `grilling`, so those two travel together.

If the answer is "not yet", closing this changes nothing below it.
