### PR TITLE
Ship an official Agent Skill inside the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+- Magpylib now ships an official [Agent Skill](https://agentskills.io) at
+  `magpylib/.agents/skills/magpylib/`, so AI coding assistants get the current
+  API instead of the pre-v5 one they were trained on — SI units, `polarization`
+  over `magnetization`, output shapes, path semantics, and the `meshing`
+  requirement of `getFT()`. It travels inside the wheel and is therefore always
+  in sync with the installed version. Users pick it up with `uvx library-skills`
+  (see [library-skills.io](https://library-skills.io)), which symlinks it into
+  their project's `.agents/skills/`.
 - Extended the path system beyond `position`/`orientation` to object attributes
   ([#916](https://github.com/magpylib/magpylib/pull/916)). Physical properties
   such as `current`, `diameter`, `dimension`, `polarization`, `magnetization`,

--- a/src/magpylib/.agents/skills/magpylib/SKILL.md
+++ b/src/magpylib/.agents/skills/magpylib/SKILL.md
@@ -239,7 +239,8 @@ array.rotate_from_angax(45, "z", anchor=(0, 0, 0))
 A `Collection` groups objects for common manipulation and spans a local frame
 for its children; moving it moves them while preserving relative placement. It
 is both a source (for `getB`) and a container. Access parts via `.sources`,
-`.observers`, `.collections`, or the `*_all` variants for nested collections.
+`.sensors`, `.collections`, `.children`, or the `*_all` variants that recurse
+into nested collections. There is no `.observers`.
 
 Subclassing `Collection` is the documented way to build a parametrised assembly
 — a magnet ring, a coil former — that behaves as one object with its own
@@ -255,7 +256,9 @@ F, T = magpy.getFT(cube, loop, pivot="centroid")
 - Numerical, not analytical: targets are discretised, so results depend on
   `meshing`. Every target except `Dipole` and `Sphere` **must** have `meshing`
   set, as an integer target number of mesh cells.
-- Output shape is `(s, p, t, 3)` for force and torque, in N and N·m.
+- `getFT` returns one array whose leading axis stacks force and torque, which is
+  what `F, T = ...` unpacks. Each of the two is `(s, p, t, 3)` before squeezing,
+  in N and N·m, so the full return is `(2, s, p, t, 3)`.
 - Torque needs a pivot. `pivot="centroid"` (default) is right for a free body;
   `pivot=None` gives nonphysical results.
 - **Scale invariance does not hold for forces.** Field results are invariant if

--- a/src/magpylib/.agents/skills/magpylib/SKILL.md
+++ b/src/magpylib/.agents/skills/magpylib/SKILL.md
@@ -30,8 +30,8 @@ parameter names, and most pre-trained code reproduces the old API.
   `(s, p, o, *pixel, 3)` before squeezing. See
   [Field computation](#field-computation).
 - Never loop in Python over positions or parameters — use a path or the
-  functional interface. See
-  [references/position-paths.md](references/position-paths.md).
+  functional interface. Paths carry physical attributes too, not just motion:
+  see [Path-varying properties](#path-varying-properties).
 - Force and torque: `magpy.getFT(sources, targets)`, and every target except
   `Dipole` and `Sphere` needs `meshing` set. See
   [Force and torque](#force-and-torque).
@@ -79,12 +79,26 @@ Available classes:
 
 All magnets accept `polarization` (T) **or** `magnetization` (A/m). The two are
 codependent, kept in sync as J = µ₀·M, so set one and read either. Prefer
-`polarization` — datasheet remanence B_r is a polarization.
+`polarization`: a datasheet's remanence B_r is a polarization. Use B_r directly
+only when ignoring material response — a real magnet demagnetises itself, so the
+mean polarization sits a few percent below B_r (about 95% of it as a rule of
+thumb, exactly the J at the working point). For an inhomogeneous treatment see
+the `magpylib-material-response` package.
 
 Every source constructor takes `position`, `orientation`, its shape parameters,
 `meshing` (for force targets), and `style`. Shape parameters are given in the
 object's **local** coordinates; `position`/`orientation` place that local frame
-in the global one.
+in the global one. `obj.copy(**kwargs)` clones an object with overrides, which
+is how arrays of near-identical magnets are built.
+
+Two classes need more than a constructor call:
+
+- `magnet.TriangularMesh` builds a solid from a closed surface mesh, via
+  `from_pyvista()` (an STL or any PyVista `PolyData`), `from_ConvexHull()`,
+  `from_triangles()`, or `from_mesh()`. It validates closedness and orientation.
+- `misc.CustomSource(field_func=...)` wraps any callable
+  `field_func(field, observers) -> (n, 3)`, which is how measured or
+  interpolated field data joins a Magpylib scene.
 
 ## Field computation
 
@@ -104,8 +118,15 @@ B = magpy.getB(
 methods on every object, so `cube.getB(sensor)` and `sensor.getB(cube)` give the
 same array.
 
+`getJ` and `getM` describe the material, not a field in space: they return the
+body's own polarization/magnetization **inside** it and exactly zero everywhere
+outside. Inside a magnet the H-field opposes J (the demagnetising field), so
+`getB` inside is not µ₀·`getH` + J by inspection — it is smaller than J.
+
 `observers` is an array of positions with shape `(..., 3)`, a `Sensor`, a
-`Collection`, or a flat list of those.
+`Collection`, or a flat list of those. Note the asymmetry on the source side: a
+`Collection` passed as `sources` counts as **one** source and superposes its
+children, whereas `[child_a, child_b]` keeps a source axis of length 2.
 
 ```python
 import numpy as np
@@ -158,30 +179,71 @@ Together they form the object's **path**, and a field computation runs over the
 whole path at once.
 
 ```python
-from scipy.spatial.transform import Rotation as R
-
 cube.position = np.linspace((0, 0, 0.01), (0, 0, 0.05), 50)  # 50-step path
-cube.rotate(R.from_rotvec((0, 0, 90), degrees=True), anchor=(0, 0, 0))
+cube.rotate_from_angax(90, "z", anchor=(0, 0, 0))  # no scipy import needed
 ```
+
+Reach for the `rotate_from_*` helpers rather than building a `Rotation` by hand:
+`rotate_from_angax`, `rotate_from_rotvec`, `rotate_from_euler`,
+`rotate_from_quat`, `rotate_from_matrix`, `rotate_from_mrp`. They take the same
+`anchor` and `start` arguments as `rotate()`.
 
 `move()` and `rotate()` behave differently for scalar and vector input, and the
 default `start="auto"` means scalar input _transforms the existing path_ while
 vector input _appends to it_. This trips up nearly everyone; read
 [references/position-paths.md](references/position-paths.md) before writing
-multi-step motion, and note that physical attributes (`current`, `dimension`,
-`polarization`, `vertices`, …) can carry a path too.
+multi-step motion.
+
+## Path-varying properties
+
+A path is not restricted to motion. Physical attributes can vary along it too,
+so a current ramps, a coil deforms, or a magnet expands — computed in the same
+single vectorised call. `obj.path_properties` lists which attributes of a class
+support this.
+
+```python
+coil = magpy.current.Circle(
+    diameter=np.linspace(0.01, 0.02, 10),  # geometry ramps
+    current=np.linspace(1, 5, 10),  # excitation ramps
+    position=np.linspace((0, 0, 0), (0, 0, 0.02), 10),  # and it moves
+)
+B = magpy.getB(coil, (0, 0, 0.03))  # (10, 3)
+```
+
+This is the vectorised replacement for a Python loop over parameter values — AC
+or ramped currents, thermal expansion, deforming conductors, parameter sweeps.
+Note that a swept attribute is still **one object** observed at n settings, not
+n objects: the result has a path axis, not a source axis.
+
+Three rules govern it, and they are the part worth remembering:
+
+- **What you set is what is stored.** Attributes are independent (except
+  `position`/`orientation`, which stay synchronised with each other) and are
+  never silently expanded to match one another.
+- **Lengths reconcile only at computation time**, by edge-padding the shorter
+  attributes to the longest — the object is static beyond its own path — on a
+  temporary copy. Your attributes keep the lengths you gave them.
+- **Derived properties follow.** `dipole_moment`, `centroid`, and friends gain a
+  leading path axis when the attributes they are computed from vary.
+
+See [references/position-paths.md](references/position-paths.md) for
+end-slicing, mismatched lengths, and worked examples.
 
 ## Collections
 
 ```python
 array = magpy.Collection(magnet1, magnet2, sensor)
-array.rotate(R.from_rotvec((0, 0, 45), degrees=True), anchor=(0, 0, 0))
+array.rotate_from_angax(45, "z", anchor=(0, 0, 0))
 ```
 
 A `Collection` groups objects for common manipulation and spans a local frame
 for its children; moving it moves them while preserving relative placement. It
 is both a source (for `getB`) and a container. Access parts via `.sources`,
 `.observers`, `.collections`, or the `*_all` variants for nested collections.
+
+Subclassing `Collection` is the documented way to build a parametrised assembly
+— a magnet ring, a coil former — that behaves as one object with its own
+constructor arguments while keeping the full Magpylib API.
 
 ## Force and torque
 
@@ -236,4 +298,12 @@ subplots. Styling is per-object via `obj.style` or globally via
 - `misc.Triangle` is a single charged facet, not a closed body. For a solid mesh
   magnet use `magnet.TriangularMesh`, which validates closedness.
 - Field on a source's own vertices/edges returns 0, not `nan`.
+- `getJ()`/`getM()` return zero outside the body. They are not "the field" — for
+  that, use `getB()`/`getH()`.
+- A `Collection` as `sources` is one source, not many: `getB(coll, obs)` already
+  superposes its children, so summing the result again double-counts.
+- Setting one path property does not lengthen the others. A `current` of 3 steps
+  with a `position` of 2 computes over 3 steps, with the object parked at its
+  last position — no error, so check `path_properties` lengths when a result has
+  an unexpected first axis.
 - `magpy.mu_0` ≠ `4πe-7`. Use the constant when converting M ↔ J.

--- a/src/magpylib/.agents/skills/magpylib/SKILL.md
+++ b/src/magpylib/.agents/skills/magpylib/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: magpylib
+description: >-
+  Use when writing, reviewing, or debugging Python code that computes magnetic
+  fields, forces, or torques — magnets, coils, current loops, Halbach arrays,
+  field sensors, magnetic simulations — even when the user never says
+  "Magpylib". Covers source and sensor objects, getB/getH/getJ/getM and their
+  output shapes, positions/orientations/paths, collections, force and torque via
+  getFT, the functional interface, and show() visualisation. Magpylib v5+ takes
+  SI units (metres, tesla, amperes) and prefers `polarization` over
+  `magnetization`; code written from pre-v5 memory silently produces answers
+  that are wrong by factors of 1e3 to 1e9, so use this skill before writing any
+  Magpylib code rather than after the numbers look odd.
+license: BSD-3-Clause
+---
+
+# Magpylib
+
+Official skill, shipped inside the `magpylib` package and versioned with it.
+Prefer it over recalled API knowledge: the v4 → v5 transition changed units and
+parameter names, and most pre-trained code reproduces the old API.
+
+## Quick reference
+
+- Units are SI throughout: metres, tesla, amperes, degrees. See
+  [Units](#units-are-si-v5-and-later).
+- Magnets take `polarization` (T), not `magnetization` (A/m), unless the user
+  really means M. See [Sources](#sources).
+- Fields: `magpy.getB(sources, observers)`; output shape is
+  `(s, p, o, *pixel, 3)` before squeezing. See
+  [Field computation](#field-computation).
+- Never loop in Python over positions or parameters — use a path or the
+  functional interface. See
+  [references/position-paths.md](references/position-paths.md).
+- Force and torque: `magpy.getFT(sources, targets)`, and every target except
+  `Dipole` and `Sphere` needs `meshing` set. See
+  [Force and torque](#force-and-torque).
+- Read [Gotchas](#gotchas) when a result is off by a suspicious factor, has an
+  unexpected array shape, or a path did not behave as written.
+
+## Units are SI (v5 and later)
+
+| Quantity        | Parameter                           | v5 unit | v4 unit |
+| --------------- | ----------------------------------- | ------- | ------- |
+| Polarization J  | `polarization`, `getJ()`            | T       | —       |
+| Magnetization M | `magnetization`, `getM()`           | A/m     | mT      |
+| Current         | `current`                           | A       | A       |
+| Dipole moment   | `moment`                            | A·m²    | mT·mm³  |
+| B-field         | `getB()`                            | T       | mT      |
+| H-field         | `getH()`                            | A/m     | kA/m    |
+| Lengths         | `position`, `dimension`, `vertices` | m       | mm      |
+| Angles          | `angle`, `dimension` (cylinder φ)   | °       | °       |
+
+A 5 mm cube is `dimension=(0.005, 0.005, 0.005)`, not `(5, 5, 5)`. A typical
+NdFeB remanence of 1.2 T is `polarization=(0, 0, 1.2)`.
+
+`magpy.mu_0` is the vacuum permeability from `scipy.constants` — not
+`4 * np.pi * 1e-7`, since the 2019 SI redefinition.
+
+## Sources
+
+```python
+import magpylib as magpy
+
+cube = magpy.magnet.Cuboid(
+    dimension=(0.005, 0.005, 0.005),  # m
+    polarization=(0, 0, 1.2),  # T
+    position=(0, 0, 0.01),  # m
+)
+loop = magpy.current.Circle(diameter=0.02, current=10)  # m, A
+```
+
+Available classes:
+
+- `magpy.magnet`: `Cuboid`, `Cylinder`, `CylinderSegment`, `Sphere`,
+  `Tetrahedron`, `TriangularMesh`
+- `magpy.current`: `Circle`, `Polyline`, `TriangleSheet`, `TriangleStrip`
+- `magpy.misc`: `Dipole`, `Triangle`, `CustomSource`
+
+All magnets accept `polarization` (T) **or** `magnetization` (A/m). The two are
+codependent, kept in sync as J = µ₀·M, so set one and read either. Prefer
+`polarization` — datasheet remanence B_r is a polarization.
+
+Every source constructor takes `position`, `orientation`, its shape parameters,
+`meshing` (for force targets), and `style`. Shape parameters are given in the
+object's **local** coordinates; `position`/`orientation` place that local frame
+in the global one.
+
+## Field computation
+
+```python
+B = magpy.getB(
+    sources,
+    observers,
+    sumup=False,
+    squeeze=True,
+    pixel_agg=None,
+    output="ndarray",
+    in_out="auto",
+)
+```
+
+`getH`, `getJ`, and `getM` take the same arguments. All four also exist as
+methods on every object, so `cube.getB(sensor)` and `sensor.getB(cube)` give the
+same array.
+
+`observers` is an array of positions with shape `(..., 3)`, a `Sensor`, a
+`Collection`, or a flat list of those.
+
+```python
+import numpy as np
+
+grid = np.mgrid[-0.02:0.02:20j, 0:1:1j, -0.02:0.02:20j].T.reshape(-1, 3)
+B = magpy.getB(cube, grid)  # shape (400, 3)
+```
+
+Output shape before squeezing is `(s, p, o, *pixel_shape, 3)` — sources, path
+length, observers, sensor pixel shape, field components. With `squeeze=True`
+(default) every length-1 axis disappears, which is why a single source at a
+single position returns plain `(3,)`. Pass `squeeze=False` whenever downstream
+code indexes axes positionally.
+
+- `sumup=True` sums the field of all sources into one array.
+- `pixel_agg="mean"` (any NumPy aggregator name) reduces over pixels, and is
+  what lets observers with different pixel shapes be mixed in one call.
+- `output="dataframe"` returns a tidy pandas DataFrame instead of an ndarray.
+- `in_out` declares whether observers sit inside or outside magnet bodies
+  (`"auto"`, `"inside"`, `"outside"`). Setting it skips a per-observer test, but
+  it only affects `Tetrahedron` and `TriangularMesh` — Magpylib warns and
+  ignores it elsewhere.
+
+**One call, many inputs.** Magpylib vectorises everything it is handed. A Python
+loop over `getB` is the single most common performance mistake — it is routinely
+100× slower than passing a path or an observer array. See
+[references/field-computation.md](references/field-computation.md) for the
+functional interface (`magpy.func.*`), which computes many parameter sets at
+once without creating objects.
+
+## Observers and sensors
+
+```python
+sensor = magpy.Sensor(
+    position=(0, 0, 0.01),
+    pixel=[(0, 0, 0), (0.001, 0, 0)],  # local coordinates, m
+    handedness="right",
+)
+```
+
+A sensor reports the field **in its own frame**: rotate the sensor and the
+returned vector components rotate with it. That is the point of sensors — for
+raw global-frame values, pass position arrays instead.
+
+## Position, orientation, and paths
+
+`position` is a point `(x, y, z)` or a sequence of points; `orientation` is a
+`scipy.spatial.transform.Rotation` (never Euler tuples) or `None` for identity.
+Together they form the object's **path**, and a field computation runs over the
+whole path at once.
+
+```python
+from scipy.spatial.transform import Rotation as R
+
+cube.position = np.linspace((0, 0, 0.01), (0, 0, 0.05), 50)  # 50-step path
+cube.rotate(R.from_rotvec((0, 0, 90), degrees=True), anchor=(0, 0, 0))
+```
+
+`move()` and `rotate()` behave differently for scalar and vector input, and the
+default `start="auto"` means scalar input _transforms the existing path_ while
+vector input _appends to it_. This trips up nearly everyone; read
+[references/position-paths.md](references/position-paths.md) before writing
+multi-step motion, and note that physical attributes (`current`, `dimension`,
+`polarization`, `vertices`, …) can carry a path too.
+
+## Collections
+
+```python
+array = magpy.Collection(magnet1, magnet2, sensor)
+array.rotate(R.from_rotvec((0, 0, 45), degrees=True), anchor=(0, 0, 0))
+```
+
+A `Collection` groups objects for common manipulation and spans a local frame
+for its children; moving it moves them while preserving relative placement. It
+is both a source (for `getB`) and a container. Access parts via `.sources`,
+`.observers`, `.collections`, or the `*_all` variants for nested collections.
+
+## Force and torque
+
+```python
+loop = magpy.current.Circle(diameter=0.02, current=10, meshing=40)
+F, T = magpy.getFT(cube, loop, pivot="centroid")
+```
+
+- Numerical, not analytical: targets are discretised, so results depend on
+  `meshing`. Every target except `Dipole` and `Sphere` **must** have `meshing`
+  set, as an integer target number of mesh cells.
+- Output shape is `(s, p, t, 3)` for force and torque, in N and N·m.
+- Torque needs a pivot. `pivot="centroid"` (default) is right for a free body;
+  `pivot=None` gives nonphysical results.
+- **Scale invariance does not hold for forces.** Field results are invariant if
+  every length uses the same unit, but force and torque are not — pass true SI
+  metres.
+
+See [references/force-torque.md](references/force-torque.md) for meshing
+convergence, `eps`, and `return_mesh`.
+
+## Visualisation
+
+```python
+magpy.show(cube, sensor, backend="plotly")
+```
+
+`show()` accepts any number of objects, `backend` (`"matplotlib"`, `"plotly"`,
+`"pyvista"`, or a registered third-party backend), `animation=True` for paths,
+`return_fig=True` to get the figure instead of displaying, and `row`/`col` for
+subplots. Styling is per-object via `obj.style` or globally via
+`magpy.defaults`. See
+[references/visualization.md](references/visualization.md).
+
+## Gotchas
+
+- **v4 code is silently wrong, not broken.**
+  `Cuboid(magnetization=(0, 0, 1000), dimension=(5, 5, 5))` is valid v5 — it
+  means 1000 A/m and a 5 metre cube. Nothing raises; the answer is off by ~1e9.
+  If input looks like millimetres, convert rather than run it.
+- `magnetization` in v4 meant _polarization_. A v4 script's
+  `magnetization=(0, 0, 1000)` (mT) becomes `polarization=(0, 0, 1.0)` (T).
+- `orientation` is a scipy `Rotation`. Passing a tuple of angles raises.
+- `rotate()` with vector input **appends** to the path by default; use `start=0`
+  to transform the existing path instead.
+- `squeeze=True` changes the output rank based on input. Code that indexes
+  `B[:, 0]` breaks the moment a second source or a path appears.
+- `getFT` without `meshing` on a magnet or current target raises — `Dipole` and
+  `Sphere` are the only exceptions.
+- The functional interface moved in v5.2: `getB("Cuboid", ...)` and `getB_dict`
+  are gone, replaced by `magpy.func.cuboid_field(...)` and friends.
+- `misc.Triangle` is a single charged facet, not a closed body. For a solid mesh
+  magnet use `magnet.TriangularMesh`, which validates closedness.
+- Field on a source's own vertices/edges returns 0, not `nan`.
+- `magpy.mu_0` ≠ `4πe-7`. Use the constant when converting M ↔ J.

--- a/src/magpylib/.agents/skills/magpylib/references/field-computation.md
+++ b/src/magpylib/.agents/skills/magpylib/references/field-computation.md
@@ -1,0 +1,102 @@
+# Field computation
+
+Read this when output shapes matter, when many parameter sets must be evaluated,
+or when a computation is too slow.
+
+## Output shape
+
+`getB`/`getH`/`getJ`/`getM` return `(s, p, o, o1, o2, ..., 3)`:
+
+| Axis        | Meaning                                         |
+| ----------- | ----------------------------------------------- |
+| `s`         | number of sources                               |
+| `p`         | path length (longest path among the objects)    |
+| `o`         | number of observers                             |
+| `o1, o2, …` | sensor pixel shape, or the observer array shape |
+| `3`         | field components (x, y, z)                      |
+
+With `squeeze=True` (the default) every axis of length 1 is dropped. A single
+source, no path, one observer therefore yields `(3,)`, while adding a second
+source silently changes the rank to `(2, 3)`.
+
+Pass `squeeze=False` in library code, then index explicitly:
+
+```python
+B = magpy.getB(sources, observers, squeeze=False)  # always 5+ dims
+b_first_source = B[0]
+```
+
+## Observers
+
+Any of these work as `observers`:
+
+- an array-like of shape `(..., 3)` — positions in global coordinates
+- a `Sensor` — the field is returned in the sensor's own frame
+- a `Collection` containing observers
+- a flat list mixing the above
+
+Sensors with **different** pixel shapes cannot be broadcast into one array; pass
+`pixel_agg="mean"` (or any NumPy aggregator name) to reduce each sensor's pixels
+first, which makes the shapes compatible.
+
+## sumup and output
+
+```python
+B = magpy.getB([magnet_a, magnet_b], grid, sumup=True)  # superposition
+df = magpy.getB(sources, sensors, output="dataframe")  # tidy pandas frame
+```
+
+`sumup=True` collapses the source axis by summing — the physically meaningful
+superposition of several sources. `output="dataframe"` is convenient for
+plotting libraries and for `groupby` over sources/sensors/path indices.
+
+## The functional interface
+
+`magpy.func.*` computes fields for many parameter sets without creating objects.
+Use it when the parameters vary, not just the positions — sweeping dimensions,
+polarizations, or currents.
+
+```python
+import numpy as np
+import magpylib as magpy
+
+n = 100_000
+B = magpy.func.cuboid_field(
+    field="B",
+    observers=np.random.rand(n, 3),
+    dimensions=np.random.rand(n, 3),
+    polarizations=np.tile((0, 0, 1.0), (n, 1)),
+)  # (100000, 3)
+```
+
+Available: `circle_field`, `polyline_field`, `cuboid_field`, `cylinder_field`,
+`cylinder_segment_field`, `sphere_field`, `tetrahedron_field`, `dipole_field`,
+`triangle_charge_field`, `triangle_current_field`.
+
+Every function takes `field` (`"B"` or `"H"`), `observers`, its shape and
+excitation parameters, and optional `positions`, `orientations`, `squeeze`.
+Scalar inputs are tiled to the longest input length. Output is `(i, 3)`.
+
+This replaced the v4-era string dispatch: `getB("Cuboid", ...)` and `getB_dict`
+no longer exist.
+
+## Performance
+
+Magpylib vectorises over sources, path steps, observers and pixels in one pass.
+The rule is one `getB` call per experiment:
+
+```python
+# Slow: one call per position
+for z in heights:
+    B.append(magpy.getB(cube, (0, 0, z)))
+
+# Fast: one call, all positions
+B = magpy.getB(cube, [(0, 0, z) for z in heights])
+```
+
+The same applies to moving sources — set a path rather than repositioning in a
+loop (see [position-paths.md](position-paths.md)).
+
+If observers sit inside `Tetrahedron` or `TriangularMesh` bodies and their
+location is known, `in_out="inside"` / `"outside"` skips the per-observer
+containment test.

--- a/src/magpylib/.agents/skills/magpylib/references/field-computation.md
+++ b/src/magpylib/.agents/skills/magpylib/references/field-computation.md
@@ -39,6 +39,19 @@ Sensors with **different** pixel shapes cannot be broadcast into one array; pass
 `pixel_agg="mean"` (or any NumPy aggregator name) to reduce each sensor's pixels
 first, which makes the shapes compatible.
 
+On the source side, a `Collection` behaves as a **single** source — it
+superposes its children internally and contributes one entry to the `s` axis.
+Pass a list of the children instead when the per-source breakdown is wanted:
+
+```python
+magpy.getB(coll, obs).shape  # (3,) — already summed
+magpy.getB(list(coll.sources_all), obs).shape  # (2, 3) — per source
+```
+
+Multiple sources and multiple observers produce **all combinations**, and
+similar sources are grouped and vectorised internally, so one call with many
+inputs beats many calls.
+
 ## sumup and output
 
 ```python

--- a/src/magpylib/.agents/skills/magpylib/references/force-torque.md
+++ b/src/magpylib/.agents/skills/magpylib/references/force-torque.md
@@ -16,7 +16,9 @@ F, T = magpy.getFT(
 ```
 
 `F` is in newtons, `T` in newton-metres, both shaped `(s, p, t, 3)` — sources,
-path, targets, components — before squeezing.
+path, targets, components — before squeezing. They arrive stacked: `getFT`
+returns one `(2, s, p, t, 3)` array, and the two-name assignment above unpacks
+its leading axis. Bind a single name instead and that axis is still there.
 
 ## Meshing is mandatory
 

--- a/src/magpylib/.agents/skills/magpylib/references/force-torque.md
+++ b/src/magpylib/.agents/skills/magpylib/references/force-torque.md
@@ -1,0 +1,83 @@
+# Force and torque
+
+Read this when computing `getFT` — holding force, magnetic bearings, actuator
+torque, floating-magnet equilibria — or when force results look mesh-dependent.
+
+```python
+F, T = magpy.getFT(
+    sources,
+    targets,
+    pivot="centroid",
+    eps=1e-5,
+    squeeze=True,
+    meshreport=False,
+    return_mesh=False,
+)
+```
+
+`F` is in newtons, `T` in newton-metres, both shaped `(s, p, t, 3)` — sources,
+path, targets, components — before squeezing.
+
+## Meshing is mandatory
+
+Unlike field computation, force is numerical: each target is discretised and the
+force integral summed over cells. Every target **except `Dipole` and `Sphere`**
+must have `meshing` set, or `getFT` raises `ValueError`.
+
+```python
+loop = magpy.current.Circle(diameter=0.02, current=10, meshing=40)
+cube = magpy.magnet.Cuboid(
+    dimension=(0.01, 0.01, 0.01), polarization=(0, 0, 1.2), meshing=1000
+)
+```
+
+`meshing` is an integer _target_ cell count; the mesher aims for uniform,
+aspect-ratio-1 cells and will not hit the number exactly. Pass `meshreport=True`
+to print the realised cell count per target, and `return_mesh=True` to get the
+mesh dictionaries (`"pts"`, `"moments"` for magnets, `"cvecs"` for currents)
+instead of F and T.
+
+**Always run a convergence check** — double `meshing` until the result stops
+moving:
+
+```python
+for n in (100, 400, 1600, 6400):
+    cube.meshing = n
+    F, _ = magpy.getFT(source, cube)
+    print(n, F)
+```
+
+## Scale invariance does NOT hold
+
+Field computation is scale invariant: a 1 mm magnet at 1 mm distance gives the
+same field as a 1 m magnet at 1 m, so any consistent length unit works. **Force
+and torque break this.** Inputs must be true SI metres or the newtons are
+meaningless.
+
+## Pivot
+
+Torque is defined about a pivot, and the force contributes
+`T_F = F × (r_pivot − r_position)`:
+
+- `pivot="centroid"` (default) — the target's barycenter, correct for a freely
+  floating body.
+- array-like `(3,)` — the same pivot point for every target, e.g. a shaft axis.
+- one pivot per target — an array with one row per target.
+- `pivot=None` — no pivot; results are nonphysical, use only when you know why.
+
+## eps
+
+`eps` is the finite-difference step used for the field gradient on magnet
+targets. The default `1e-5` suits metre-scale problems; a good value is roughly
+`1e-6 ×` the characteristic source size. Too large smears the gradient, too
+small loses precision to floating-point cancellation. It is unused for current
+targets.
+
+## Sanity checks
+
+- Newton's third law: `getFT(a, b)` and `getFT(b, a)` should give opposite
+  forces. A mismatch usually means one target is under-meshed.
+- A target must be a magnet, a current, or a `Dipole`; `CustomSource` cannot be
+  a target.
+- Forces between touching or overlapping bodies are unreliable — the analytical
+  field diverges at surfaces.

--- a/src/magpylib/.agents/skills/magpylib/references/position-paths.md
+++ b/src/magpylib/.agents/skills/magpylib/references/position-paths.md
@@ -46,6 +46,22 @@ Pass an explicit `start=0` to overwrite instead of append.
 about its own `position`, an array-like `(3,)` rotates it about that global
 point — which is how you build orbits and Halbach arrangements.
 
+Prefer the convenience constructors over assembling a `Rotation` yourself; they
+take the same `anchor` and `start`:
+
+| Method                           | Input                        |
+| -------------------------------- | ---------------------------- |
+| `rotate_from_angax(angle, axis)` | angle (°) about a named axis |
+| `rotate_from_rotvec(rotvec)`     | rotation vector              |
+| `rotate_from_euler(angles, seq)` | Euler angles                 |
+| `rotate_from_quat(quat)`         | quaternion                   |
+| `rotate_from_matrix(matrix)`     | rotation matrix              |
+| `rotate_from_mrp(mrp)`           | modified Rodrigues params    |
+
+Each accepts vector input as well, so
+`sensor.rotate_from_angax(np.linspace(0, 360, 37), "z", start=0)` writes a full
+37-step spin over an existing path.
+
 ```python
 # 8 magnets evenly placed on a circle, each rotated about the origin
 magnets = []
@@ -63,20 +79,73 @@ Chained calls compose, and `reset_path()` restores `position=(0, 0, 0)` and
 
 Beyond position and orientation, physical attributes can vary along the path:
 `current`, `diameter`, `dimension`, `polarization`, `magnetization`, `moment`,
-`vertices`. Ask an object which of its attributes support this with
-`obj.path_properties`.
+`vertices`. Ask an object which of its attributes support this — the answer is
+per class:
 
 ```python
-coil = magpy.current.Circle(
-    diameter=np.linspace(0.01, 0.05, 10),  # geometry ramps
-    current=np.linspace(1, 10, 10),  # excitation ramps
-)
+loop = magpy.current.Circle(current=1, diameter=0.01)
+loop.path_properties  # ('position', 'orientation', 'current', 'diameter')
 ```
 
-This models AC or ramped currents, deforming geometry, and thermal expansion
-without a Python loop. Attributes are independent — setting one to a path does
-not lengthen the others; shorter ones are edge-padded to the longest at
-computation time.
+A sinusoidal drive is then one object, not forty:
+
+```python
+t = np.linspace(0, 1, 40)
+coil = magpy.current.Circle(diameter=0.02, current=5 * np.sin(2 * np.pi * t))
+B = magpy.getB(coil, (0, 0, 0.01))  # (40, 3) in one vectorised call
+```
+
+Geometry works the same way — a cube expanding from 10 mm to 11 mm is a path
+over `dimension`, and `vertices` lets a conductor deform:
+
+```python
+side = np.linspace(0.010, 0.011, 20)
+cube = magpy.magnet.Cuboid(
+    dimension=np.column_stack([side, side, side]),
+    polarization=(0, 0, 1),
+)
+cube.dimension.shape  # (20, 3)
+cube.dipole_moment.shape  # (20, 3) — derived properties gain the path axis
+```
+
+### Storage and reconciliation
+
+`position` and `orientation` are special in exactly one respect: they stay
+eagerly synchronised with each other, because geometric consistency is always
+required. **Every other path property is independent, and what you set is what
+is stored** — an attribute keeps the shape it was given and is never expanded to
+match the others.
+
+```python
+cube = magpy.magnet.Cuboid(dimension=(0.01, 0.01, 0.01), polarization=(0, 0, 1))
+cube.position = [(0, 0, z) for z in np.linspace(0, 0.04, 5)]
+np.shape(cube.position)  # (5, 3) — a path
+cube.dimension  # [0.01 0.01 0.01] — untouched
+```
+
+Lengths are reconciled only when they must be — at field, force, and display
+time — on a temporary copy, by two rules:
+
+- **Edge-padding**: when a step beyond an attribute's own length is needed, its
+  last entry is repeated. The object is _static_ beyond its path.
+- **End-slicing**: when a path is automatically shortened, the **end** is kept.
+
+So mismatched lengths inside one object are legal and quiet:
+
+```python
+loop = magpy.current.Circle(current=[1, 2, 3], diameter=0.01)
+loop.position = [(0, 0, 0), (0, 0, 0.01)]  # only 2 steps
+
+magpy.getB(loop, (0, 0, 0.02)).shape  # (3, 3) — runs over 3 steps
+len(loop.position)  # still 2 — padding never rewrote the attribute
+```
+
+The third step reuses the final position while the current keeps changing. This
+is a feature for combining a long excitation with a short motion, and a trap
+when the mismatch was unintentional: nothing raises, so a wrong path length
+shows up only as an unexpected leading axis. The same edge-padding applies
+_between_ objects — when sources of different path lengths are combined, the
+shorter ones are treated as static beyond their end.
 
 ## Frames
 

--- a/src/magpylib/.agents/skills/magpylib/references/position-paths.md
+++ b/src/magpylib/.agents/skills/magpylib/references/position-paths.md
@@ -1,0 +1,87 @@
+# Position, orientation, and paths
+
+Read this before writing any motion — rotation about a point, a swept
+trajectory, a parameter ramp — or when a path came out with the wrong length.
+
+## The path
+
+`position` (shape `(3,)` or `(p, 3)`, metres) and `orientation` (a scipy
+`Rotation` of length 1 or `p`) together define an object's path. Magpylib keeps
+the two the same length. A field computation evaluates every path step at once,
+so paths are the vectorised way to model motion.
+
+```python
+import numpy as np
+import magpylib as magpy
+from scipy.spatial.transform import Rotation as R
+
+cube = magpy.magnet.Cuboid(dimension=(0.01, 0.01, 0.01), polarization=(0, 0, 1))
+cube.position = np.linspace((0, 0, 0.02), (0, 0, 0.10), 50)
+B = magpy.getB(cube, (0, 0, 0))  # (50, 3) — one call, 50 steps
+```
+
+`orientation` must be a `scipy.spatial.transform.Rotation`. A tuple of Euler
+angles raises `MagpylibBadUserInput`.
+
+## move() and rotate()
+
+```python
+obj.move(displacement, start="auto")
+obj.rotate(rotation, anchor=None, start="auto")
+```
+
+The behaviour depends on whether the input is scalar or vector, and this is the
+most common source of surprise:
+
+| Input                          | `start="auto"` means | Effect                                 |
+| ------------------------------ | -------------------- | -------------------------------------- |
+| scalar (one vector / rotation) | `start=0`            | transforms the **whole existing path** |
+| vector (n vectors / rotations) | `start=len(path)`    | **appends** n new steps to the path    |
+
+So `obj.move((0, 0, 0.01))` shifts an existing 50-step path bodily, while
+`obj.move(np.linspace((0, 0, 0), (0, 0, 0.01), 10))` grows the path by 10 steps.
+Pass an explicit `start=0` to overwrite instead of append.
+
+`anchor` is the pivot for rotation: `anchor=None` (default) spins the object
+about its own `position`, an array-like `(3,)` rotates it about that global
+point — which is how you build orbits and Halbach arrangements.
+
+```python
+# 8 magnets evenly placed on a circle, each rotated about the origin
+magnets = []
+for i in range(8):
+    m = magpy.magnet.Cuboid(dimension=(0.01, 0.01, 0.01), polarization=(0, 0, 1))
+    m.position = (0.05, 0, 0)
+    m.rotate(R.from_rotvec((0, 0, i * 45), degrees=True), anchor=(0, 0, 0))
+    magnets.append(m)
+```
+
+Chained calls compose, and `reset_path()` restores `position=(0, 0, 0)` and
+`orientation=None`.
+
+## Path-varying attributes
+
+Beyond position and orientation, physical attributes can vary along the path:
+`current`, `diameter`, `dimension`, `polarization`, `magnetization`, `moment`,
+`vertices`. Ask an object which of its attributes support this with
+`obj.path_properties`.
+
+```python
+coil = magpy.current.Circle(
+    diameter=np.linspace(0.01, 0.05, 10),  # geometry ramps
+    current=np.linspace(1, 10, 10),  # excitation ramps
+)
+```
+
+This models AC or ramped currents, deforming geometry, and thermal expansion
+without a Python loop. Attributes are independent — setting one to a path does
+not lengthen the others; shorter ones are edge-padded to the longest at
+computation time.
+
+## Frames
+
+Shape parameters (`dimension`, `vertices`, sensor `pixel`) are always in the
+object's **local** frame. `position`/`orientation` place that frame in the
+global one. A `Collection` spans its own frame for its children: moving the
+collection moves all children while preserving their relative placement, and
+children remain individually addressable afterwards.

--- a/src/magpylib/.agents/skills/magpylib/references/visualization.md
+++ b/src/magpylib/.agents/skills/magpylib/references/visualization.md
@@ -8,21 +8,28 @@ objects.
 ```python
 magpy.show(
     *objects,
-    backend=None,
-    canvas=None,
-    animation=False,
-    zoom=0,
-    markers=None,
-    return_fig=False,
-    row=None,
-    col=None,
-    style=None,
+    backend,
+    canvas,
+    canvas_update,
+    animation,
+    zoom,
+    markers,
+    return_fig,
+    row,
+    col,
+    output,
+    sumup,
+    pixel_agg,
+    style,
+    **kwargs,
 )
 ```
 
 `show()` takes any number of sources, sensors, and collections. It is also a
 method on every object (`cube.show()`), and `magpy.show(cube, sensor)` draws
-them in one scene.
+them in one scene. Every keyword defaults to the matching entry in
+`magpy.defaults` rather than to a literal in the signature, so changing a
+default globally changes what an unqualified `show()` does.
 
 - `return_fig=True` returns the backend figure instead of displaying it — use
   this in scripts, tests, and docs builds rather than relying on a display.

--- a/src/magpylib/.agents/skills/magpylib/references/visualization.md
+++ b/src/magpylib/.agents/skills/magpylib/references/visualization.md
@@ -42,10 +42,25 @@ magpy.defaults.display.backend = "plotly"  # session-wide
 magpy.show(cube, backend="pyvista")  # one call
 ```
 
+All three animate and do subplots; they differ in what else they can draw:
+
+| Capability                              | matplotlib | plotly | pyvista |
+| --------------------------------------- | ---------- | ------ | ------- |
+| `supports_animation`                    | yes        | yes    | yes     |
+| `supports_subplots`                     | yes        | yes    | yes     |
+| `supports_colorgradient`                | **no**     | yes    | yes     |
+| `supports_animation_output` (gif / mp4) | no         | no     | **yes** |
+| `supports_native_traces` (`model3d`)    | yes        | yes    | **no**  |
+
 Rough guidance: matplotlib for static figures in papers and docs, plotly for
-interactive notebook work, pyvista for large meshes and high-quality 3D. Note
-that matplotlib's 3D compositing has no real depth sorting, so overlapping
-bodies can render misleadingly — prefer plotly or pyvista for dense scenes.
+interactive notebook work, pyvista for large meshes, saved animations, and
+high-quality 3D. Matplotlib's 3D compositing has no real depth sorting, so
+overlapping bodies can render misleadingly — prefer plotly or pyvista for dense
+scenes.
+
+A backend handed something it never declared support for warns and falls back
+rather than producing silently wrong output — custom `style.model3d` traces sent
+to pyvista, for instance.
 
 Third-party backends register at runtime with
 `magpy.register_backend(name, show_func, **capabilities)`, or ship in a package
@@ -60,8 +75,9 @@ magpy.show(cube, animation=True)
 ```
 
 `animation=True` plays the object path; `animation=<seconds>` sets the duration.
-Not every backend supports animation — matplotlib does not. Check
-`magpy.defaults.display.animation` for frame-rate and looping options.
+All three built-in backends animate, but only pyvista can write the animation to
+a file (gif or mp4). Check `magpy.defaults.display.animation` for frame-rate and
+looping options.
 
 ## Subplots
 
@@ -95,3 +111,14 @@ cube.style.opacity = 0.5  # or afterwards, by attribute
 Global defaults live under `magpy.defaults.display.style`, and anything left
 unset on an object defers to them. `magpy.defaults.reset()` restores factory
 settings — useful between test cases, since defaults are process-wide state.
+
+## Custom 3D models
+
+`obj.style.model3d` carries extra geometry drawn in place of, or alongside, the
+default body — a dashed outline on a `CustomSource`, a coil former, a housing.
+Build traces with the helpers in `magpy.graphics.model3d`: `make_Cuboid`,
+`make_Prism`, `make_Pyramid`, `make_Ellipsoid`, `make_CylinderSegment`,
+`make_Tetrahedron`, `make_TriangularMesh`, `make_Arrow`; or pass a
+backend-native trace via `magpy.graphics.Trace3d`. Set
+`style.model3d.showdefault = False` to replace the default representation rather
+than add to it. Pyvista does not consume these (see the capability table above).

--- a/src/magpylib/.agents/skills/magpylib/references/visualization.md
+++ b/src/magpylib/.agents/skills/magpylib/references/visualization.md
@@ -1,0 +1,97 @@
+# Visualisation
+
+Read this when producing figures, animating paths, building subplots, or styling
+objects.
+
+## show()
+
+```python
+magpy.show(
+    *objects,
+    backend=None,
+    canvas=None,
+    animation=False,
+    zoom=0,
+    markers=None,
+    return_fig=False,
+    row=None,
+    col=None,
+    style=None,
+)
+```
+
+`show()` takes any number of sources, sensors, and collections. It is also a
+method on every object (`cube.show()`), and `magpy.show(cube, sensor)` draws
+them in one scene.
+
+- `return_fig=True` returns the backend figure instead of displaying it — use
+  this in scripts, tests, and docs builds rather than relying on a display.
+- `canvas` draws into an existing figure/axes/plotter, which is how Magpylib
+  scenes get embedded in a larger dashboard.
+- `zoom` widens (positive) or tightens the automatic bounds.
+- `markers` adds plain position markers for reference points.
+
+## Backends
+
+Built in: `"matplotlib"`, `"plotly"`, `"pyvista"` (see
+`magpy.SUPPORTED_PLOTTING_BACKENDS`). The default is
+`magpy.defaults.display.backend`, itself `"auto"`, which picks by context.
+
+```python
+magpy.defaults.display.backend = "plotly"  # session-wide
+magpy.show(cube, backend="pyvista")  # one call
+```
+
+Rough guidance: matplotlib for static figures in papers and docs, plotly for
+interactive notebook work, pyvista for large meshes and high-quality 3D. Note
+that matplotlib's 3D compositing has no real depth sorting, so overlapping
+bodies can render misleadingly — prefer plotly or pyvista for dense scenes.
+
+Third-party backends register at runtime with
+`magpy.register_backend(name, show_func, **capabilities)`, or ship in a package
+under the `magpylib.backends` entry-point group, after which the name is
+accepted anywhere a built-in one is.
+
+## Animation
+
+```python
+cube.position = np.linspace((0, 0, 0.02), (0, 0, 0.1), 50)
+magpy.show(cube, animation=True)
+```
+
+`animation=True` plays the object path; `animation=<seconds>` sets the duration.
+Not every backend supports animation — matplotlib does not. Check
+`magpy.defaults.display.animation` for frame-rate and looping options.
+
+## Subplots
+
+```python
+with magpy.show_context(cube, sensor, backend="plotly") as sc:
+    sc.show(col=1)  # 3D scene
+    sc.show(col=2, output="Bx")  # field plot of the same objects
+```
+
+`show_context()` collects several `show()` calls into one figure, with `row` and
+`col` placing each panel. `output` selects what a panel draws: `"model3d"` (the
+default) or field components such as `"Bx"`, `"Hz"`, or `"B"` for magnitude,
+plotted over the path.
+
+## Styling
+
+Every object carries a `style` tree, and any style leaf can be set at
+construction with a `style_`-prefixed keyword:
+
+```python
+cube = magpy.magnet.Cuboid(
+    dimension=(0.01, 0.01, 0.01),
+    polarization=(0, 0, 1),
+    style_label="rotor magnet",
+    style_color="crimson",
+    style_magnetization_show=True,
+)
+cube.style.opacity = 0.5  # or afterwards, by attribute
+```
+
+Global defaults live under `magpy.defaults.display.style`, and anything left
+unset on an object defers to them. `magpy.defaults.reset()` restores factory
+settings — useful between test cases, since defaults are process-wide state.

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,9 +1,13 @@
 import importlib.metadata
 import os
+import re
+from pathlib import Path
 
 import pytest
 
 import magpylib as m
+
+SKILL_DIR = Path(m.__file__).parent / ".agents" / "skills" / "magpylib"
 
 
 @pytest.mark.skipif(
@@ -16,3 +20,47 @@ import magpylib as m
 )
 def test_version() -> None:
     assert importlib.metadata.version("magpylib") == m.__version__
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    """Read the SKILL.md YAML frontmatter without depending on a YAML parser."""
+    assert text.startswith("---\n"), "SKILL.md must open with YAML frontmatter"
+    block = text.split("---\n", 2)[1]
+    fields: dict[str, list[str]] = {}
+    key = None
+    for line in block.splitlines():
+        if match := re.match(r"^([a-z][\w-]*):\s*(.*)$", line):
+            key = match.group(1)
+            value = match.group(2)
+            fields[key] = [] if value in {">-", ">", "|", "|-"} else [value]
+        elif key is not None and line.startswith("  "):
+            fields[key].append(line.strip())
+    return {k: " ".join(v) for k, v in fields.items()}
+
+
+def test_agent_skill_is_packaged() -> None:
+    """The Agent Skill ships inside the package, next to the code it describes."""
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_agent_skill_frontmatter() -> None:
+    """Frontmatter follows the Agent Skills spec (https://agentskills.io)."""
+    fields = _frontmatter((SKILL_DIR / "SKILL.md").read_text(encoding="utf-8"))
+
+    name = fields.get("name", "")
+    assert name == SKILL_DIR.name, "name must match the parent directory name"
+    assert re.fullmatch(r"[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?", name)
+    assert "--" not in name
+
+    description = fields.get("description", "")
+    assert description, "description is required"
+    assert len(description) <= 1024, "description exceeds the 1024 character limit"
+
+
+def test_agent_skill_links_resolve() -> None:
+    """Relative links out of SKILL.md point at files that are shipped too."""
+    text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    targets = re.findall(r"\]\((?!https?://|#)([^)]+)\)", text)
+    assert targets, "expected SKILL.md to reference its files in references/"
+    missing = [t for t in targets if not (SKILL_DIR / t).is_file()]
+    assert not missing, f"broken relative links in SKILL.md: {missing}"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,6 +1,8 @@
 import importlib.metadata
 import os
 import re
+import tarfile
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -8,6 +10,8 @@ import pytest
 import magpylib as m
 
 SKILL_DIR = Path(m.__file__).parent / ".agents" / "skills" / "magpylib"
+DIST_DIR = Path(__file__).resolve().parents[1] / "dist"
+SKILL_IN_DIST = "magpylib/.agents/skills/magpylib"
 
 
 @pytest.mark.skipif(
@@ -38,9 +42,50 @@ def _frontmatter(text: str) -> dict[str, str]:
     return {k: " ".join(v) for k, v in fields.items()}
 
 
-def test_agent_skill_is_packaged() -> None:
-    """The Agent Skill ships inside the package, next to the code it describes."""
+def test_agent_skill_is_present() -> None:
+    """The Agent Skill sits inside the package, next to the code it describes.
+
+    This resolves through ``magpylib.__file__``, which is the source tree under
+    an editable install. It shows the skill is in the right place, not that it
+    ships -- ``test_agent_skill_ships_in_distributions`` is the check for that.
+    """
     assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def _distribution_members() -> dict[str, list[str]]:
+    """Map each built artifact in ``dist/`` to the paths it contains."""
+    members: dict[str, list[str]] = {}
+    for wheel in sorted(DIST_DIR.glob("*.whl")):
+        with zipfile.ZipFile(wheel) as archive:
+            members[wheel.name] = archive.namelist()
+    for sdist in sorted(DIST_DIR.glob("*.tar.gz")):
+        with tarfile.open(sdist) as archive:
+            members[sdist.name] = archive.getnames()
+    return members
+
+
+def test_agent_skill_ships_in_distributions() -> None:
+    """The built wheel and sdist really carry the skill and its references.
+
+    Package data is easy to lose to a build-backend or ignore-file change, and
+    a source-tree assertion cannot see that happen. Build first with
+    ``uvx nox -s build``; without artifacts there is nothing to inspect.
+    """
+    artifacts = _distribution_members()
+    if not artifacts:
+        pytest.skip("no artifacts in dist/ -- run `uvx nox -s build` first")
+
+    references = sorted(p.name for p in (SKILL_DIR / "references").glob("*.md"))
+    assert references, "expected reference files beside SKILL.md"
+    expected = ["SKILL.md", *(f"references/{name}" for name in references)]
+
+    for artifact, paths in artifacts.items():
+        missing = [
+            rel
+            for rel in expected
+            if not any(path.endswith(f"{SKILL_IN_DIST}/{rel}") for path in paths)
+        ]
+        assert not missing, f"{artifact} is missing {missing}"
 
 
 def test_agent_skill_frontmatter() -> None:


### PR DESCRIPTION
The only one of these that ships to users.

Adds a `magpylib` skill at `src/magpylib/.agents/skills/magpylib/`, which lands in wheels and sdists as `magpylib/.agents/skills/magpylib/`, so it's versioned with the release it describes. Users pick it up with `uvx library-skills` ([library-skills.io](https://library-skills.io)).

Why bother: assistants write plausible Magpylib code from pre-v5 memory — millimetres for metres, millitesla for tesla, `magnetization` where v5 wants `polarization`. None of it raises. The answers are just wrong by 1e3 to 1e9.

`SKILL.md` covers units, sources, field computation and output shapes, sensors, paths, path-varying properties, collections, force and torque, visualisation, and the failure modes that don't raise. Four references sit behind it for detail.

Three things worth deciding now rather than at the next release:

1. It becomes a compatibility surface. Every API claim is something a release can break, and a skill that has quietly drifted is worse than no skill, because it still reads as authoritative.
2. It's release-blocking by construction. Shipping inside the wheel is what buys version-pinning, but it also makes skill correctness a release gate.
3. It's a support surface. Expect "the skill told me X" issues.

None of that argues against merging, just for deciding it deliberately.

Verification: `tests/test_package.py` checks the frontmatter against the Agent Skills spec, that relative links resolve, and — separately — that the skill and every reference are really inside the built wheel and sdist. That last check only runs after `nox -s build`; with no artifacts it skips. Every API claim was checked against current source, docstrings or executable behaviour.

One trap: don't run `library-skills install` at the repo root. Its symlink points back into `src/magpylib`, and Hatch can then record the skill under the symlink in the sdist while omitting the real path. Test discovery from a separate project instead.
