### PR TITLE
Add contributor skills and load them from .agents

### DIFF
--- a/.agents/.claude-plugin/marketplace.json
+++ b/.agents/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "magpylib-agent-skills",
+  "owner": {
+    "name": "Magpylib contributors"
+  },
+  "description": "Local Claude Code skills for working on the Magpylib repository",
+  "plugins": [
+    {
+      "name": "magpylib-skills",
+      "source": "./",
+      "description": "Local skills for developing the Magpylib repository"
+    }
+  ]
+}

--- a/.agents/.claude-plugin/plugin.json
+++ b/.agents/.claude-plugin/plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "magpylib-skills",
+  "description": "Local skills for developing the Magpylib repository"
+}

--- a/.agents/skills/magpylib-development/SKILL.md
+++ b/.agents/skills/magpylib-development/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: magpylib-development
+description: >-
+  Develop and maintain the Magpylib repository. Use when changing Python source,
+  tests, packaging, CI, or contributor tooling in this repository, or when
+  choosing the correct local validation command.
+license: BSD-3-Clause
+---
+
+# Magpylib Development
+
+Follow the repository's established Scientific Python workflow. Read the code
+nearest to the requested behavior and its focused tests before changing it.
+
+## Repository map
+
+- Public package: `src/magpylib/`
+- Internal implementation: `src/magpylib/_src/`
+- Tests: `tests/`
+- Sphinx and MyST documentation: `docs/`
+- Development sessions: `noxfile.py`
+- Tool configuration and dependency groups: `pyproject.toml`
+
+Keep public APIs in the public package namespaces. Preserve the existing split
+between public classes and helpers in `_src`, and update type information when a
+public signature changes.
+
+## Implementation workflow
+
+1. Identify the public or package-internal behavior that owns the change.
+1. Find the closest existing test and state the behavior it observes.
+1. For a bug fix or behavior change, add a focused regression test and witness
+   the intended failure before editing the implementation when practical.
+1. Make the smallest coherent change at the owning abstraction.
+1. Run the focused test immediately, then widen validation according to risk.
+1. Update user documentation and docstrings when the public contract changes.
+
+Do not rewrite unrelated code or weaken warnings, numerical tolerances, or test
+assertions merely to obtain a passing run. For numerical work, derive expected
+values independently from the implementation under test and include boundary,
+inside/outside, path, and array-shape cases where relevant.
+
+## Project conventions
+
+- Python support starts at 3.11.
+- Public code is typed; MyPy is strict for `magpylib.*`.
+- Public docstrings use NumPy style.
+- Source and test formatting is governed by the checked-in Ruff, Pylint, and
+  prek configuration.
+- Tests run with strict Pytest configuration and warnings treated as errors.
+- Follow the SPOTIN axis vocabulary documented in `CONTRIBUTING.md`.
+- Use SI units for Magpylib v5 code and examples.
+
+## Validation
+
+Start narrow and broaden only as the changed surface requires:
+
+```console
+uv run pytest tests/test_relevant_file.py -k relevant_behavior
+uv run pytest
+uvx nox -s lint
+uvx nox -s pylint
+uvx nox -s docs --non-interactive
+uvx nox -s build
+```
+
+Use `uvx nox` when Nox is not installed. A source change normally requires its
+focused tests and linting. A public API change also requires the relevant docs
+build. Packaging changes require the build session.
+
+## Sources
+
+This project workflow is derived from `.github/CONTRIBUTING.md`,
+`CONTRIBUTING.md`, `noxfile.py`, and `pyproject.toml`. Its general packaging and
+tooling practices follow the public
+[Scientific Python Development Guide](https://learn.scientific-python.org/development/)
+and the [scientific-python/cookie](https://github.com/scientific-python/cookie)
+template used to generate this repository.

--- a/.agents/skills/primary-source-research/SKILL.md
+++ b/.agents/skills/primary-source-research/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: primary-source-research
+description: >-
+  Research technical questions using authoritative primary sources. Use when a
+  task depends on current API behavior, specifications, upstream source code,
+  release history, or claims that should not rely on memory alone.
+license: BSD-3-Clause
+---
+
+# Primary-Source Research
+
+Investigate the question against sources that own the facts: official
+documentation, specifications, upstream repositories, release notes, and
+executable behavior. Use a read-only research subagent for an independent scope
+when available, but verify its material claims before relying on them.
+
+## Process
+
+1. Define the exact questions and what evidence would answer each one.
+1. Prefer primary sources; use secondary sources only to locate or contrast
+   authoritative material.
+1. Record versions, dates, and applicability constraints.
+1. Trace every non-obvious conclusion to a source or reproducible check.
+1. Reconcile contradictions explicitly instead of selecting the convenient
+   source.
+1. Return a concise synthesis separating established facts, inference, and
+   unresolved uncertainty.
+
+Create a repository artifact only when the user requests one or the findings
+must support later implementation. In that case, use an agreed project location
+and include source links beside the claims they support.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "enabledPlugins": {
+    "magpylib-skills@magpylib-agent-skills": true
+  },
+  "extraKnownMarketplaces": {
+    "magpylib-agent-skills": {
+      "source": {
+        "source": "directory",
+        "path": ".agents"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Two contributor skills, plus the wiring that makes any skill in this repo actually load.

Skills live in `.agents/skills/` so any agent can read them, but Claude Code only looks in `.claude/skills/` and plugin directories — so as things stand nothing here is ever discovered. dask solves this by symlinking `.claude -> .agents`; ruff registers `.agents` as a plugin marketplace. I went with ruff's way, because the symlink makes every skill show up twice in the file tree and in search.

What's here:

- `magpylib-development` — repo layout, conventions, which validation command to run
- `primary-source-research` — for claims that shouldn't rest on a model's memory
- `.agents/.claude-plugin/` and `.claude/settings.json` — declares the plugin and enables it

`.claude/settings.json` is committed deliberately: that's what hands contributors the marketplace without a separate prompt. Skills load as `magpylib-skills:<name>` and stay readable by anything else that reads `.agents/`.

Bottom of the stack. #989, #992, #990 and #991 all sit on top, and most of them reference `magpylib-development` by name.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
